### PR TITLE
Require at least PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,12 @@ matrix:
       env: WP_VERSION=latest
     - php: 7.0
       env: WP_VERSION=latest
-    - php: 5.6
+    - php: 7.0
       env: WP_VERSION=5.0
-    - php: 5.6
-      env: WP_VERSION=latest
-    - php: 5.6
+    - php: 7.0
       env: WP_VERSION=trunk
-    - php: 5.6
+    - php: 7.0
       env: WP_TRAVISCI=phpcs
-    - php: 5.5
-      env: WP_VERSION=5.0
-      dist: precise
 
 before_install:
   - if [[ "$WP_TRAVISCI" == "phpcs" ]]; then export PHPCS_DIR=/tmp/phpcs; fi

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: matomoteam
 Tags: matomo,piwik,analytics,statistics,tracking,ecommerce
 Requires at least: 4.8
 Tested up to: 5.2
-Requires PHP: 5.5.9
+Requires PHP: 7.0.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
We need to require PHP 7. The tests are failing for PHP 5.X and the reason is that the archiver always returns 0 results in the DB queries:

The problem is eg 

```sql
SELECT
				count(distinct log_visit.idvisitor) AS `1`, 
			count(*) AS `2`, 
			sum(log_visit.visit_total_actions) AS `3`, 
			max(log_visit.visit_total_actions) AS `4`, 
			sum(log_visit.visit_total_time) AS `5`, 
			sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) AS `6`, 
			sum(case log_visit.visit_goal_converted when 1 then 1 else 0 end) AS `7`, 
			count(distinct log_visit.user_id) AS `9`
			FROM
				wptests_matomo_log_visit AS log_visit
			WHERE
				log_visit.visit_last_action_time >= '2019-11-13 00:00:00'
				AND log_visit.visit_last_action_time <= '2019-11-13 23:59:59'
				AND log_visit.idsite IN ('1')
```

Would not return any result even if there is a matching row.

Changing the numeric columns to a string will return a result for these columns:

```sql
SELECT
				count(distinct log_visit.idvisitor) AS `sdsdsd1`, 
			count(*) AS `2`, 
			sum(log_visit.visit_total_actions) AS `3`, 
			max(log_visit.visit_total_actions) AS `4`, 
			sum(log_visit.visit_total_time) AS `5`, 
			sum(case log_visit.visit_total_actions when 1 then 1 when 0 then 1 else 0 end) AS `sdsdsd16`, 
			sum(case log_visit.visit_goal_converted when 1 then 1 else 0 end) AS `sdsdsd17`, 
			count(distinct log_visit.user_id) AS `9`
			FROM
				wptests_matomo_log_visit AS log_visit
			WHERE
				log_visit.visit_last_action_time >= '2019-11-13 00:00:00'
				AND log_visit.visit_last_action_time <= '2019-11-13 23:59:59'
				AND log_visit.idsite IN ('1')
```

In this case it would return 3 columns... if I replace all numeric columns it will return all results. We're using this a lot so we can't support PHP 5.X.

At least it will make it easier when we upgrade to Matomo 4 where we will require some PHP 7 version anyway.