### PR TITLE
Fix error core JS proxy couldn't be decoded when gzipped

### DIFF
--- a/app/core/ProxyHttp.php
+++ b/app/core/ProxyHttp.php
@@ -169,6 +169,8 @@ class ProxyHttp
         if ($compressed) {
             Common::sendHeader('Content-Encoding: ' . $encoding);
         }
+        
+        @ob_get_clean();
 
         if (!_readfile($file, $byteStart, $byteEnd)) {
             Common::sendResponseCode(500);


### PR DESCRIPTION
This happens when eg WordPress might be triggering a notice before we do the "readfile" in which case the notice will be mixed with the gzipped content in the response and therefore the browser cannot read the gzipped JS/CSS. You can easily reproduce this by eg replacing the `ob_get_clean` with an `echo 'foobar';`

Something I don't quite understand yet is why it works when echoing something after the `_readfile`.