### PR TITLE
[WIP] Add possibility to select created containers in tracking settings

### DIFF
--- a/app/plugins/TagManager/Dao/TagsDao.php
+++ b/app/plugins/TagManager/Dao/TagsDao.php
@@ -224,6 +224,14 @@ class TagsDao extends BaseDao implements TagManagerDao
         $tag['fire_delay'] = (int)$tag['fire_delay'];
         $tag['priority'] = (int)$tag['priority'];
 
+        if ($tag['start_date'] === '0000-00-00 00:00:00') {
+	        $tag['start_date'] = null;
+        }
+
+        if ($tag['end_date'] === '0000-00-00 00:00:00') {
+	        $tag['end_date'] = null;
+        }
+
         if (!empty($tag['parameters'])) {
             $tag['parameters'] = json_decode($tag['parameters'], true);
         }

--- a/app/plugins/TagManager/Template/Variable/MatomoConfigurationVariable.php
+++ b/app/plugins/TagManager/Template/Variable/MatomoConfigurationVariable.php
@@ -11,6 +11,7 @@ use Piwik\Common;
 use Piwik\Settings\FieldConfig;
 use Piwik\SettingsPiwik;
 use Piwik\Site;
+use Piwik\Tracker\TrackerCodeGenerator;
 use Piwik\Validators\CharacterLength;
 use Piwik\Validators\NotEmpty;
 use Piwik\Validators\UrlLike;
@@ -57,6 +58,10 @@ class MatomoConfigurationVariable extends BaseVariable
             $field->validators[] = new NotEmpty();
             $field->validators[] = new UrlLike();
         });
+
+        $trackerCodeGenerator = new TrackerCodeGenerator();
+        $jsEndpoint = $trackerCodeGenerator->getJsTrackerEndpoint();
+        $phpEndpoint = $trackerCodeGenerator->getPhpTrackerEndpoint();
 
         return array(
             $matomoUrl,
@@ -206,7 +211,7 @@ class MatomoConfigurationVariable extends BaseVariable
                 $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
                 $field->description = 'By bundling the Matomo JavaScript tracker directly into the container it may improve the performance of your website as it reduces the number of needed requests. It is recommended to bundle the Matomo tracker because in most cases the tracker would otherwise be otherwise loaded in a separate request on page view anyway. Note: If you use two different Matomo configurations in one container, the setting of the first configuration used in the first Matomo Tag will be applied to all Matomo tags within one container.';
             }),
