### PR TITLE
Support development mode for non-core plugins

### DIFF
--- a/app/core/AssetManager.php
+++ b/app/core/AssetManager.php
@@ -313,7 +313,7 @@ class AssetManager extends Singleton
      * @param UIAssetFetcher $assetFetcher
      * @return string
      */
-    private function getIndividualJsIncludesFromAssetFetcher($assetFetcher)
+    protected function getIndividualJsIncludesFromAssetFetcher($assetFetcher)
     {
         $jsIncludeString = '';
 
@@ -332,7 +332,7 @@ class AssetManager extends Singleton
         return new JScriptUIAssetFetcher($this->getLoadedPlugins(true), $this->theme);
     }
 
-    private function getNonCoreJScriptFetcher()
+    protected function getNonCoreJScriptFetcher()
     {
         return new JScriptUIAssetFetcher($this->getLoadedPlugins(false), $this->theme);
     }
@@ -398,7 +398,7 @@ class AssetManager extends Singleton
     /**
      * @return UIAsset
      */
-    private function getMergedNonCoreJSAsset()
+    protected function getMergedNonCoreJSAsset()
     {
         return $this->getMergedUIAsset(self::MERGED_NON_CORE_JS_FILE);
     }

--- a/plugins/WordPress/WpAssetManager.php
+++ b/plugins/WordPress/WpAssetManager.php
@@ -58,9 +58,14 @@ class WpAssetManager extends AssetManager
 		}
 
 		$result .= "<script type=\"text/javascript\">window.$ = jQuery;</script>";
-
 		$result .= sprintf(self::JS_IMPORT_DIRECTIVE, self::GET_CORE_JS_MODULE_ACTION);
-		$result .= sprintf(self::JS_IMPORT_DIRECTIVE, self::GET_NON_CORE_JS_MODULE_ACTION);
+
+		if ($this->isMergedAssetsDisabled()) {
+			$this->getMergedNonCoreJSAsset()->delete();
+			$result .= $this->getIndividualJsIncludesFromAssetFetcher($this->getNonCoreJScriptFetcher());
+		} else {
+			$result .= sprintf(self::JS_IMPORT_DIRECTIVE, self::GET_NON_CORE_JS_MODULE_ACTION);
+		}
 
 		return $result;
 	}


### PR DESCRIPTION
When working on Matomo plugins then it wasn't supporting the development mode aka it was never invalidating the nonCoreAsset file making it hard to make changes in a different plugin.