### PR TITLE
Generate tracking code immediately after saving

### DIFF
--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -31,6 +31,8 @@ class Settings {
 	const OPTION_LICENSE_KEY = 'license_key';
 	const SHOW_GET_STARTED_PAGE = 'show_get_started_page';
 
+	public static $is_doing_action_tracking_related = false;
+
 	/**
 	 * Environment variables and default settings container
 	 * @var array
@@ -277,6 +279,13 @@ class Settings {
 		$this->set_global_option( Settings::OPTION_LAST_TRACKING_SETTINGS_CHANGE, time() );
 
 		$this->apply_changes( $values );
+
+		if (!self::$is_doing_action_tracking_related) {
+			// prevent recurison if any plugin was listening to this event and calling this method again
+			self::$is_doing_action_tracking_related = true;
+			do_action('matomo_tracking_settings_changed', $this);
+			self::$is_doing_action_tracking_related = false;
+		}
 	}
 
 	/**

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -43,6 +43,7 @@ class TrackingCodeGenerator {
 
 	public function register_hooks() {
 		add_action( 'matomo_site_synced', array( $this, 'update_tracking_code' ), $prio = 10, $args = 0 );
+		add_action( 'matomo_tracking_settings_changed', array( $this, 'update_tracking_code' ), $prio = 10, $args = 0 );
 	}
 
 	public function update_tracking_code() {


### PR DESCRIPTION
refs https://github.com/matomo-org/wp-matomo/issues/37