### PR TITLE
Better handling of stripslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.2.3
+- Better handling of stripslashes
+
 0.2.2
 - Fix tag manager custom html tag adds slashes
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -12,7 +12,9 @@ if ( ! defined( 'PIWIK_ENABLE_ERROR_HANDLER' ) ) {
 	define( 'PIWIK_ENABLE_ERROR_HANDLER', false );
 }
 
-if ( ! defined( 'ABSPATH' ) ) {
+$was_loaded_directly = ! defined( 'ABSPATH' );
+
+if ( $was_loaded_directly ) {
 	// prevent from loading twice
 	require_once( dirname( __FILE__ ) . '/../../../../wp-load.php' );
 }
@@ -21,27 +23,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // if accessed directly
 }
 
-if (!empty($_GET)) {
-	$_GET     = stripslashes_deep( $_GET );
-}
-if (!empty($_POST)) {
-	$_POST    = stripslashes_deep( $_POST );
-}
-if (!empty($_COOKIE)) {
-	$_COOKIE  = stripslashes_deep( $_COOKIE );
-}
-if (!empty($_SERVER)) {
-	$_SERVER  = stripslashes_deep( $_SERVER );
-}
-if (!empty($_REQUEST)) {
-	$_REQUEST = stripslashes_deep( $_REQUEST );
-}
-
 if ( !is_plugin_active('matomo/matomo.php')
      && !defined( 'MATOMO_PHPUNIT_TEST' )
      && !MATOMO_PHPUNIT_TEST ) { // during tests the plugin may temporarily not be active
 	exit;
 }
+
+if ($was_loaded_directly) {
+	// do not strip slashes if we bootstrap matomo within a regular wordpress request
+	if (!empty($_GET)) {
+		$_GET     = stripslashes_deep( $_GET );
+	}
+	if (!empty($_POST)) {
+		$_POST    = stripslashes_deep( $_POST );
+	}
+	if (!empty($_COOKIE)) {
+		$_COOKIE  = stripslashes_deep( $_COOKIE );
+	}
+	if (!empty($_SERVER)) {
+		$_SERVER  = stripslashes_deep( $_SERVER );
+	}
+	if (!empty($_REQUEST)) {
+		$_REQUEST = stripslashes_deep( $_REQUEST );
+	}
+}
+
 
 if ( is_matomo_app_request() ) {
 	// pretend we are in the admin... potentially avoiding caching etc

--- a/classes/WpMatomo/Admin/ExclusionSettings.php
+++ b/classes/WpMatomo/Admin/ExclusionSettings.php
@@ -95,6 +95,7 @@ class ExclusionSettings implements AdminSettingsInterface {
 		if ( empty( $value ) ) {
 			return '';
 		}
+		$value = stripslashes($value); // Wordpress adds slashes
 		$value = str_replace( "\r", '', $value );
 
 		return implode( ',', array_filter( explode( "\n", $value ) ) );

--- a/matomo.php
+++ b/matomo.php
@@ -4,7 +4,7 @@
  * Description: Most powerful web analytics for WordPress giving you 100% data ownership and privacy protection
  * Author: Matomo
  * Author URI: https://matomo.org
- * Version: 0.2.2
+ * Version: 0.2.3
  * Domain Path: /languages
  * WC requires at least: 2.4.0
  * WC tested up to: 3.2.6


### PR DESCRIPTION
Only stripslashes when the request goes directly to the Matomo app. Also stripslashes for exclusion settings.