### PR TITLE
Check not compatible plugins in system report 

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -37,6 +37,10 @@ class SystemReport {
 	const TROUBLESHOOT_CLEAR_MATOMO_CACHE = 'matomo_troubleshooting_action_clear_matomo_cache';
 	const TROUBLESHOOT_ARCHIVE_NOW        = 'matomo_troubleshooting_action_archive_now';
 
+	protected $not_compatible_plugins = array(
+		'background-manager/background-manager.php', // Uses an old version of Twig and plugin is no longer maintained.
+	);
+
 	private $valid_tabs = array( 'troubleshooting' );
 
 	/**
@@ -639,12 +643,23 @@ class SystemReport {
 		}
 
 		$active_plugins = get_option( 'active_plugins', array() );
+
 		if ( ! empty( $active_plugins ) && is_array( $active_plugins ) ) {
 			$rows[] = array(
 				'name'    => 'Active Plugins',
 				'value'   => count( $active_plugins ),
 				'comment' => implode( ', ', $active_plugins ),
 			);
+
+			$used_not_compatible = array_intersect( $active_plugins, $this->not_compatible_plugins );
+			if ( ! empty( $used_not_compatible ) ) {
+				$rows[] = array(
+					'name'     => __( 'Not compatible plugins', 'matomo' ),
+					'value'    => count( $used_not_compatible ),
+					'comment'  => implode( ', ', $used_not_compatible ),
+					'is_error' => true,
+				);
+			}
 		}
 
 		return $rows;

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -37,7 +37,7 @@ class SystemReport {
 	const TROUBLESHOOT_CLEAR_MATOMO_CACHE = 'matomo_troubleshooting_action_clear_matomo_cache';
 	const TROUBLESHOOT_ARCHIVE_NOW        = 'matomo_troubleshooting_action_archive_now';
 
-	protected $not_compatible_plugins = array(
+	private $not_compatible_plugins = array(
 		'background-manager/background-manager.php', // Uses an old version of Twig and plugin is no longer maintained.
 	);
 
@@ -50,6 +50,10 @@ class SystemReport {
 
 	public function __construct( Settings $settings ) {
 		$this->settings = $settings;
+	}
+
+	public function get_not_compatible_plugins() {
+		return $this->not_compatible_plugins;
 	}
 
 	private function execute_troubleshoot_if_needed() {

--- a/tests/phpunit/wpmatomo/admin/test-systemreport.php
+++ b/tests/phpunit/wpmatomo/admin/test-systemreport.php
@@ -75,6 +75,14 @@ class AdminSystemReportTest extends MatomoUnit_TestCase {
 		}
 	}
 
+	public function test_not_compatible_plugins_are_mentioned_in_faq() {
+		$contents = file_get_contents( 'https://matomo.org/faq/wordpress/which-plugins-is-matomo-for-wordpress-known-to-be-not-compatible-with/' );
+
+		foreach ( $this->report->get_not_compatible_plugins() as $not_compatible_plugin ) {
+			$this->assertContains( $not_compatible_plugin, $contents );
+		}
+	}
+
 	private function fake_request( $field ) {
 		$_POST[ $field ]        = 1;
 		$_REQUEST['_wpnonce']   = wp_create_nonce( SystemReport::NONCE_NAME );


### PR DESCRIPTION
Also includes an automated test that each plugin checked in the system report is also mentioned on  https://matomo.org/faq/wordpress/which-plugins-is-matomo-for-wordpress-known-to-be-not-compatible-with/

fix #89