### PR TITLE
Round woocommerce subtotal

### DIFF
--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -159,7 +159,7 @@ class Woocommerce extends Base {
 			'trackEcommerceOrder',
 			$order_id_to_track,
 			$order->get_total(),
-			$order->get_subtotal(),
+			round($order->get_subtotal(), 2),
 			$order->get_cart_tax(),
 			$this->isWC3() ? $order->get_shipping_total() : $order->get_total_shipping(),
 			$order->get_total_discount()


### PR DESCRIPTION
Noticed it was sending in my case `trackEcommerceOrder("1277","448.75",448.753425,"0","0.00",0);`