### PR TITLE
Fix compatibility with cookiebot as good as we can

### DIFF
--- a/app/vendor/composer/autoload_real.php
+++ b/app/vendor/composer/autoload_real.php
@@ -49,7 +49,7 @@ class ComposerAutoloaderInit20965b5e193daae3814e448b2561c788
             }
         }
 
-        $loader->register(true);
+        $loader->register(false);
 
         if ($useStaticLoader) {
             $includeFiles = Composer\Autoload\ComposerStaticInit20965b5e193daae3814e448b2561c788::$files;


### PR DESCRIPTION
fix https://github.com/matomo-org/wp-matomo/issues/19

The problem still persists if Matomo was loaded first and then cookiebot since they seem to prepend the autoloader as well.

refs https://github.com/matomo-org/matomo-package/issues/105

created https://github.com/CybotAS/CookiebotWP/issues/141