### PR TITLE
Throw exceptions on DB errors in our DB adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.1.6
+- Handle database errors better and behave same as Matomo DB adapters
+- Fix an issue in managing goals
+- Improve support for PHP 7.2
+- Show MySQL adapter in system report
+- Hide not working link to tracking code in tour widget
+
 0.1.5
 - Fix error in htaccess file preventing tracker file to load
 - Easy way to embed tag manager containers into site

--- a/classes/WpMatomo/Db/Wordpress.php
+++ b/classes/WpMatomo/Db/Wordpress.php
@@ -156,6 +156,8 @@ class Wordpress extends Mysqli {
 		} else {
 			$prepare = $this->prepareWp( $sql, $bind );
 			$result  = $wpdb->query( $prepare );
+
+			$this->throwExceptionIfError($wpdb);
 		}
 
 		return new WordPressDbStatement( $this, $sql, $result );
@@ -175,27 +177,54 @@ class Wordpress extends Mysqli {
 		global $wpdb;
 		$prepare = $this->prepareWp( $sql, $bind );
 
-		return $wpdb->get_col( $prepare );
+		$col = $wpdb->get_col( $prepare );
+
+		$this->throwExceptionIfError($wpdb);
+
+		return $col;
 	}
 
 	public function fetchAssoc( $sql, $bind = array() ) {
 		global $wpdb;
 		$prepare = $this->prepareWp( $sql, $bind );
 
-		return $wpdb->get_results( $prepare, ARRAY_A );
+		$assoc = $wpdb->get_results( $prepare, ARRAY_A );
+
+		$this->throwExceptionIfError($wpdb);
+
+		return $assoc;
+	}
+
+	/**
+	 * @param \wpdb $wpdb
+	 *
+	 * @throws \Zend_Db_Statement_Exception
+	 */
+	private function throwExceptionIfError($wpdb)
+	{
+		if ($wpdb->last_error) {
+			throw new \Zend_Db_Statement_Exception($wpdb->last_error);
+		}
 	}
 
 	public function fetchAll( $sql, $bind = array(), $fetchMode = null ) {
 		global $wpdb;
 		$prepare = $this->prepareWp( $sql, $bind );
 
-		return $wpdb->get_results( $prepare, ARRAY_A );
+		$results = $wpdb->get_results( $prepare, ARRAY_A );
+
+		$this->throwExceptionIfError($wpdb);
+
+		return $results;
 	}
 
 	public function fetchOne( $sql, $bind = array() ) {
 		global $wpdb;
 		$prepare = $this->prepareWp( $sql, $bind );
 		$value   = $wpdb->get_var( $prepare );
+
+		$this->throwExceptionIfError($wpdb);
+
 		if ( $value === null ) {
 			return false; // make sure to behave same way as matomo
 		}
@@ -207,13 +236,21 @@ class Wordpress extends Mysqli {
 		global $wpdb;
 		$prepare = $this->prepareWp( $sql, $bind );
 
-		return $wpdb->get_row( $prepare, ARRAY_A );
+		$row = $wpdb->get_row( $prepare, ARRAY_A );
+
+		$this->throwExceptionIfError($wpdb);
+
+		return $row;
 	}
 
 	public function insert( $table, array $bind ) {
 		global $wpdb;
 
-		return $wpdb->insert( $table, $bind );
+		$insert = $wpdb->insert( $table, $bind );
+
+		$this->throwExceptionIfError($wpdb);
+
+		return $insert;
 	}
 
 	public function update( $table, array $bind, $where = '' ) {
@@ -228,6 +265,10 @@ class Wordpress extends Mysqli {
 		$sql      = "UPDATE `$table` SET $fields " . ( ( $where ) ? " WHERE $where" : '' );
 		$prepared = $wpdb->prepare( $sql, $bind );
 
-		return $wpdb->query( $prepared );
+		$update = $wpdb->query( $prepared );
+
+		$this->throwExceptionIfError($wpdb);
+
+		return $update;
 	}
 }

--- a/classes/WpMatomo/Db/Wordpress.php
+++ b/classes/WpMatomo/Db/Wordpress.php
@@ -203,7 +203,7 @@ class Wordpress extends Mysqli {
 	private function throwExceptionIfError($wpdb)
 	{
 		if ($wpdb->last_error) {
-			throw new \Zend_Db_Statement_Exception($wpdb->last_error);
+			throw new \Zend_Db_Statement_Exception('WP DB Error: ' . $wpdb->last_error);
 		}
 	}
 

--- a/classes/WpMatomo/Db/WordpressTracker.php
+++ b/classes/WpMatomo/Db/WordpressTracker.php
@@ -184,7 +184,7 @@ class Wordpress extends Mysqli {
 
 		$results = $wpdb->get_results( $prepare, ARRAY_A );
 
-		$this->throwExceptionIfError($results);
+		$this->throwExceptionIfError($wpdb);
 
 		return $results;
 	}

--- a/classes/WpMatomo/Db/WordpressTracker.php
+++ b/classes/WpMatomo/Db/WordpressTracker.php
@@ -59,6 +59,18 @@ class Wordpress extends Mysqli {
 		return $queryResult->rowCount();
 	}
 
+	/**
+	 * @param \wpdb $wpdb
+	 *
+	 * @throws \Zend_Db_Statement_Exception
+	 */
+	private function throwExceptionIfError($wpdb)
+	{
+		if ($wpdb->last_error) {
+			throw new \Zend_Db_Statement_Exception($wpdb->last_error);
+		}
+	}
+
 	private function prepareWp( $sql, $bind = array() ) {
 		global $wpdb;
 
@@ -96,6 +108,7 @@ class Wordpress extends Mysqli {
 		} else {
 			$query  = $this->prepareWp( $query, $parameters );
 			$result = $wpdb->query( $query );
+			$this->throwExceptionIfError($wpdb);
 		}
 
 		return new WordPressDbStatement( $this, $query, $result );
@@ -158,14 +171,22 @@ class Wordpress extends Mysqli {
 		global $wpdb;
 		$prepare = $this->prepareWp( $query, $parameters );
 
-		return $wpdb->get_row( $prepare, ARRAY_A );
+		$row = $wpdb->get_row( $prepare, ARRAY_A );
+
+		$this->throwExceptionIfError($wpdb);
+
+		return $row;
 	}
 
 	public function fetchAll( $query, $parameters = array() ) {
 		global $wpdb;
 		$prepare = $this->prepareWp( $query, $parameters );
 
-		return $wpdb->get_results( $prepare, ARRAY_A );
+		$results = $wpdb->get_results( $prepare, ARRAY_A );
+
+		$this->throwExceptionIfError($results);
+
+		return $results;
 	}
 
 

--- a/config/config.php
+++ b/config/config.php
@@ -41,6 +41,8 @@ return array(
 		 */
 		global $wpdb;
 
+		\Piwik\Plugins\TagManager\TagManager::$enableAutoContainerCreation = false;
+
 		// in case DB credentials change in wordpress, we need to apply these changes here as well on demand
 		$hostParts = explode(':', DB_HOST);
 		$host = $hostParts[0];

--- a/matomo.php
+++ b/matomo.php
@@ -48,7 +48,18 @@ function has_matomo_tag_manager()
 	if (defined('MATOMO_DISABLE_TAG_MANAGER') && MATOMO_DISABLE_TAG_MANAGER) {
 		return false;
 	}
-	return !function_exists('is_multisite') || !is_multisite();
+
+	$is_multisite = function_exists('is_multisite') && is_multisite();
+	if ($is_multisite) {
+		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		}
+
+		$network_enabled = is_plugin_active_for_network( 'matomo/matomo.php' );
+		return !$network_enabled;
+	}
+
+	return true;
 }
 
 function add_matomo_plugin( $plugins_directory, $wp_plugin_file ) {

--- a/matomo.php
+++ b/matomo.php
@@ -4,7 +4,7 @@
  * Description: Most powerful web analytics for WordPress giving you 100% data ownership and privacy protection
  * Author: Matomo
  * Author URI: https://matomo.org
- * Version: 0.1.5
+ * Version: 0.1.6
  * Domain Path: /languages
  * WC requires at least: 2.4.0
  * WC tested up to: 3.2.6
@@ -56,7 +56,7 @@ function has_matomo_tag_manager()
 		}
 
 		$network_enabled = is_plugin_active_for_network( 'matomo/matomo.php' );
-		return !$network_enabled;
+		return false;
 	}
 
 	return true;

--- a/tests/phpunit/wpmatomo/admin/test-trackingsettings-bootstrapped.php
+++ b/tests/phpunit/wpmatomo/admin/test-trackingsettings-bootstrapped.php
@@ -26,6 +26,11 @@ class AdminTrackingSettingsBootstrappedTest extends MatomoAnalytics_TestCase {
 	}
 
 	public function test_get_active_containers_when_containers_defined() {
+		if (function_exists('is_multisite') && is_multisite()) {
+			$this->markTestSkipped('We do not run this test for multisite');
+			return;
+		}
+
 		$site = new WpMatomo\Site();
 		$idsite = $site->get_current_matomo_site_id();
 

--- a/tests/phpunit/wpmatomo/test-access.php
+++ b/tests/phpunit/wpmatomo/test-access.php
@@ -8,7 +8,7 @@ use WpMatomo\Capabilities;
 use WpMatomo\Roles;
 use WpMatomo\Settings;
 
-class AccessTest extends MatomoUnit_TestCase {
+class AccessTest extends MatomoAnalytics_TestCase {
 
 	/**
 	 * @var Access


### PR DESCRIPTION
Noticed archiving for segments wasn't quite working as expected cause no exception was thrown when the segment table did not exist. I'm hoping this fixes things and behaves now more like the Matomo DB adapter.

I've been debugging this for hours and sometimes mysqli seems to not return an error eg when table did not exist and instead only returned null in the query (the next call to mysqli_error did not return any error etc). `null` would maybe allow us to detect when a query fails. Problem is, that WP API also returns null by the looks when there is eg no matching row/value/variable eg in `$wpdb->get_var()` etc. and we can't differentiate between actual result and error and we can't access the original result of the query `$this->last_result` since the property is protected.