### PR TITLE
When tracking mode is disabled, show the tracking code below the form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+0.2.6
+- Improvements for multi site tracking in network mode
+- Show default tracking code when tracking is disabled
+
 0.2.5
 - Require at least PHP 7.0 as WP with PHP 5.X is not compatible with Matomo
 - Various improvements

--- a/assets/css/admin-style.css
+++ b/assets/css/admin-style.css
@@ -52,3 +52,19 @@ ol.matomo-list {
 .matomo-systemreport .widefat .section {
     font-weight: bold;
 }
+
+.postbox .table .widefat.matomo-table {
+    border: 0;
+}
+
+#matomo_default_tracking_code {
+    margin-top: 100px;
+}
+
+#matomo_default_tracking_code textarea {
+    width: 100%;
+    height: 140px;
+}
+#matomo_default_tracking_code textarea.no_script {
+    height: 50px;
+}

--- a/classes/WpMatomo/Admin/TrackingSettings.php
+++ b/classes/WpMatomo/Admin/TrackingSettings.php
@@ -108,17 +108,21 @@ class TrackingSettings implements AdminSettingsInterface {
 		$values['tagmanger_container_ids'] = array();
 
 		if ( ! empty( $_POST[ self::FORM_NAME ]['track_mode'] ) ) {
-			if ( self::TRACK_MODE_TAGMANAGER === $_POST[ self::FORM_NAME ]['track_mode'] ) {
+			$track_mode         = $_POST[ self::FORM_NAME ]['track_mode'];
+			$previus_track_mode = $this->settings->get_global_option( 'track_mode' );
+
+			if ( self::TRACK_MODE_TAGMANAGER === $track_mode ) {
 				// no noscript mode in this case
-				$_POST['track_noscript'] = '';
-				$_POST['noscript_code']  = '';
+				$_POST[ self::FORM_NAME ]['track_noscript'] = '';
+				$_POST[ self::FORM_NAME ]['noscript_code']  = '';
 			} else {
 				unset( $_POST['tagmanger_container_ids'] );
 			}
 
-			if ( self::TRACK_MODE_MANUALLY === $_POST[ self::FORM_NAME ]['track_mode']
-				 || ( self::TRACK_MODE_DISABLED === $_POST[ self::FORM_NAME ]['track_mode'] &&
-					  self::TRACK_MODE_MANUALLY === $this->settings->get_global_option( 'track_mode' ) ) ) {
+			if ( self::TRACK_MODE_MANUALLY === $track_mode
+				 || ( self::TRACK_MODE_DISABLED === $track_mode &&
+					  in_array( $previus_track_mode, array( self::TRACK_MODE_DISABLED, self::TRACK_MODE_MANUALLY ) ) ) ) {
+				// We want to keep the tracking code when user switches between disabled and manually or disabled to disabled.
 				if ( ! empty( $_POST[ self::FORM_NAME ]['tracking_code'] ) ) {
 					$_POST[ self::FORM_NAME ]['tracking_code'] = stripslashes( $_POST[ self::FORM_NAME ]['tracking_code'] );
 				} else {
@@ -129,6 +133,9 @@ class TrackingSettings implements AdminSettingsInterface {
 				} else {
 					$_POST[ self::FORM_NAME ]['noscript_code'] = '';
 				}
+			} else {
+				$_POST[ self::FORM_NAME ]['noscript_code'] = '';
+				$_POST[ self::FORM_NAME ]['tracking_code'] = '';
 			}
 		}
 

--- a/classes/WpMatomo/Admin/TrackingSettings.php
+++ b/classes/WpMatomo/Admin/TrackingSettings.php
@@ -11,6 +11,8 @@ namespace WpMatomo\Admin;
 
 use WpMatomo\Capabilities;
 use WpMatomo\Settings;
+use WpMatomo\Site;
+use WpMatomo\TrackingCode\TrackingCodeGenerator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // if accessed directly
@@ -156,6 +158,12 @@ class TrackingSettings implements AdminSettingsInterface {
 		if ( ! empty( $containers ) ) {
 			$track_modes[ self::TRACK_MODE_TAGMANAGER ] = esc_html__( 'Tag Manager', 'matomo' );
 		}
+
+		$site   = new Site();
+		$idsite = $site->get_current_matomo_site_id();
+
+		$tracking_code_generator = new TrackingCodeGenerator( $this->settings );
+		$matomo_default_tracking_code = $tracking_code_generator->prepare_tracking_code( $idsite );
 
 		include dirname( __FILE__ ) . '/views/tracking.php';
 	}

--- a/classes/WpMatomo/Admin/TrackingSettings.php
+++ b/classes/WpMatomo/Admin/TrackingSettings.php
@@ -162,7 +162,7 @@ class TrackingSettings implements AdminSettingsInterface {
 		$site   = new Site();
 		$idsite = $site->get_current_matomo_site_id();
 
-		$tracking_code_generator = new TrackingCodeGenerator( $this->settings );
+		$tracking_code_generator      = new TrackingCodeGenerator( $this->settings );
 		$matomo_default_tracking_code = $tracking_code_generator->prepare_tracking_code( $idsite );
 
 		include dirname( __FILE__ ) . '/views/tracking.php';

--- a/classes/WpMatomo/Admin/views/systemreport.php
+++ b/classes/WpMatomo/Admin/views/systemreport.php
@@ -66,7 +66,8 @@ if ( ! function_exists( 'matomo_anonymize_value' ) ) {
 
 		</p>
 		<textarea style="width:100%;height: 200px;" readonly
-				  id="matomo_system_report_info"><?php
+				  id="matomo_system_report_info">
+				  <?php
 					foreach ( $matomo_tables as $matomo_table ) {
 						echo '# ' . esc_html( $matomo_table['title'] ) . "\n";
 						foreach ( $matomo_table['rows'] as $index => $matomo_row ) {

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -51,7 +51,7 @@ if ( $was_updated ) {
 
 		$matomo_manually_network = '';
 		if ( $settings->is_network_enabled() ) {
-		    $matomo_manually_network = ' ' . sprintf( esc_html__( 'You can use these variables: %1$s. %2$sLearn more%3$s', 'matomo'), '{MATOMO_IDSITE}, {MATOMO_API_ENDPOINT}, {MATOMO_JS_ENDPOINT}', '<a href="" target="_blank" rel="noreferrer noopener">', '</a>');
+		    $matomo_manually_network = ' ' . sprintf( esc_html__( 'You can use these variables: %1$s. %2$sLearn more%3$s', 'matomo'), '{MATOMO_IDSITE}, {MATOMO_API_ENDPOINT}, {MATOMO_JS_ENDPOINT}', '<a href="https://matomo.org/faq/wordpress/how-can-i-configure-the-tracking-code-manually-when-i-have-wordpress-network-enabled-in-multisite-mode/" target="_blank" rel="noreferrer noopener">', '</a>');
         }
 
 		if ( ! empty( $containers ) ) {

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -49,6 +49,11 @@ if ( $was_updated ) {
 		$matomo_description = sprintf( '%s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s<br /><strong>%s:</strong> %s', esc_html__( 'You can choose between four tracking code modes:', 'matomo' ), esc_html__( 'Disabled', 'matomo' ), esc_html__( 'matomo will not add the tracking code. Use this, if you want to add the tracking code to your template files or you use another plugin to add the tracking code.', 'matomo' ), esc_html__( 'Default tracking', 'matomo' ), esc_html__( 'matomo will use Matomo\'s standard tracking code.', 'matomo' ), esc_html__( 'Enter manually', 'matomo' ), esc_html__( 'Enter your own tracking code manually. You can choose one of the prior options, pre-configure your tracking code and switch to manually editing at last.', 'matomo' ) . ( $settings->is_network_enabled() ? ' ' . esc_html__( 'Use the placeholder {ID} to add the Matomo site ID.', 'matomo' ) : '' ), esc_html__( 'Tag Manager', 'matomo' ), esc_html__( 'If you have created containers in the Tag Manager, you can select one of them and it will embed the code for the container automatically.', 'matomo' ) );
 		$matomo_form->show_select( 'track_mode', esc_html__( 'Add tracking code', 'matomo' ), $track_modes, $matomo_description, 'jQuery(\'tr.matomo-track-option\').addClass(\'hidden\'); jQuery(\'tr.matomo-track-option-\' + jQuery(\'#track_mode\').val()).removeClass(\'hidden\'); jQuery(\'#tracking_code, #noscript_code\').prop(\'readonly\', jQuery(\'#track_mode\').val() != \'manually\');' );
 
+		$matomo_manually_network = '';
+		if ( $settings->is_network_enabled() ) {
+		    $matomo_manually_network = ' ' . sprintf( esc_html__( 'You can use these variables: %1$s. %2$sLearn more%3$s', 'matomo'), '{MATOMO_IDSITE}, {MATOMO_API_ENDPOINT}, {MATOMO_JS_ENDPOINT}', '<a href="" target="_blank" rel="noreferrer noopener">', '</a>');
+        }
+
 		if ( ! empty( $containers ) ) {
 			echo '<tr class="matomo-track-option matomo-track-option-tagmanager ' . ( $matomo_is_not_tracking ? ' hidden' : '' ) . '">';
 			echo '<th scope="row"><label for="tagmanger_container_ids">' . esc_html__( 'Add these Tag Manager containers', 'matomo' ) . '</label>:</th><td>';
@@ -60,7 +65,7 @@ if ( $was_updated ) {
 			echo '</td></tr>';
 		}
 
-		$matomo_form->show_textarea( 'tracking_code', esc_html__( 'Tracking code', 'matomo' ), 15, 'This is a preview of your current tracking code. If you choose to enter your tracking code manually, you can change it here. Have a look at the system report to get a list of all available JS tracker and tracking API endpoints.', $matomo_is_not_tracking, 'matomo-track-option matomo-track-option-default matomo-track-option-tagmanager  matomo-track-option-manually', true, '', ( $settings->get_global_option( 'track_mode' ) !== 'manually' ), false );
+		$matomo_form->show_textarea( 'tracking_code', esc_html__( 'Tracking code', 'matomo' ), 15, 'This is a preview of your current tracking code. If you choose to enter your tracking code manually, you can change it here. Have a look at the system report to get a list of all available JS tracker and tracking API endpoints.' . $matomo_manually_network, $matomo_is_not_tracking, 'matomo-track-option matomo-track-option-default matomo-track-option-tagmanager  matomo-track-option-manually', true, '', ( $settings->get_global_option( 'track_mode' ) !== 'manually' ), false );
 
 		$matomo_form->show_select(
 			'track_codeposition',

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -207,14 +207,14 @@ if ( $was_updated ) {
 	</table>
 </form>
 
-<?php if ($matomo_is_not_tracking) { ?>
+<?php if ( $matomo_is_not_tracking && ! $settings->is_network_enabled() ) { // Can't show it for multisite as idsite and url is always different. ?>
 <div id="matomo_default_tracking_code">
-    <h2><?php esc_html_e('JavaScript tracking code', 'matomo')?></h2>
-    <p>
-        <?php echo sprintf(esc_html__('Wanting to embed the tracking code manually into your site or using a different plugin? No problem! Simply copy/paste below tracking code. Want to adjust it? %1$sCheck out our developer documentation.%2$s', 'matomo'), '<a href="https://developer.matomo.org/guides/tracking-javascript-guide" target="_blank" rel="noreferrer noopener">', '</a>') ?>
-    </p>
-    <?php echo '<pre><textarea>' . esc_html(implode(";\n", explode(';', $matomo_default_tracking_code['script']))) . '</textarea></pre>'; ?>
-    <h3><?php esc_html_e('NoScript tracking code', 'matomo')?></h3>
-       <?php echo '<pre><textarea class="no_script">' . esc_html($matomo_default_tracking_code['noscript']) . '</textarea></pre>';?>
+	<h2><?php esc_html_e( 'JavaScript tracking code', 'matomo' ); ?></h2>
+	<p>
+		<?php echo sprintf( esc_html__( 'Wanting to embed the tracking code manually into your site or using a different plugin? No problem! Simply copy/paste below tracking code. Want to adjust it? %1$sCheck out our developer documentation.%2$s', 'matomo' ), '<a href="https://developer.matomo.org/guides/tracking-javascript-guide" target="_blank" rel="noreferrer noopener">', '</a>' ); ?>
+	</p>
+	<?php echo '<pre><textarea>' . esc_html( implode( ";\n", explode( ';', $matomo_default_tracking_code['script'] ) ) ) . '</textarea></pre>'; ?>
+	<h3><?php esc_html_e( 'NoScript tracking code', 'matomo' ); ?></h3>
+	   <?php echo '<pre><textarea class="no_script">' . esc_html( $matomo_default_tracking_code['noscript'] ) . '</textarea></pre>'; ?>
 </div>
 <?php } ?>

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -51,8 +51,8 @@ if ( $was_updated ) {
 
 		$matomo_manually_network = '';
 		if ( $settings->is_network_enabled() ) {
-		    $matomo_manually_network = ' ' . sprintf( esc_html__( 'You can use these variables: %1$s. %2$sLearn more%3$s', 'matomo'), '{MATOMO_IDSITE}, {MATOMO_API_ENDPOINT}, {MATOMO_JS_ENDPOINT}', '<a href="https://matomo.org/faq/wordpress/how-can-i-configure-the-tracking-code-manually-when-i-have-wordpress-network-enabled-in-multisite-mode/" target="_blank" rel="noreferrer noopener">', '</a>');
-        }
+			$matomo_manually_network = ' ' . sprintf( esc_html__( 'You can use these variables: %1$s. %2$sLearn more%3$s', 'matomo' ), '{MATOMO_IDSITE}, {MATOMO_API_ENDPOINT}, {MATOMO_JS_ENDPOINT}', '<a href="https://matomo.org/faq/wordpress/how-can-i-configure-the-tracking-code-manually-when-i-have-wordpress-network-enabled-in-multisite-mode/" target="_blank" rel="noreferrer noopener">', '</a>' );
+		}
 
 		if ( ! empty( $containers ) ) {
 			echo '<tr class="matomo-track-option matomo-track-option-tagmanager ' . ( $matomo_is_not_tracking ? ' hidden' : '' ) . '">';

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 /** @var \WpMatomo\Settings $settings */
 /** @var bool $was_updated */
+/** @var array $matomo_default_tracking_code */
 /** @var array $containers */
 /** @var array $track_modes */
 
@@ -205,3 +206,15 @@ if ( $was_updated ) {
 		</tbody>
 	</table>
 </form>
+
+<?php if ($matomo_is_not_tracking) { ?>
+<div id="matomo_default_tracking_code">
+    <h2><?php esc_html_e('JavaScript tracking code', 'matomo')?></h2>
+    <p>
+        <?php echo sprintf(esc_html__('Wanting to embed the tracking code manually into your site or using a different plugin? No problem! Simply copy/paste below tracking code. Want to adjust it? %1$sCheck out our developer documentation.%2$s', 'matomo'), '<a href="https://developer.matomo.org/guides/tracking-javascript-guide" target="_blank" rel="noreferrer noopener">', '</a>') ?>
+    </p>
+    <?php echo '<pre><textarea>' . esc_html(implode(";\n", explode(';', $matomo_default_tracking_code['script']))) . '</textarea></pre>'; ?>
+    <h3><?php esc_html_e('NoScript tracking code', 'matomo')?></h3>
+       <?php echo '<pre><textarea class="no_script">' . esc_html($matomo_default_tracking_code['noscript']) . '</textarea></pre>';?>
+</div>
+<?php } ?>

--- a/classes/WpMatomo/TrackingCode.php
+++ b/classes/WpMatomo/TrackingCode.php
@@ -102,7 +102,7 @@ class TrackingCode {
 			$site    = new Site();
 			$site_id = $site->get_current_matomo_site_id();
 			if ( $site_id ) {
-				$tracking_code = str_replace( '{MATOMO_TRACKER_ENDPOINT}', $this->generator->get_tracker_endpoint(), $tracking_code );
+				$tracking_code = str_replace( '{MATOMO_API_ENDPOINT}', $this->generator->get_tracker_endpoint(), $tracking_code );
 				$tracking_code = str_replace( '{MATOMO_JS_ENDPOINT}', $this->generator->get_js_endpoint(), $tracking_code );
 				echo str_replace( '{MATOMO_IDSITE}', $site_id, $tracking_code );
 			} else {

--- a/classes/WpMatomo/TrackingCode.php
+++ b/classes/WpMatomo/TrackingCode.php
@@ -102,8 +102,8 @@ class TrackingCode {
 			$site    = new Site();
 			$site_id = $site->get_current_matomo_site_id();
 			if ( $site_id ) {
-				$tracking_code = str_replace( '{MATOMO_API_ENDPOINT}', $this->generator->get_tracker_endpoint(), $tracking_code );
-				$tracking_code = str_replace( '{MATOMO_JS_ENDPOINT}', $this->generator->get_js_endpoint(), $tracking_code );
+				$tracking_code = str_replace( '{MATOMO_API_ENDPOINT}', wp_json_encode($this->generator->get_tracker_endpoint()), $tracking_code );
+				$tracking_code = str_replace( '{MATOMO_JS_ENDPOINT}', wp_json_encode($this->generator->get_js_endpoint()), $tracking_code );
 				echo str_replace( '{MATOMO_IDSITE}', $site_id, $tracking_code );
 			} else {
 				echo '<!-- Site not yet synced with Matomo, tracking code will be added later -->';

--- a/classes/WpMatomo/TrackingCode.php
+++ b/classes/WpMatomo/TrackingCode.php
@@ -102,8 +102,8 @@ class TrackingCode {
 			$site    = new Site();
 			$site_id = $site->get_current_matomo_site_id();
 			if ( $site_id ) {
-				$tracking_code = str_replace( '{MATOMO_API_ENDPOINT}', wp_json_encode($this->generator->get_tracker_endpoint()), $tracking_code );
-				$tracking_code = str_replace( '{MATOMO_JS_ENDPOINT}', wp_json_encode($this->generator->get_js_endpoint()), $tracking_code );
+				$tracking_code = str_replace( '{MATOMO_API_ENDPOINT}', wp_json_encode( $this->generator->get_tracker_endpoint() ), $tracking_code );
+				$tracking_code = str_replace( '{MATOMO_JS_ENDPOINT}', wp_json_encode( $this->generator->get_js_endpoint() ), $tracking_code );
 				echo str_replace( '{MATOMO_IDSITE}', $site_id, $tracking_code );
 			} else {
 				echo '<!-- Site not yet synced with Matomo, tracking code will be added later -->';

--- a/classes/WpMatomo/TrackingCode.php
+++ b/classes/WpMatomo/TrackingCode.php
@@ -102,7 +102,9 @@ class TrackingCode {
 			$site    = new Site();
 			$site_id = $site->get_current_matomo_site_id();
 			if ( $site_id ) {
-				echo str_replace( '{ID}', $site_id, $tracking_code );
+				$tracking_code = str_replace( '{MATOMO_TRACKER_ENDPOINT}', $this->generator->get_tracker_endpoint(), $tracking_code );
+				$tracking_code = str_replace( '{MATOMO_JS_ENDPOINT}', $this->generator->get_js_endpoint(), $tracking_code );
+				echo str_replace( '{MATOMO_IDSITE}', $site_id, $tracking_code );
 			} else {
 				echo '<!-- Site not yet synced with Matomo, tracking code will be added later -->';
 			}
@@ -171,12 +173,7 @@ class TrackingCode {
 			$posturl = get_permalink( $post->ID );
 			$urlref  = get_bloginfo( 'rss2_url' );
 
-			$paths = new Paths();
-			if ( $this->settings->get_global_option( 'track_api_endpoint' ) === 'restapi' ) {
-				$tracker_endpoint = $paths->get_tracker_api_rest_api_endpoint();
-			} else {
-				$tracker_endpoint = $paths->get_tracker_api_url_in_matomo_dir();
-			}
+			$tracker_endpoint = $this->generator->get_tracker_endpoint();
 
 			$tracking_image = $tracker_endpoint . '?idsite=' . $site_id . '&amp;rec=1&amp;url=' . rawurlencode( $posturl ) . '&amp;action_name=' . rawurlencode( $title ) . '&amp;urlref=' . rawurlencode( $urlref );
 			$content       .= '<img src="' . $tracking_image . '" style="border:0;width:0;height:0" width="0" height="0" alt="" />';

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -170,6 +170,27 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="' . $container_ur
 		);
 	}
 
+	public function get_tracker_endpoint() {
+		$paths = new Paths();
+		if ( $this->settings->get_global_option( 'track_api_endpoint' ) === 'restapi' ) {
+			$tracker_endpoint = $paths->get_tracker_api_rest_api_endpoint();
+		} else {
+			$tracker_endpoint = $paths->get_tracker_api_url_in_matomo_dir();
+		}
+
+		return $tracker_endpoint;
+	}
+
+	public function get_js_endpoint() {
+		 $paths = new Paths();
+		if ( $this->settings->get_global_option( 'track_js_endpoint' ) === 'restapi' ) {
+			$js_endpoint = $paths->get_js_tracker_rest_api_endpoint();
+		} else {
+			$js_endpoint = $paths->get_js_tracker_url_in_matomo_dir();
+		}
+		return $js_endpoint;
+	}
+
 	/**
 	 * @param $idsite
 	 *
@@ -181,17 +202,8 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="' . $container_ur
 		$settings = $this->settings;
 		$paths    = new Paths();
 
-		if ( $this->settings->get_global_option( 'track_api_endpoint' ) === 'restapi' ) {
-			$tracker_endpoint = $paths->get_tracker_api_rest_api_endpoint();
-		} else {
-			$tracker_endpoint = $paths->get_tracker_api_url_in_matomo_dir();
-		}
-
-		if ( $this->settings->get_global_option( 'track_js_endpoint' ) === 'restapi' ) {
-			$js_endpoint = $paths->get_js_tracker_rest_api_endpoint();
-		} else {
-			$js_endpoint = $paths->get_js_tracker_url_in_matomo_dir();
-		}
+		$tracker_endpoint = $this->get_tracker_endpoint();
+		$js_endpoint      = $this->get_js_endpoint();
 
 		if ( $settings->get_global_option( 'force_protocol' ) == 'https' ) {
 			$js_endpoint      = preg_replace( '(^http://)', 'https://', $js_endpoint );

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -172,10 +172,17 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="' . $container_ur
 
 	public function get_tracker_endpoint() {
 		$paths = new Paths();
+
 		if ( $this->settings->get_global_option( 'track_api_endpoint' ) === 'restapi' ) {
 			$tracker_endpoint = $paths->get_tracker_api_rest_api_endpoint();
 		} else {
 			$tracker_endpoint = $paths->get_tracker_api_url_in_matomo_dir();
+		}
+
+		if ( $this->settings->get_global_option( 'force_protocol' ) === 'https' ) {
+			$tracker_endpoint = preg_replace( '(^http://)', 'https://', $tracker_endpoint );
+		} else {
+			$tracker_endpoint = preg_replace( '(^https?://)', '//', $tracker_endpoint );
 		}
 
 		return $tracker_endpoint;
@@ -188,6 +195,13 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="' . $container_ur
 		} else {
 			$js_endpoint = $paths->get_js_tracker_url_in_matomo_dir();
 		}
+
+		if ( $this->settings->get_global_option( 'force_protocol' ) === 'https' ) {
+			$js_endpoint = preg_replace( '(^http://)', 'https://', $js_endpoint );
+		} else {
+			$js_endpoint = preg_replace( '(^https?://)', '//', $js_endpoint );
+		}
+
 		return $js_endpoint;
 	}
 
@@ -199,38 +213,27 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="' . $container_ur
 	public function prepare_tracking_code( $idsite ) {
 		$this->logger->log( 'Apply tracking code changes:' );
 
-		$settings = $this->settings;
-		$paths    = new Paths();
-
 		$tracker_endpoint = $this->get_tracker_endpoint();
 		$js_endpoint      = $this->get_js_endpoint();
 
-		if ( $settings->get_global_option( 'force_protocol' ) == 'https' ) {
-			$js_endpoint      = preg_replace( '(^http://)', 'https://', $js_endpoint );
-			$tracker_endpoint = preg_replace( '(^http://)', 'https://', $tracker_endpoint );
-		} else {
-			$js_endpoint      = preg_replace( '(^https?://)', '//', $js_endpoint );
-			$tracker_endpoint = preg_replace( '(^https?://)', '//', $tracker_endpoint );
-		}
-
 		$options = array();
 
-		if ( $settings->get_global_option( 'set_download_extensions' ) ) {
-			$options[] = "_paq.push(['setDownloadExtensions', " . wp_json_encode( $settings->get_global_option( 'set_download_extensions' ) ) . ']);';
+		if ( $this->settings->get_global_option( 'set_download_extensions' ) ) {
+			$options[] = "_paq.push(['setDownloadExtensions', " . wp_json_encode( $this->settings->get_global_option( 'set_download_extensions' ) ) . ']);';
 		}
-		if ( $settings->get_global_option( 'add_download_extensions' ) ) {
-			$options[] = "_paq.push(['addDownloadExtensions', " . wp_json_encode( $settings->get_global_option( 'add_download_extensions' ) ) . ']);';
+		if ( $this->settings->get_global_option( 'add_download_extensions' ) ) {
+			$options[] = "_paq.push(['addDownloadExtensions', " . wp_json_encode( $this->settings->get_global_option( 'add_download_extensions' ) ) . ']);';
 		}
-		if ( $settings->get_global_option( 'set_download_classes' ) ) {
-			$options[] = "_paq.push(['setDownloadClasses', " . wp_json_encode( $settings->get_global_option( 'set_download_classes' ) ) . ']);';
+		if ( $this->settings->get_global_option( 'set_download_classes' ) ) {
+			$options[] = "_paq.push(['setDownloadClasses', " . wp_json_encode( $this->settings->get_global_option( 'set_download_classes' ) ) . ']);';
 		}
-		if ( $settings->get_global_option( 'set_link_classes' ) ) {
-			$options[] = "_paq.push(['setLinkClasses', " . wp_json_encode( $settings->get_global_option( 'set_link_classes' ) ) . ']);';
+		if ( $this->settings->get_global_option( 'set_link_classes' ) ) {
+			$options[] = "_paq.push(['setLinkClasses', " . wp_json_encode( $this->settings->get_global_option( 'set_link_classes' ) ) . ']);';
 		}
-		if ( $settings->get_global_option( 'disable_cookies' ) ) {
+		if ( $this->settings->get_global_option( 'disable_cookies' ) ) {
 			$options[] = "_paq.push(['disableCookies']);";
 		}
-		if ( $settings->get_global_option( 'track_crossdomain_linking' ) ) {
+		if ( $this->settings->get_global_option( 'track_crossdomain_linking' ) ) {
 			$options[] = "_paq.push(['enableCrossDomainLinking']);";
 		}
 
@@ -239,7 +242,7 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="' . $container_ur
 			$options[] = '_paq.push(["setCookieDomain", ' . wp_json_encode( $cookie_domain ) . ']);';
 		}
 
-		$track_across_alias = $settings->get_global_option( 'track_across_alias' );
+		$track_across_alias = $this->settings->get_global_option( 'track_across_alias' );
 
 		if ( $track_across_alias ) {
 			// todo detect more hosts such as when using WPML etc
@@ -255,22 +258,22 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="' . $container_ur
 				$options[] = '_paq.push(["setDomains", ' . wp_json_encode( $hosts ) . ']);';
 			}
 		}
-		if ( $settings->get_global_option( 'limit_cookies' ) ) {
-			$options[] = "_paq.push(['setVisitorCookieTimeout', " . wp_json_encode( $settings->get_global_option( 'limit_cookies_visitor' ) ) . ']);';
-			$options[] = "_paq.push(['setSessionCookieTimeout', " . wp_json_encode( $settings->get_global_option( 'limit_cookies_session' ) ) . ']);';
-			$options[] = "_paq.push(['setReferralCookieTimeout', " . wp_json_encode( $settings->get_global_option( 'limit_cookies_referral' ) ) . ']);';
+		if ( $this->settings->get_global_option( 'limit_cookies' ) ) {
+			$options[] = "_paq.push(['setVisitorCookieTimeout', " . wp_json_encode( $this->settings->get_global_option( 'limit_cookies_visitor' ) ) . ']);';
+			$options[] = "_paq.push(['setSessionCookieTimeout', " . wp_json_encode( $this->settings->get_global_option( 'limit_cookies_session' ) ) . ']);';
+			$options[] = "_paq.push(['setReferralCookieTimeout', " . wp_json_encode( $this->settings->get_global_option( 'limit_cookies_referral' ) ) . ']);';
 		}
-		if ( $settings->get_global_option( 'track_content' ) == 'all' ) {
+		if ( $this->settings->get_global_option( 'track_content' ) == 'all' ) {
 			$options[] = "_paq.push(['trackAllContentImpressions']);";
-		} elseif ( $settings->get_global_option( 'track_content' ) == 'visible' ) {
+		} elseif ( $this->settings->get_global_option( 'track_content' ) == 'visible' ) {
 			$options[] = "_paq.push(['trackVisibleContentImpressions']);";
 		}
-		if ( (int) $settings->get_global_option( 'track_heartbeat' ) > 0 ) {
-			$options[] = "_paq.push(['enableHeartBeatTimer', " . intval( $settings->get_global_option( 'track_heartbeat' ) ) . ']);';
+		if ( (int) $this->settings->get_global_option( 'track_heartbeat' ) > 0 ) {
+			$options[] = "_paq.push(['enableHeartBeatTimer', " . intval( $this->settings->get_global_option( 'track_heartbeat' ) ) . ']);';
 		}
 
 		$data_cf_async = '';
-		if ( $settings->get_global_option( 'track_datacfasync' ) ) {
+		if ( $this->settings->get_global_option( 'track_datacfasync' ) ) {
 			$data_cf_async = 'data-cfasync="false"';
 		}
 

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -75,7 +75,6 @@ class TrackingCodeGenerator {
 			if ( ! $this->settings->get_global_option( 'track_noscript' ) ) {
 				$result['noscript'] = '';
 			}
-
 		} elseif ( TrackingSettings::TRACK_MODE_TAGMANAGER === $track_mode && matomo_has_tag_manager() ) {
 			$result = $this->prepare_tagmanger_code( $this->settings, $this->logger );
 		} else {

--- a/matomo.php
+++ b/matomo.php
@@ -4,7 +4,7 @@
  * Description: Most powerful web analytics for WordPress giving you 100% data ownership and privacy protection
  * Author: Matomo
  * Author URI: https://matomo.org
- * Version: 0.2.5
+ * Version: 0.2.6
  * Domain Path: /languages
  * WC requires at least: 2.4.0
  * WC tested up to: 3.2.6

--- a/tests/phpunit/wpmatomo/test-trackingcode.php
+++ b/tests/phpunit/wpmatomo/test-trackingcode.php
@@ -158,7 +158,7 @@ class TrackingCodeTest extends MatomoUnit_TestCase {
 		$this->set_is_feed();
 
 		$url = apply_filters( 'the_excerpt_rss', '<p>foobarbaz</p>' );
-		$this->assertStringStartsWith( '<p>foobarbaz</p><img src="http://example.org/index.php?rest_route=/matomo/v1/hit/?idsite=23&amp;rec=1&amp;url=http%3A%2F%2Fexample.org%2F%3Fp%3D7&amp;action_name=hello-world&amp;urlref=http%3A%2F%2Fexample.org%2F', $url );
+		$this->assertStringStartsWith( '<p>foobarbaz</p><img src="//example.org/index.php?rest_route=/matomo/v1/hit/?idsite=23&amp;rec=1&amp;url=http%3A%2F%2Fexample.org%2F%3Fp%3D7&amp;action_name=hello-world&amp;urlref=http%3A%2F%2Fexample.org%2F', $url );
 		$this->assertStringEndsWith( '" style="border:0;width:0;height:0" width="0" height="0" alt="" />', $url );
 	}
 

--- a/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
+++ b/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
@@ -89,7 +89,7 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="\/\/example.org\/
 	public function test_get_tracker_endpoint() {
 		$this->make_tracking_code();
 		$this->assertSame(
-			"//example.org/wp-content/plugins/matomo/app/matomo.php",
+			'//example.org/wp-content/plugins/matomo/app/matomo.php',
 			$this->tracking_code->get_tracker_endpoint()
 		);
 
@@ -100,18 +100,18 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="\/\/example.org\/
 		);
 
 		$this->assertSame(
-			"//example.org/index.php?rest_route=/matomo/v1/hit/",
+			'//example.org/index.php?rest_route=/matomo/v1/hit/',
 			$this->tracking_code->get_tracker_endpoint()
 		);
 
 		$this->settings->apply_tracking_related_changes(
 			array(
-				'force_protocol' => 'https'
+				'force_protocol' => 'https',
 			)
 		);
 
 		$this->assertSame(
-			"https://example.org/index.php?rest_route=/matomo/v1/hit/",
+			'https://example.org/index.php?rest_route=/matomo/v1/hit/',
 			$this->tracking_code->get_tracker_endpoint()
 		);
 	}
@@ -119,7 +119,7 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="\/\/example.org\/
 	public function test_get_js_endpoint() {
 		$this->make_tracking_code();
 		$this->assertSame(
-			"//example.org/wp-content/plugins/matomo/app/matomo.js",
+			'//example.org/wp-content/plugins/matomo/app/matomo.js',
 			$this->tracking_code->get_js_endpoint()
 		);
 
@@ -130,18 +130,18 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="\/\/example.org\/
 		);
 
 		$this->assertSame(
-			"//example.org/index.php?rest_route=/matomo/v1/hit/",
+			'//example.org/index.php?rest_route=/matomo/v1/hit/',
 			$this->tracking_code->get_js_endpoint()
 		);
 
 		$this->settings->apply_tracking_related_changes(
 			array(
-				'force_protocol' => 'https'
+				'force_protocol' => 'https',
 			)
 		);
 
 		$this->assertSame(
-			"https://example.org/index.php?rest_route=/matomo/v1/hit/",
+			'https://example.org/index.php?rest_route=/matomo/v1/hit/',
 			$this->tracking_code->get_js_endpoint()
 		);
 	}

--- a/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
+++ b/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
@@ -86,6 +86,66 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="\/\/example.org\/
 		);
 	}
 
+	public function test_get_tracker_endpoint() {
+		$this->make_tracking_code();
+		$this->assertSame(
+			"//example.org/wp-content/plugins/matomo/app/matomo.php",
+			$this->tracking_code->get_tracker_endpoint()
+		);
+
+		$this->settings->apply_tracking_related_changes(
+			array(
+				'track_api_endpoint' => 'restapi',
+			)
+		);
+
+		$this->assertSame(
+			"//example.org/index.php?rest_route=/matomo/v1/hit/",
+			$this->tracking_code->get_tracker_endpoint()
+		);
+
+		$this->settings->apply_tracking_related_changes(
+			array(
+				'force_protocol' => 'https'
+			)
+		);
+
+		$this->assertSame(
+			"https://example.org/index.php?rest_route=/matomo/v1/hit/",
+			$this->tracking_code->get_tracker_endpoint()
+		);
+	}
+
+	public function test_get_js_endpoint() {
+		$this->make_tracking_code();
+		$this->assertSame(
+			"//example.org/wp-content/uploads/matomo/matomo.js",
+			$this->tracking_code->get_js_endpoint()
+		);
+
+		$this->settings->apply_tracking_related_changes(
+			array(
+				'track_js_endpoint' => 'restapi',
+			)
+		);
+
+		$this->assertSame(
+			"//example.org/index.php?rest_route=/matomo/v1/hit/",
+			$this->tracking_code->get_js_endpoint()
+		);
+
+		$this->settings->apply_tracking_related_changes(
+			array(
+				'force_protocol' => 'https'
+			)
+		);
+
+		$this->assertSame(
+			"https://example.org/index.php?rest_route=/matomo/v1/hit/",
+			$this->tracking_code->get_js_endpoint()
+		);
+	}
+
 	public function test_get_tracking_code_test_user_id() {
 		$id1 = self::factory()->user->create();
 

--- a/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
+++ b/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
@@ -119,7 +119,7 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="\/\/example.org\/
 	public function test_get_js_endpoint() {
 		$this->make_tracking_code();
 		$this->assertSame(
-			"//example.org/wp-content/uploads/matomo/matomo.js",
+			"//example.org/wp-content/plugins/matomo/app/matomo.js",
 			$this->tracking_code->get_js_endpoint()
 		);
 


### PR DESCRIPTION
fix https://github.com/matomo-org/wp-matomo/issues/37

To be done:
* [x] Write tests
* [x] Document multisite network tracking code

```
<!-- Matomo --><script  type="text/javascript">var _paq = window._paq || [];
_paq.push(['trackPageView']);_paq.push(['enableLinkTracking']);_paq.push(['setTrackerUrl', {MATOMO_API_ENDPOINT}]);_paq.push(['setSiteId', '{MATOMO_IDSITE}']);var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
g.type='text/javascript'; g.async=true; g.defer=true; g.src={MATOMO_JS_ENDPOINT}; s.parentNode.insertBefore(g,s);</script><!-- End Matomo Code -->
```