### PR TITLE
Add new feature: Matomo Safe Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.2.4
+- Add new feature: Safe mode
+
 0.2.3
 - Better handling of stripslashes
 

--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -48,6 +48,14 @@ class WpMatomo {
 
 		$this->settings = new Settings();
 
+		if ( self::is_safe_mode() ) {
+			if ( is_admin() ) {
+				new \WpMatomo\Admin\SafeModeMenu($this->settings);
+			}
+
+			return;
+		}
+
 		add_action( 'init', array( $this, 'init_plugin' ) );
 
 		$capabilities = new Capabilities( $this->settings );
@@ -139,6 +147,11 @@ class WpMatomo {
 		}
 
 		return is_super_admin();
+	}
+
+	public static function is_safe_mode()
+	{
+		return defined('MATOMO_SAFE_MODE') && MATOMO_SAFE_MODE;
 	}
 
 	public function add_settings_link( $links ) {

--- a/classes/WpMatomo/Admin/SafeModeMenu.php
+++ b/classes/WpMatomo/Admin/SafeModeMenu.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+namespace WpMatomo\Admin;
+
+use Piwik\Plugins\UsersManager\UserPreferences;
+use WpMatomo\Bootstrap;
+use WpMatomo\Capabilities;
+use WpMatomo\Marketplace\Api as MarketplaceApi;
+use WpMatomo\Report\Dates;
+use WpMatomo\Settings;
+use WpMatomo\Site;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // if accessed directly
+}
+
+class SafeModeMenu {
+	/**
+	 * @var Settings
+	 */
+	private $settings;
+
+	private $parentSlug = 'matomo';
+
+	/**
+	 * @param Settings $settings
+	 */
+	public function __construct( $settings ) {
+		$this->settings = $settings;
+		add_action( 'admin_menu', array( $this, 'add_menu' ) );
+		add_action( 'network_admin_menu', array( $this, 'add_menu' ) );
+	}
+
+	public function add_menu() {
+		if (!\WpMatomo::is_admin_user()) {
+			return;
+		}
+
+		$system_report = new SystemReport( $this->settings );
+
+		add_menu_page( 'Matomo Analytics', 'Matomo Analytics', Menu::CAP_NOT_EXISTS, 'matomo', null, 'dashicons-analytics' );
+
+		add_submenu_page( $this->parentSlug, __( 'System Report', 'matomo' ), __( 'System Report', 'matomo' ), 'administrator', Menu::SLUG_SYSTEM_REPORT, array(
+			$system_report,
+			'show'
+		) );
+
+	}
+
+}

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -269,16 +269,18 @@ class SystemReport {
 
 		}
 
-		$rows[] = array(
-			'section' => __( 'Mandatory checks', 'matomo' ),
-		);
+		if ( ! \WpMatomo::is_safe_mode() ) {
+			$rows[] = array(
+				'section' => __( 'Mandatory checks', 'matomo' ),
+			);
 
-		$rows = $this->add_diagnostic_results( $rows, $report->getMandatoryDiagnosticResults() );
+			$rows = $this->add_diagnostic_results( $rows, $report->getMandatoryDiagnosticResults() );
 
-		$rows[] = array(
-			'section' => __( 'Optional checks', 'matomo' ),
-		);
-		$rows   = $this->add_diagnostic_results( $rows, $report->getOptionalDiagnosticResults() );
+			$rows[] = array(
+				'section' => __( 'Optional checks', 'matomo' ),
+			);
+			$rows   = $this->add_diagnostic_results( $rows, $report->getOptionalDiagnosticResults() );
+		}
 
 		$cliMulti = new CliMulti();
 

--- a/matomo.php
+++ b/matomo.php
@@ -4,7 +4,7 @@
  * Description: Most powerful web analytics for WordPress giving you 100% data ownership and privacy protection
  * Author: Matomo
  * Author URI: https://matomo.org
- * Version: 0.2.3
+ * Version: 0.2.4
  * Domain Path: /languages
  * WC requires at least: 2.4.0
  * WC tested up to: 3.2.6


### PR DESCRIPTION
If Matomo fails to install, they can't troubleshoot or send us the system report. They can now add a constant `MATOMO_SAFE_MODE` to their wp-config.php by adding following line:

```php
define( 'MATOMO_SAFE_MODE', true );
```

And then the system report page will appear. This allows us to troubleshoot issues better.