### PR TITLE
Assume secure protocol when admin ssl is enforced

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -57,6 +57,7 @@ return array(
 			$general['enable_users_admin'] = 1;
 			if (defined('FORCE_SSL_ADMIN') && FORCE_SSL_ADMIN) {
 				$general['force_ssl'] = 1;
+				$general['assume_secure_protocol'] = 1;
 			}
 			$previous->General = $general;
 		}


### PR DESCRIPTION
fix #8 

Not going to change the setting for the tracking protocol for now since I'm not sure we can assume SSL is there for the frontend and should always be used when it's only enabled for the admin maybe. I reckon it should work but can always add this feature later. Also I suppose we can later automatically force ssl and also in the tracking code when `blog_url()` has an https address. Not adding this right now as I reckon it works anyway maybe when a user is visiting the frontend and it's tracking using `//domain`... It doesn't fix assume secure protocol though automatically. This we should maybe still add eventually when blog url is https