### PR TITLE
Add htaccess file to disallow any request to php file except index|matomo.php and disallow geo db

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,43 @@
+# This file is provided from Matomo Analytics, do not edit directly
+# Please report any issue or improvement directly to the Matomo team.
+# Do not allow access to any php file directly unless it is index/matomo.php
+<Files ~ "(\.php)$">
+<IfModule mod_version.c>
+	<IfVersion < 2.4>
+        Order allow,deny
+        Deny from all
+	</IfVersion>
+	<IfVersion >= 2.4>
+		Require all denied
+	</IfVersion>
+</IfModule>
+<IfModule !mod_version.c>
+	<IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+	</IfModule>
+	<IfModule mod_authz_core.c>
+		Require all denied
+	</IfModule>
+</IfModule>
+</Files>
+<Files ~ "^((index|matomo)\.php)$">
+<IfModule mod_version.c>
+	<IfVersion < 2.4>
+        Order allow,deny
+        Allow from all
+	</IfVersion>
+	<IfVersion >= 2.4>
+		Require all granted
+	</IfVersion>
+</IfModule>
+<IfModule !mod_version.c>
+	<IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+	</IfModule>
+	<IfModule mod_authz_core.c>
+		Require all granted
+	</IfModule>
+</IfModule>
+</Files>

--- a/app/plugins/Installation/ServerFilesGenerator.php
+++ b/app/plugins/Installation/ServerFilesGenerator.php
@@ -232,7 +232,7 @@ Header set Cache-Control \"Cache-Control: private, no-cache, no-store\"
     /**
      * @return string
      */
-    protected static function getDenyHtaccessContent()
+    public static function getDenyHtaccessContent()
     {
 # Source: https://github.com/phpbb/phpbb/pull/2386/files#diff-f72a38c4bec79cc6ded3f8e435d6bd55L11
 # With Apache 2.4 the "Order, Deny" syntax has been deprecated and moved from

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -17,6 +17,7 @@ use Piwik\Exception\NotYetInstalledException;
 use Piwik\Filesystem;
 use Piwik\Plugin\API;
 use Piwik\Plugins\Installation\FormDatabaseSetup;
+use Piwik\Plugins\Installation\ServerFilesGenerator;
 use Piwik\SettingsPiwik;
 use WpMatomo\Site\Sync;
 
@@ -140,6 +141,9 @@ class Installer {
 				@file_put_contents( $upload_dir . '/index.php', '//hello' );
 				@file_put_contents( $upload_dir . '/index.html', '//hello' );
 				@file_put_contents( $upload_dir . '/index.htm', '//hello' );
+				@file_put_contents( $upload_dir . '/.htaccess', '<Files GeoLite2-City.mmdb>
++'.ServerFilesGenerator::getDenyHtaccessContent().'
++</Files>' );
 			}
 			$config_dir = $paths->get_config_ini_path();
 			if (is_dir($config_dir) && is_writable($config_dir)) {


### PR DESCRIPTION
In case a user is using apache and disallows any direct access to PHP files then this should avoid users having to whitelist these files.

Not sure if .htaccess files will actually be extracted on WordPress when they are present in a zip. In Matomo they aren't. We'll need to test this later I suppose to make Matomo work on more instances by default. Otherwise we should be able to listen to a WP hook and add it to the .htaccess file in the root directory.