-            $this->makeSetting('jsEndpoint', 'piwik.js', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+            $this->makeSetting('jsEndpoint', $jsEndpoint, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = 'Tracker Javascript Path';
                 $field->uiControl = FieldConfig::UI_CONTROL_SINGLE_SELECT;
                 $field->availableValues = array(
@@ -218,7 +223,7 @@ class MatomoConfigurationVariable extends BaseVariable
     
                 $field->description = 'Here you can configure the source path of the Matomo Tracker JavaScript, if you are not using the "Bundle Tracker" option.';
             }),
-            $this->makeSetting('trackingEndpoint', 'piwik.php', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+            $this->makeSetting('trackingEndpoint', $phpEndpoint, FieldConfig::TYPE_STRING, function (FieldConfig $field) {
                 $field->title = 'Tracking Request Target Path';
                 $field->uiControl = FieldConfig::UI_CONTROL_SINGLE_SELECT;
                 $field->availableValues = array(

--- a/app/plugins/TagManager/angularjs/manageInstallCode/manage-install-tag-code.controller.js
+++ b/app/plugins/TagManager/angularjs/manageInstallCode/manage-install-tag-code.controller.js
@@ -33,7 +33,9 @@
                 self.isLoading = false;
                 $timeout(function () {
                     var codeBlock = $('.manageInstallTagCode .codeblock');
-                    codeBlock.effect("highlight", {}, 1500);
+                    codeBlock.each(function (i, element) {
+                        $(element).effect("highlight", {}, 1500);
+                    });
                 });
 
             }, function () {

--- a/app/plugins/TagManager/angularjs/manageInstallCode/manage-install-tag-code.directive.html
+++ b/app/plugins/TagManager/angularjs/manageInstallCode/manage-install-tag-code.directive.html
@@ -18,7 +18,7 @@
             <a href="{{ installInstruction.helpUrl }}" target="_blank" ng-show="installInstruction.helpUrl">{{ 'TagManager_LearnMore'|translate }}</a>
         </p>
 
-        <pre piwik-select-on-focus class="codeblock"
+        <pre piwik-select-on-focus class="codeblock" ng-show="installInstruction.embedCode"
              ng-bind="installInstruction.embedCode">
         </pre>
     </div>

--- a/classes/WpMatomo/Admin/TrackingSettings.php
+++ b/classes/WpMatomo/Admin/TrackingSettings.php
@@ -108,6 +108,8 @@ class TrackingSettings implements AdminSettingsInterface {
 			// no noscript mode in this case
 			$_POST[ 'track_noscript' ] = '';
 			$_POST[ 'noscript_code' ]  = '';
+		} else {
+			unset($_POST[ 'tagmanger_container_ids' ]);
 		}
 
 		if ( $_POST[ self::FORM_NAME ]['track_mode'] === self::TRACK_MODE_MANUALLY
@@ -155,7 +157,7 @@ class TrackingSettings implements AdminSettingsInterface {
 		include_once( dirname( __FILE__ ) . '/views/tracking.php' );
 	}
 
-	private function get_active_containers()
+	public function get_active_containers()
 	{
 		// we don't use Matomo API here to avoid needing to bootstrap Matomo which is slow and could break things
 		$containers = array();

--- a/classes/WpMatomo/Admin/TrackingSettings.php
+++ b/classes/WpMatomo/Admin/TrackingSettings.php
@@ -165,13 +165,18 @@ class TrackingSettings implements AdminSettingsInterface {
 			global $wpdb;
 			$dbsettings = new \WpMatomo\Db\Settings();
 			$containerTable = $dbsettings->prefix_table_name('tagmanager_container');
-			$containers = $wpdb->get_results(sprintf('SELECT `idcontainer`, `name` FROM %s where `status` = "active"', $containerTable));
+			try {
+				$containers = $wpdb->get_results(sprintf('SELECT `idcontainer`, `name` FROM %s where `status` = "active"', $containerTable));
+			} catch (\Exception $e) {
+				// table may not exist yet etc
+				$containers = array();
+			}
 		}
-		$byId = array();
+		$by_id = array();
 		foreach ($containers as $container) {
-			$byId[$container->idcontainer] = $container->name;
+			$by_id[$container->idcontainer] = $container->name;
 		}
-		return $byId;
+		return $by_id;
 	}
 
 

--- a/classes/WpMatomo/Admin/TrackingSettings.php
+++ b/classes/WpMatomo/Admin/TrackingSettings.php
@@ -104,6 +104,12 @@ class TrackingSettings implements AdminSettingsInterface {
 		$values['add_post_annotations'] = array();
 		$values['tagmanger_container_ids'] = array();
 
+		if ( $_POST[ self::FORM_NAME ]['track_mode'] === self::TRACK_MODE_TAGMANAGER ) {
+			// no noscript mode in this case
+			$_POST[ 'track_noscript' ] = '';
+			$_POST[ 'noscript_code' ]  = '';
+		}
+
 		if ( $_POST[ self::FORM_NAME ]['track_mode'] === self::TRACK_MODE_MANUALLY
 		     || ( $_POST[ self::FORM_NAME ]['track_mode'] === self::TRACK_MODE_DISABLED &&
 		          $this->settings->get_global_option( 'track_mode' ) === self::TRACK_MODE_MANUALLY ) ) {

--- a/classes/WpMatomo/Admin/TrackingSettings/Forms.php
+++ b/classes/WpMatomo/Admin/TrackingSettings/Forms.php
@@ -117,14 +117,19 @@ class Forms {
 	 * @param boolean $global set to false if the textarea shows a site-specific option (default: true)
 	 */
 	public function show_select( $id, $name, $options = array(), $description = '', $onChange = '', $isHidden = false, $groupName = '', $hideDescription = true, $global = true ) {
-		$optionList = '';
+		$options_list = '';
 		$default    = $global ? $this->settings->get_global_option( $id ) : $this->settings->get_option( $id );
 		if ( is_array( $options ) ) {
 			foreach ( $options as $key => $value ) {
-				$optionList .= sprintf( '<option value="%s"' . ( $key == $default ? ' selected="selected"' : '' ) . '>%s</option>', esc_attr($key), esc_html($value) );
+				$options_list .= sprintf( '<option value="%s"' . ( $key == $default ? ' selected="selected"' : '' ) . '>%s</option>', esc_attr($key), esc_html($value) );
 			}
 		}
-		printf( '<tr class="' . $groupName . ( $isHidden ? ' hidden' : '' ) . '"><th scope="row"><label for="%2$s">%s:</label></th><td><select name="' . TrackingSettings::FORM_NAME . '[%s]" id="%2$s" onchange="%s">%s</select> %s</td></tr>', $name, $id, $onChange, $optionList, $this->get_description( $id, $description, $hideDescription ) );
+		$script_change = '';
+		if ($onChange) {
+			// we make sure it will select the right settings by default
+			$script_change .= '<script type="text/javascript">setTimeout(function () { jQuery("#'.$id.'").change(); }, 800);</script>';
+		}
+		printf( '<tr class="' . $groupName . ( $isHidden ? ' hidden' : '' ) . '"><th scope="row"><label for="%3$s">%s:%s</label></th><td><select name="' . TrackingSettings::FORM_NAME . '[%s]" id="%3$s" onchange="%s">%s</select> %s</td></tr>', $name, $script_change, $id, $onChange, $options_list, $this->get_description( $id, $description, $hideDescription ) );
 	}
 
 	/**

--- a/classes/WpMatomo/Admin/TrackingSettings/Forms.php
+++ b/classes/WpMatomo/Admin/TrackingSettings/Forms.php
@@ -127,7 +127,7 @@ class Forms {
 		$script_change = '';
 		if ($onChange) {
 			// we make sure it will select the right settings by default
-			$script_change .= '<script type="text/javascript">setTimeout(function () { jQuery("#'.$id.'").change(); }, 800);</script>';
+			$script_change .= '<script type="text/javascript">setTimeout(function () { jQuery("#'.esc_js($id).'").change(); }, 800);</script>';
 		}
 		printf( '<tr class="' . $groupName . ( $isHidden ? ' hidden' : '' ) . '"><th scope="row"><label for="%3$s">%s:%s</label></th><td><select name="' . TrackingSettings::FORM_NAME . '[%s]" id="%3$s" onchange="%s">%s</select> %s</td></tr>', $name, $script_change, $id, $onChange, $options_list, $this->get_description( $id, $description, $hideDescription ) );
 	}

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -49,7 +49,7 @@ $paths = new Paths();
 
 		if (!empty($containers)) {
 		    foreach ($containers as $container) {
-			    echo '<tr class="matomo-track-option matomo-track-option-tagmanager' . ( $isNotTracking ? ' hidden' : '' ) . '">';
+			    echo '<tr class="matomo-track-option matomo-track-option-tagmanager ' . ( $isNotTracking ? ' hidden' : '' ) . '">';
 			    echo '<th scope="row"><label for="add_post_annotations">' . __( 'Add these Tag Manager containers', 'matomo' ) . '</label>:</th><td>';
 			    $selected_container_ids = $settings->get_global_option( 'tagmanger_container_ids' );
 			    foreach ( $containers as $container_id => $container_name ) {
@@ -60,7 +60,7 @@ $paths = new Paths();
 		    }
 		}
 
-		$form->show_textarea( 'tracking_code', __( 'Tracking code', 'matomo' ), 15, 'This is a preview of your current tracking code. If you choose to enter your tracking code manually, you can change it here. Have a look at the system report to get a list of all available JS tracker and tracking API endpoints.', $isNotTracking, 'matomo-track-option matomo-track-option-default   matomo-track-option-manually', true, '', ( $settings->get_global_option( 'track_mode' ) != 'manually' ), false );
+		$form->show_textarea( 'tracking_code', __( 'Tracking code', 'matomo' ), 15, 'This is a preview of your current tracking code. If you choose to enter your tracking code manually, you can change it here. Have a look at the system report to get a list of all available JS tracker and tracking API endpoints.', $isNotTracking, 'matomo-track-option matomo-track-option-default matomo-track-option-tagmanager  matomo-track-option-manually', true, '', ( $settings->get_global_option( 'track_mode' ) != 'manually' ), false );
 
 		$form->show_select( 'track_codeposition', __( 'JavaScript code position', 'matomo' ), array(
 			'footer' => __( 'Footer', 'matomo' ),

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -52,7 +52,7 @@ $paths = new Paths();
 		    echo '<th scope="row"><label for="tagmanger_container_ids">' . __( 'Add these Tag Manager containers', 'matomo' ) . '</label>:</th><td>';
 		    $selected_container_ids = $settings->get_global_option( 'tagmanger_container_ids' );
 		    foreach ( $containers as $container_id => $container_name ) {
-			    echo '<input type="checkbox" ' . ( isset ( $selected_container_ids [ $container_id ] ) && $selected_container_ids [ $container_id ] ? 'checked="checked" ' : '' ) . 'value="1" name="matomo[tagmanger_container_ids][' . $container_id . ']" /> ID:' . $container_id . ' Name: ' . $container_name . ' &nbsp; <br />';
+			    echo '<input type="checkbox" ' . ( isset ( $selected_container_ids [ $container_id ] ) && $selected_container_ids [ $container_id ] ? 'checked="checked" ' : '' ) . 'value="1" name="matomo[tagmanger_container_ids][' . $container_id . ']" /> ID:' . esc_html($container_id) . ' Name: ' . esc_html($container_name) . ' &nbsp; <br />';
 		    }
 		    echo '<br /><br /><a href="'.menu_page_url(\WpMatomo\Admin\Menu::SLUG_TAGMANAGER, false).'" rel="noreferrer noopener" target="_blank">Edit containers <span class="dashicons-before dashicons-external"></span></a>';
 		    echo '</td></tr>';

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -20,6 +20,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 /** @var \WpMatomo\Settings $settings */
 /** @var bool $was_updated */
+/** @var array $containers */
+/** @var array $track_modes */
 
 $form  = new \WpMatomo\Admin\TrackingSettings\Forms( $settings );
 $paths = new Paths();
@@ -37,24 +39,33 @@ $paths = new Paths();
 
 		<?php
 		// Tracking Configuration
-		$isNotTracking = $settings->get_global_option( 'track_mode' ) == 'disabled';
+		$isNotTracking = $settings->get_global_option( 'track_mode' ) == TrackingSettings::TRACK_MODE_DISABLED;
 
-		$isNotGeneratedTracking     = $isNotTracking || $settings->get_global_option( 'track_mode' ) == 'manually';
+		$isNotGeneratedTracking     = $isNotTracking || $settings->get_global_option( 'track_mode' ) == TrackingSettings::TRACK_MODE_MANUALLY;
 		$fullGeneratedTrackingGroup = 'matomo-track-option matomo-track-option-default  ';
 
-		$description = sprintf( '%s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s', __( 'You can choose between three tracking code modes:', 'matomo' ), __( 'Disabled', 'matomo' ), __( 'matomo will not add the tracking code. Use this, if you want to add the tracking code to your template files or you use another plugin to add the tracking code.', 'matomo' ), __( 'Default tracking', 'matomo' ), __( 'matomo will use Matomo\'s standard tracking code.', 'matomo' ), __( 'Enter manually', 'matomo' ), __( 'Enter your own tracking code manually. You can choose one of the prior options, pre-configure your tracking code and switch to manually editing at last.', 'matomo' ) . ( $settings->is_network_enabled() ? ' ' . __( 'Use the placeholder {ID} to add the Matomo site ID.', 'matomo' ) : '' ) );
-		$form->show_select( 'track_mode', __( 'Add tracking code', 'matomo' ), array(
-			TrackingSettings::TRACK_MODE_DISABLED => __( 'Disabled', 'matomo' ),
-			TrackingSettings::TRACK_MODE_DEFAULT  => __( 'Default tracking', 'matomo' ),
-			TrackingSettings::TRACK_MODE_MANUALLY => __( 'Enter manually', 'matomo' )
-		), $description, 'jQuery(\'tr.matomo-track-option\').addClass(\'hidden\'); jQuery(\'tr.matomo-track-option-\' + jQuery(\'#track_mode\').val()).removeClass(\'hidden\'); jQuery(\'#tracking_code, #noscript_code\').prop(\'readonly\', jQuery(\'#track_mode\').val() != \'manually\');' );
+		$description = sprintf( '%s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s', __( 'You can choose between four tracking code modes:', 'matomo' ), __( 'Disabled', 'matomo' ), __( 'matomo will not add the tracking code. Use this, if you want to add the tracking code to your template files or you use another plugin to add the tracking code.', 'matomo' ), __( 'Default tracking', 'matomo' ), __( 'matomo will use Matomo\'s standard tracking code.', 'matomo' ), __( 'Enter manually', 'matomo' ), __( 'Enter your own tracking code manually. You can choose one of the prior options, pre-configure your tracking code and switch to manually editing at last.', 'matomo' ) . ( $settings->is_network_enabled() ? ' ' . __( 'Use the placeholder {ID} to add the Matomo site ID.', 'matomo' ) : '' ) , __( 'Tag Manager', 'matomo' ), __( 'If you have created containers in the Tag Manager, you can select one of them and it will embed the code for the container automatically.', 'matomo' ));
+		$form->show_select( 'track_mode', __( 'Add tracking code', 'matomo' ), $track_modes, $description, 'jQuery(\'tr.matomo-track-option\').addClass(\'hidden\'); jQuery(\'tr.matomo-track-option-\' + jQuery(\'#track_mode\').val()).removeClass(\'hidden\'); jQuery(\'#tracking_code, #noscript_code\').prop(\'readonly\', jQuery(\'#track_mode\').val() != \'manually\');' );
+
+		if (!empty($containers)) {
+		    foreach ($containers as $container) {
+			    echo '<tr class="matomo-track-option matomo-track-option-tagmanager' . ( $isNotTracking ? ' hidden' : '' ) . '">';
+			    echo '<th scope="row"><label for="add_post_annotations">' . __( 'Add these Tag Manager containers', 'matomo' ) . '</label>:</th><td>';
+			    $selected_container_ids = $settings->get_global_option( 'tagmanger_container_ids' );
+			    foreach ( $containers as $container_id => $container_name ) {
+				    echo '<input type="checkbox" ' . ( isset ( $selected_container_ids [ $container_id ] ) && $selected_container_ids [ $container_id ] ? 'checked="checked" ' : '' ) . 'value="1" name="matomo[tagmanger_container_ids][' . $container_id . ']" /> ' . $container_name . ' (ID:' . $container_id . ') &nbsp; ';
+			    }
+			    echo '<br /><br /><a href="'.menu_page_url(\WpMatomo\Admin\Menu::SLUG_TAGMANAGER, false).'" rel="noreferrer noopener" target="_blank">Edit containers <span class="dashicons-before dashicons-external"></span></a>';
+			    echo '</td></tr>';
+		    }
+		}
 
 		$form->show_textarea( 'tracking_code', __( 'Tracking code', 'matomo' ), 15, 'This is a preview of your current tracking code. If you choose to enter your tracking code manually, you can change it here. Have a look at the system report to get a list of all available JS tracker and tracking API endpoints.', $isNotTracking, 'matomo-track-option matomo-track-option-default   matomo-track-option-manually', true, '', ( $settings->get_global_option( 'track_mode' ) != 'manually' ), false );
 
 		$form->show_select( 'track_codeposition', __( 'JavaScript code position', 'matomo' ), array(
 			'footer' => __( 'Footer', 'matomo' ),
 			'header' => __( 'Header', 'matomo' )
-		), __( 'Choose whether the JavaScript code is added to the footer or the header.', 'matomo' ), '', $isNotTracking, 'matomo-track-option matomo-track-option-default   matomo-track-option-manually' );
+		), __( 'Choose whether the JavaScript code is added to the footer or the header.', 'matomo' ), '', $isNotTracking, 'matomo-track-option matomo-track-option-default  matomo-track-option-tagmanager matomo-track-option-manually' );
 
 		$form->show_textarea( 'noscript_code', __( 'Noscript code', 'matomo' ), 2, 'This is a preview of your &lt;noscript&gt; code which is part of your tracking code.', $isNotTracking, 'matomo-track-option matomo-track-option-default  matomo-track-option-manually', true, '', ( $settings->get_global_option( 'track_mode' ) != 'manually' ), false );
 
@@ -63,7 +74,7 @@ $paths = new Paths();
 		$form->show_select( 'track_api_endpoint', __( 'Endpoint for HTTP Tracking API', 'matomo' ), array(
 			'default' => __( 'Default', 'matomo' ),
 			'restapi' => __( 'Through WordPress Rest API', 'matomo' ),
-		), __( 'By default the HTTP Tracking API points to your Matomo plugin directory "' . esc_html( $paths->get_tracker_api_url_in_matomo_dir() ) . '". You can choose to use the WP Rest API (' . esc_html( $paths->get_tracker_api_rest_api_endpoint() ) . ') instead for example to hide matomo.php or if the other URL doesn\'t work for you.', 'matomo' ), '', $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually ' );
+		), __( 'By default the HTTP Tracking API points to your Matomo plugin directory "' . esc_html( $paths->get_tracker_api_url_in_matomo_dir() ) . '". You can choose to use the WP Rest API (' . esc_html( $paths->get_tracker_api_rest_api_endpoint() ) . ') instead for example to hide matomo.php or if the other URL doesn\'t work for you. Note: If the tracking mode "Tag Manager" is selected, then this URL currently only applies to the feed tracking.', 'matomo' ), '', $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually matomo-track-option-tagmanager' );
 
 		$form->show_select( 'track_js_endpoint', __( 'Endpoint for JavaScript tracker', 'matomo' ), array(
 			'default' => __( 'Default', 'matomo' ),
@@ -100,7 +111,7 @@ $paths = new Paths();
 
 		$form->show_input( 'limit_cookies_referral', __( 'Referral timeout (seconds)', 'matomo' ), false, $isNotGeneratedTracking || ! $settings->get_global_option( 'limit_cookies' ), $fullGeneratedTrackingGroup . ' matomo-cookielifetime-option' . ( $settings->get_global_option( 'limit_cookies' ) ? '' : ' matomo-hidden' ) );
 
-		$form->show_checkbox( 'track_admin', __( 'Track admin pages', 'matomo' ), __( 'Enable to track users on admin pages (remember to configure the tracking filter appropriately).', 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually' );
+		$form->show_checkbox( 'track_admin', __( 'Track admin pages', 'matomo' ), __( 'Enable to track users on admin pages (remember to configure the tracking filter appropriately).', 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually matomo-track-option-tagmanager' );
 
 		$form->show_checkbox( 'track_across', __( 'Track subdomains in the same website', 'matomo' ), __( 'Adds *.-prefix to cookie domain.', 'matomo' ) . ' ' . sprintf( __( 'See %sMatomo documentation%s.', 'matomo' ), '<a href="https://developer.matomo.org/guides/tracking-javascript-guide#tracking-subdomains-in-the-same-website" target="_BLANK">', '</a>' ), $isNotGeneratedTracking, $fullGeneratedTrackingGroup );
 
@@ -108,11 +119,11 @@ $paths = new Paths();
 
 		$form->show_checkbox( 'track_crossdomain_linking', __( 'Enable cross domain linking', 'matomo' ), __( 'When enabled, it will make sure to use the same visitor ID for the same visitor across several domains. This works only when this feature is enabled because the visitor ID is stored in a cookie and cannot be read on the other domain by default. When this feature is enabled, it will append a URL parameter "pk_vid" that contains the visitor ID when a user clicks on a URL that belongs to one of your domains. For this feature to work, you also have to configure which domains should be treated as local in your Matomo website settings.', 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup );
 
-		$form->show_checkbox( 'track_feed', __( 'Track RSS feeds', 'matomo' ), __( 'Enable to track posts in feeds via tracking pixel.', 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually' );
+		$form->show_checkbox( 'track_feed', __( 'Track RSS feeds', 'matomo' ), __( 'Enable to track posts in feeds via tracking pixel.', 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually matomo-track-option-tagmanager' );
 
-		$form->show_checkbox( 'track_feed_addcampaign', __( 'Track RSS feed links as campaign', 'matomo' ), __( 'This will add Matomo campaign parameters to the RSS feed links.' . ' ' . sprintf( __( 'See %sMatomo documentation%s.', 'matomo' ), '<a href="https://matomo.org/docs/tracking-campaigns/" target="_BLANK">', '</a>' ), 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually', true, 'jQuery(\'tr.matomo-feed_campaign-option\').toggle(\'hidden\');' );
+		$form->show_checkbox( 'track_feed_addcampaign', __( 'Track RSS feed links as campaign', 'matomo' ), __( 'This will add Matomo campaign parameters to the RSS feed links.' . ' ' . sprintf( __( 'See %sMatomo documentation%s.', 'matomo' ), '<a href="https://matomo.org/docs/tracking-campaigns/" target="_BLANK">', '</a>' ), 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually matomo-track-option-tagmanager', true, 'jQuery(\'tr.matomo-feed_campaign-option\').toggle(\'hidden\');' );
 
-		$form->show_input( 'track_feed_campaign', __( 'RSS feed campaign', 'matomo' ), __( 'Keyword: post name.', 'matomo' ), $isNotGeneratedTracking || ! $settings->get_global_option( 'track_feed_addcampaign' ), $fullGeneratedTrackingGroup . ' matomo-feed_campaign-option' );
+		$form->show_input( 'track_feed_campaign', __( 'RSS feed campaign', 'matomo' ), __( 'Keyword: post name.', 'matomo' ), $isNotGeneratedTracking || ! $settings->get_global_option( 'track_feed_addcampaign' ), $fullGeneratedTrackingGroup . ' matomo-feed_campaign-option matomo-track-option-tagmanager' );
 
 		$form->show_input( 'track_heartbeat', __( 'Enable heartbeat timer', 'matomo' ), __( 'Enable a heartbeat timer to get more accurate visit lengths by sending periodical HTTP ping requests as long as the site is opened. Enter the time between the pings in seconds (Matomo default: 15) to enable or 0 to disable this feature. <strong>Note:</strong> This will cause a lot of additional HTTP requests on your site.', 'matomo' ), $isNotGeneratedTracking, $fullGeneratedTrackingGroup );
 
@@ -124,7 +135,7 @@ $paths = new Paths();
 			'displayname' => __( 'Display Name (Not Recommended!)', 'matomo' )
 		), __( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'matomo' ), '', $isNotTracking, $fullGeneratedTrackingGroup );
 
-		$form->show_checkbox( 'track_datacfasync', __( 'Add data-cfasync=false', 'matomo' ), __( 'Adds data-cfasync=false to the script tag, e.g., to ask Rocket Loader to ignore the script.' . ' ' . sprintf( __( 'See %sCloudFlare Knowledge Base%s.', 'matomo' ), '<a href="https://support.cloudflare.com/hc/en-us/articles/200169436-How-can-I-have-Rocket-Loader-ignore-my-script-s-in-Automatic-Mode-" target="_BLANK">', '</a>' ), 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup );
+		$form->show_checkbox( 'track_datacfasync', __( 'Add data-cfasync=false', 'matomo' ), __( 'Adds data-cfasync=false to the script tag, e.g., to ask Rocket Loader to ignore the script.' . ' ' . sprintf( __( 'See %sCloudFlare Knowledge Base%s.', 'matomo' ), '<a href="https://support.cloudflare.com/hc/en-us/articles/200169436-How-can-I-have-Rocket-Loader-ignore-my-script-s-in-Automatic-Mode-" target="_BLANK">', '</a>' ), 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup . '  matomo-track-option-tagmanager' );
 
 		$submitButton = '<tr><td colspan="2"><p class="submit"><input name="Submit" type="submit" class="button-primary" value="' . esc_attr__( 'Save Changes' ) . '" /></p></td></tr>';
 
@@ -137,7 +148,7 @@ $paths = new Paths();
 		$form->show_select( 'force_protocol', __( 'Force Matomo to use a specific protocol', 'matomo' ), array(
 			'disabled' => __( 'Disabled (default)', 'matomo' ),
 			'https'    => __( 'https (SSL) ', 'matomo' )
-		), __( 'Choose if you want to explicitly want to force Matomo to use HTTP or HTTPS. Does not work with a CDN URL.', 'matomo' ), '', $isNotTracking, $fullGeneratedTrackingGroup );
+		), __( 'Choose if you want to explicitly want to force Matomo to use HTTP or HTTPS. Does not work with a CDN URL.', 'matomo' ), '', $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-tagmanager' );
 
 		echo $submitButton; ?>
 

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -48,16 +48,14 @@ $paths = new Paths();
 		$form->show_select( 'track_mode', __( 'Add tracking code', 'matomo' ), $track_modes, $description, 'jQuery(\'tr.matomo-track-option\').addClass(\'hidden\'); jQuery(\'tr.matomo-track-option-\' + jQuery(\'#track_mode\').val()).removeClass(\'hidden\'); jQuery(\'#tracking_code, #noscript_code\').prop(\'readonly\', jQuery(\'#track_mode\').val() != \'manually\');' );
 
 		if (!empty($containers)) {
-		    foreach ($containers as $container) {
-			    echo '<tr class="matomo-track-option matomo-track-option-tagmanager ' . ( $isNotTracking ? ' hidden' : '' ) . '">';
-			    echo '<th scope="row"><label for="add_post_annotations">' . __( 'Add these Tag Manager containers', 'matomo' ) . '</label>:</th><td>';
-			    $selected_container_ids = $settings->get_global_option( 'tagmanger_container_ids' );
-			    foreach ( $containers as $container_id => $container_name ) {
-				    echo '<input type="checkbox" ' . ( isset ( $selected_container_ids [ $container_id ] ) && $selected_container_ids [ $container_id ] ? 'checked="checked" ' : '' ) . 'value="1" name="matomo[tagmanger_container_ids][' . $container_id . ']" /> ' . $container_name . ' (ID:' . $container_id . ') &nbsp; ';
-			    }
-			    echo '<br /><br /><a href="'.menu_page_url(\WpMatomo\Admin\Menu::SLUG_TAGMANAGER, false).'" rel="noreferrer noopener" target="_blank">Edit containers <span class="dashicons-before dashicons-external"></span></a>';
-			    echo '</td></tr>';
+		    echo '<tr class="matomo-track-option matomo-track-option-tagmanager ' . ( $isNotTracking ? ' hidden' : '' ) . '">';
+		    echo '<th scope="row"><label for="tagmanger_container_ids">' . __( 'Add these Tag Manager containers', 'matomo' ) . '</label>:</th><td>';
+		    $selected_container_ids = $settings->get_global_option( 'tagmanger_container_ids' );
+		    foreach ( $containers as $container_id => $container_name ) {
+			    echo '<input type="checkbox" ' . ( isset ( $selected_container_ids [ $container_id ] ) && $selected_container_ids [ $container_id ] ? 'checked="checked" ' : '' ) . 'value="1" name="matomo[tagmanger_container_ids][' . $container_id . ']" /> ' . $container_name . ' (ID:' . $container_id . ') &nbsp; ';
 		    }
+		    echo '<br /><br /><a href="'.menu_page_url(\WpMatomo\Admin\Menu::SLUG_TAGMANAGER, false).'" rel="noreferrer noopener" target="_blank">Edit containers <span class="dashicons-before dashicons-external"></span></a>';
+		    echo '</td></tr>';
 		}
 
 		$form->show_textarea( 'tracking_code', __( 'Tracking code', 'matomo' ), 15, 'This is a preview of your current tracking code. If you choose to enter your tracking code manually, you can change it here. Have a look at the system report to get a list of all available JS tracker and tracking API endpoints.', $isNotTracking, 'matomo-track-option matomo-track-option-default matomo-track-option-tagmanager  matomo-track-option-manually', true, '', ( $settings->get_global_option( 'track_mode' ) != 'manually' ), false );

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -52,7 +52,7 @@ $paths = new Paths();
 		    echo '<th scope="row"><label for="tagmanger_container_ids">' . __( 'Add these Tag Manager containers', 'matomo' ) . '</label>:</th><td>';
 		    $selected_container_ids = $settings->get_global_option( 'tagmanger_container_ids' );
 		    foreach ( $containers as $container_id => $container_name ) {
-			    echo '<input type="checkbox" ' . ( isset ( $selected_container_ids [ $container_id ] ) && $selected_container_ids [ $container_id ] ? 'checked="checked" ' : '' ) . 'value="1" name="matomo[tagmanger_container_ids][' . $container_id . ']" /> ' . $container_name . ' (ID:' . $container_id . ') &nbsp; ';
+			    echo '<input type="checkbox" ' . ( isset ( $selected_container_ids [ $container_id ] ) && $selected_container_ids [ $container_id ] ? 'checked="checked" ' : '' ) . 'value="1" name="matomo[tagmanger_container_ids][' . $container_id . ']" /> ID:' . $container_id . ' Name: ' . $container_name . ' &nbsp; <br />';
 		    }
 		    echo '<br /><br /><a href="'.menu_page_url(\WpMatomo\Admin\Menu::SLUG_TAGMANAGER, false).'" rel="noreferrer noopener" target="_blank">Edit containers <span class="dashicons-before dashicons-external"></span></a>';
 		    echo '</td></tr>';
@@ -85,7 +85,7 @@ $paths = new Paths();
 			'visible'  => __( 'Track only visible content blocks', 'matomo' )
 		), __( 'Content tracking allows you to track interaction with the content of a web page or application.' ) . ' ' . sprintf( __( 'See %sMatomo documentation%s.', 'matomo' ), '<a href="https://developer.matomo.org/guides/content-tracking" target="_BLANK">', '</a>' ), '', $isNotTracking, $fullGeneratedTrackingGroup );
 
-		$form->show_checkbox( 'track_search', __( 'Track search', 'matomo' ), __( 'Use Matomo\'s advanced Site Search Analytics feature.' ) . ' ' . sprintf( __( 'See %sMatomo documentation%s.', 'matomo' ), '<a href="https://matomo.org/docs/site-search/#track-site-search-using-the-tracking-api-advanced-users-only" target="_BLANK">', '</a>' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually' );
+		$form->show_checkbox( 'track_search', __( 'Track search', 'matomo' ), __( 'Use Matomo\'s advanced Site Search Analytics feature.' ) . ' ' . sprintf( __( 'See %sMatomo documentation%s.', 'matomo' ), '<a href="https://matomo.org/docs/site-search/#track-site-search-using-the-tracking-api-advanced-users-only" target="_BLANK">', '</a>' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually matomo-track-option-tagmanager' );
 
 		$form->show_checkbox( 'track_404', __( 'Track 404', 'matomo' ), __( 'Matomo can automatically add a 404-category to track 404-page-visits.', 'matomo' ) . ' ' . sprintf( __( 'See %sMatomo FAQ%s.', 'matomo' ), '<a href="https://matomo.org/faq/how-to/faq_60/" target="_BLANK">', '</a>' ), $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-manually' );
 
@@ -131,7 +131,7 @@ $paths = new Paths();
 			'email'       => __( 'Email Address', 'matomo' ),
 			'username'    => __( 'Username', 'matomo' ),
 			'displayname' => __( 'Display Name (Not Recommended!)', 'matomo' )
-		), __( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'matomo' ), '', $isNotTracking, $fullGeneratedTrackingGroup );
+		), __( 'When a user is logged in to WordPress, track their &quot;User ID&quot;. You can select which field from the User\'s profile is tracked as the &quot;User ID&quot;. When enabled, Tracking based on Email Address is recommended.', 'matomo' ), '', $isNotTracking, $fullGeneratedTrackingGroup . ' matomo-track-option-tagmanager' );
 
 		$form->show_checkbox( 'track_datacfasync', __( 'Add data-cfasync=false', 'matomo' ), __( 'Adds data-cfasync=false to the script tag, e.g., to ask Rocket Loader to ignore the script.' . ' ' . sprintf( __( 'See %sCloudFlare Knowledge Base%s.', 'matomo' ), '<a href="https://support.cloudflare.com/hc/en-us/articles/200169436-How-can-I-have-Rocket-Loader-ignore-my-script-s-in-Automatic-Mode-" target="_BLANK">', '</a>' ), 'matomo' ), $isNotTracking, $fullGeneratedTrackingGroup . '  matomo-track-option-tagmanager' );
 

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -135,6 +135,11 @@ class Installer {
 
 			DbHelper::recordInstallVersion();
 
+			if (!SettingsPiwik::getPiwikUrl()) {
+				// especially needed for tests on cli
+				\Piwik\SettingsPiwik::overwritePiwikUrl(plugins_url( 'app', MATOMO_ANALYTICS_FILE ));
+			}
+
 			$this->logger->log( 'Creating some index files' );
 
 			$paths = new Paths();

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -133,6 +133,8 @@ class Installer {
 
 			}
 
+			DbHelper::recordInstallVersion();
+
 			$this->logger->log( 'Creating some index files' );
 
 			$paths = new Paths();

--- a/classes/WpMatomo/Paths.php
+++ b/classes/WpMatomo/Paths.php
@@ -109,17 +109,23 @@ class Paths {
 	}
 
 	public function get_relative_dir_to_matomo( $target_dir ) {
-		$matomo_dir         = realpath( __DIR__ . '/../../app' );
+		$matomo_dir         = plugin_dir_path(MATOMO_ANALYTICS_FILE) . 'app';
 		$matomo_dir_parts   = explode( '/', $matomo_dir );
 		$target_dir_parts   = explode( '/', $target_dir );
 		$relative_directory = '';
 		$add_at_the_end     = array();
+		$was_previous_same  = false;
+
 		foreach ( $target_dir_parts as $index => $part ) {
 			if ( isset( $matomo_dir_parts[ $index ] )
 			     && $part !== 'matomo' // not when matomo is same part cause it's the plugin name but eg also the upload folder name and it would generate wrong path
-			     && $matomo_dir_parts[ $index ] === $part ) {
+			     && $matomo_dir_parts[ $index ] === $part
+				&& !$was_previous_same) {
 				continue;
 			}
+
+			$was_previous_same = true;
+
 			if ( isset( $matomo_dir_parts[ $index ] ) ) {
 				$relative_directory .= '../';
 			}

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -66,6 +66,7 @@ class Settings {
 		'track_content'                            => 'disabled',
 		'track_search'                             => false,
 		'track_404'                                => false,
+		'tagmanger_container_ids'                  => array(),
 		'add_post_annotations'                     => array(),
 		'add_customvars_box'                       => false,
 		'js_manually'                              => '',

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -120,11 +120,12 @@ class TrackingCodeGenerator {
 
 		$container_ids = $settings->get_global_option('tagmanger_container_ids');
 
+		$code = '<!-- Matomo Tag Manager -->';
+
 		if (!empty($container_ids) && is_array($container_ids)) {
 			$paths = new Paths();
 			$upload_url = $paths->get_upload_base_url();
 
-			$code = '';
 			foreach ($container_ids as $container_id => $enabled) {
 				if ( $enabled
 				     && ctype_alnum($container_id)
@@ -140,17 +141,18 @@ class TrackingCodeGenerator {
 						$container_url = preg_replace( "(^http://)", "https://", $container_url );
 					}
 
-					$code .= '<!-- Matomo Tag Manager -->
+					$code .= '
 <script type="text/javascript" '.$data_cf_async.'>
 var _mtm = _mtm || [];
 _mtm.push({\'mtm.startTime\': (new Date().getTime()), \'event\': \'mtm.Start\'});
 var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
 g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="'.$container_url.'"; s.parentNode.insertBefore(g,s);
-</script>
-<!-- End Matomo Tag Manager -->';
+</script>';
 				}
 			}
 		}
+
+		$code .= '<!-- End Matomo Tag Manager -->';
 
 		return array('script' => $code, 'noscript' => '');
 	}

--- a/config/common.config.ini.php
+++ b/config/common.config.ini.php
@@ -48,3 +48,6 @@ allowedRetriesTimeRange = 60
 
 [PrivacyManager]
 showInEmbeddedWidgets = 0
+
+[TagManager]
+environments[] = 'live'

--- a/config/config.php
+++ b/config/config.php
@@ -27,12 +27,12 @@ return array(
 	'TagManagerContainerStorageDir' => function () {
 		// the location where we store the generated javascript or json container files
 		$paths = new \WpMatomo\Paths();
-		return '/'. $paths->get_relative_dir_to_matomo($paths->get_upload_base_dir().'/');
+		return rtrim('/'. $paths->get_relative_dir_to_matomo($paths->get_upload_base_dir().'/'), '/');
 	},
 	'TagManagerContainerWebDir' => function () {
 		// the location where we store the generated javascript or json container files
 		$paths = new \WpMatomo\Paths();
-		return '/'. $paths->get_relative_dir_to_matomo($paths->get_upload_base_dir().'/');
+		return rtrim('/'. $paths->get_relative_dir_to_matomo($paths->get_upload_base_dir().'/'), '/');
 	},
 	'Piwik\Auth' => DI\object('Piwik\Plugins\WordPress\Auth'),
 	\Piwik\Config::class => DI\decorate(function ($previous) {

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -53,7 +53,17 @@ class WordPress extends Plugin
             'Template.header' => 'onHeader',
             'AssetManager.makeNewAssetManagerObject' => 'makeNewAssetManagerObject',
             'ScheduledTasks.shouldExecuteTask' => 'shouldExecuteTask',
+            'API.TagManager.getContainerInstallInstructions.end' => 'addInstallInstructions',
         );
+    }
+
+    public function addInstallInstructions(&$instructions)
+    {
+	    $instructions[] = array(
+		    'description' => 'Alternatively, simply go to "Tracking Settings" in your WordPress Admin and select "Tag Manager" as tracking mode or choose "Manually" and paste the above code into the tracking code field.',
+		    'embedCode' => '',
+		    'helpUrl' => ''
+	    );
     }
 
 	/**

--- a/scripts/update-core.sh
+++ b/scripts/update-core.sh
@@ -30,7 +30,6 @@ find $MATOMO_ROOT/misc/* ! -name 'gpl-3.0.txt' -exec rm -rf {} +
 rm -rf $MATOMO_ROOT/tmp
 rm -rf $MATOMO_ROOT/tests
 rm -rf $MATOMO_ROOT/config/manifest.inc.php
-rm -rf $MATOMO_ROOT/piwik.js
 # important to remove pclzip as it is shipped with WP and would need to use their lib
 rm -rf $MATOMO_ROOT/matomo/app/vendor/piwik/decompress/libs/PclZip
 

--- a/tests/phpunit/wpmatomo/admin/test-trackingsettings-bootstrapped.php
+++ b/tests/phpunit/wpmatomo/admin/test-trackingsettings-bootstrapped.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package Matomo_Analytics
+ */
+
+use WpMatomo\Admin\TrackingSettings;
+use WpMatomo\Settings;
+
+class AdminTrackingSettingsBootstrappedTest extends MatomoAnalytics_TestCase {
+
+	/**
+	 * @var TrackingSettings
+	 */
+	private $tracking_settings;
+
+	public function setUp() {
+		parent::setUp();
+
+		$settings                = new Settings();
+		$this->tracking_settings = new TrackingSettings( $settings );
+
+		$this->assume_admin_page();
+		$this->create_set_super_admin();
+
+		\WpMatomo\Bootstrap::do_bootstrap();
+	}
+
+	public function test_get_active_containers_when_containers_defined() {
+		$site = new WpMatomo\Site();
+		$idsite = $site->get_current_matomo_site_id();
+
+		$id = \Piwik\API\Request::processRequest('TagManager.createDefaultContainerForSite', array(
+			'idSite' => $idsite
+		));
+
+		$containers = $this->tracking_settings->get_active_containers();
+		$this->assertSame(array($id => 'Default Container'), $containers);
+	}
+
+}

--- a/tests/phpunit/wpmatomo/admin/test-trackingsettings.php
+++ b/tests/phpunit/wpmatomo/admin/test-trackingsettings.php
@@ -97,5 +97,9 @@ class AdminTrackingSettingsTest extends MatomoUnit_TestCase {
 		$this->assertEquals( array(), $this->settings->get_global_option( Settings::OPTION_KEY_CAPS_ACCESS ) );
 	}
 
+	public function test_get_active_containers_when_no_container_defined() {
+		$containers = $this->tracking_settings->get_active_containers();
+		$this->assertSame(array(), $containers);
+	}
 
 }

--- a/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
+++ b/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
@@ -95,5 +95,27 @@ _paq.push([\'trackAllContentImpressions\']);_paq.push([\'trackPageView\']);_paq.
 		$this->assertSame( '<script>foobar</script>', $this->get_tracking_code() );
 	}
 
+	public function test_get_tracking_code_when_using_tagmanager_mode() {
+		$this->settings->apply_tracking_related_changes( array(
+			'track_mode' => TrackingSettings::TRACK_MODE_TAGMANAGER,
+			'tagmanger_container_ids' => array('abcdefgh' => 1, 'cfk3jjw' => 0)
+		) );
+		$this->assertSame( '<!-- Matomo Tag Manager -->
+<script type="text/javascript" >
+var _mtm = _mtm || [];
+_mtm.push({\'mtm.startTime\': (new Date().getTime()), \'event\': \'mtm.Start\'});
+var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];
+g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="http://example.org/wp-content/uploads/matomo/container_abcdefgh.js"; s.parentNode.insertBefore(g,s);
+</script><!-- End Matomo Tag Manager -->', $this->get_tracking_code() );
+	}
+
+	public function test_get_tracking_code_when_using_tagmanager_mode_and_no_containers() {
+		$this->settings->apply_tracking_related_changes( array(
+			'track_mode' => TrackingSettings::TRACK_MODE_TAGMANAGER,
+			'tagmanger_container_ids' => array()
+		) );
+		$this->assertSame( '<!-- Matomo Tag Manager --><!-- End Matomo Tag Manager -->', $this->get_tracking_code() );
+	}
+
 
 }


### PR DESCRIPTION
This will be a basic solution where users can select one or multiple containers and we print the debug code. They currently won't be able to select a tracking JS / or tracking API endpoint.(rest  API instead of the regular endpoint). And some features like userId are not yet supported. We would basically need to add custom userId templates for this to the tag manager so they can select it. There's heaps that could be done but would need to go there step by step.

fix #11