### PR TITLE
When bootstrapping Matomo within WordPress do not start a session

### DIFF
--- a/classes/WpMatomo/Bootstrap.php
+++ b/classes/WpMatomo/Bootstrap.php
@@ -48,6 +48,11 @@ class Bootstrap {
 			define( 'PIWIK_ENABLE_DISPATCH', false );
 		}
 
+		// prevent session related errors during install making it more stable
+		if ( ! defined( 'PIWIK_ENABLE_SESSION_START' ) ) {
+			define( 'PIWIK_ENABLE_SESSION_START', false );
+		}
+			
 		if ( ! defined( 'PIWIK_DOCUMENT_ROOT' ) ) {
 			define( 'PIWIK_DOCUMENT_ROOT', dirname( __FILE__ ) == '/' ? '' : dirname( __FILE__ ) . '/../../app' );
 		}


### PR DESCRIPTION
Sessions shouldn't be needed in that case. Should make things more reliable.