### PR TITLE
Store all settings in one field instead of many fields

### DIFF
--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -23,6 +23,8 @@ class Settings {
 
 	const OPTION_PREFIX                        = 'matomo-';
 	const GLOBAL_OPTION_PREFIX                 = 'matomo_global-';
+	const OPTION                               = 'matomo-option';
+	const OPTION_GLOBAL                        = 'matomo-global-option';
 	const OPTION_KEY_CAPS_ACCESS               = 'caps_access';
 	const OPTION_KEY_STEALTH                   = 'caps_tracking';
 	const OPTION_LAST_TRACKING_SETTINGS_CHANGE = 'last_tracking_settings_update';
@@ -30,13 +32,6 @@ class Settings {
 	const SHOW_GET_STARTED_PAGE                = 'show_get_started_page';
 
 	public static $is_doing_action_tracking_related = false;
-
-	/**
-	 * Environment variables and default settings container
-	 *
-	 * @var array
-	 */
-	private $default_settings;
 
 	/**
 	 * Tests only
@@ -51,7 +46,7 @@ class Settings {
 	 *
 	 * @var array
 	 */
-	private $global_settings = array(
+	private $default_global_settings = array(
 		// Plugin settings
 		'last_settings_update'                     => 0,
 		self::OPTION_LAST_TRACKING_SETTINGS_CHANGE => 0,
@@ -79,9 +74,9 @@ class Settings {
 		'set_download_classes'                     => '',
 		'disable_cookies'                          => false,
 		'limit_cookies'                            => false,
-		'limit_cookies_visitor'                    => 34186669, // Matomo default 13 months
-		'limit_cookies_session'                    => 1800, // Matomo default 30 minutes
-		'limit_cookies_referral'                   => 15778463, // Matomo default 6 months
+		'limit_cookies_visitor'                    => '34186669', // Matomo default 13 months
+		'limit_cookies_session'                    => '1800', // Matomo default 30 minutes
+		'limit_cookies_referral'                   => '15778463', // Matomo default 6 months
 		'track_admin'                              => false,
 		'track_across'                             => false,
 		'track_across_alias'                       => false,
@@ -101,14 +96,20 @@ class Settings {
 	 *
 	 * @var array
 	 */
-	private $settings = array(
+	private $default_blog_settings = array(
 		'noscript_code'                        => '',
 		'tracking_code'                        => '',
 		self::OPTION_LAST_TRACKING_CODE_UPDATE => 0,
 	);
 
+	private $global_settings = array();
+	private $blog_settings = array();
+
 	private $settings_changed = false;
 
+	/**
+	 * @var Logger
+	 */
 	private $logger;
 
 	/**
@@ -116,39 +117,38 @@ class Settings {
 	 *
 	 */
 	public function __construct() {
-		$this->logger           = new Logger();
-		$this->default_settings = array(
-			'globalSettings' => $this->global_settings,
-			'settings'       => $this->settings,
-		);
+		$this->logger = new Logger();
 
 		$this->init_settings();
 	}
 
 	public function init_settings() {
-		$this->global_settings  = $this->default_settings['globalSettings'];
-		$this->settings         = $this->default_settings['settings'];
 		$this->settings_changed = false;
+		$this->global_settings  = array();
+		$this->blog_settings    = array();
 
-		foreach ( $this->global_settings as $key => $default ) {
-			if ( $this->is_network_enabled() ) {
-				$this->global_settings[ $key ] = get_site_option( self::GLOBAL_OPTION_PREFIX . $key, $default );
-			} else {
-				$this->global_settings[ $key ] = get_option( self::GLOBAL_OPTION_PREFIX . $key, $default );
-			}
+		if ( $this->is_network_enabled() ) {
+			$global_settings = get_site_option( self::OPTION_GLOBAL, array() );
+		} else {
+			$global_settings = get_option( self::OPTION_GLOBAL, array() );
 		}
-		foreach ( $this->settings as $key => $default ) {
-			$this->settings[ $key ] = get_option( self::OPTION_PREFIX . $key, $default );
+		if (!empty($global_settings) && is_array($global_settings)) {
+			$this->default_global_settings = $global_settings;
+		}
+
+		$settings = get_option( self::OPTION, array() );
+
+		if (!empty($settings) && is_array($settings)) {
+			$this->blog_settings = $settings;
 		}
 	}
 
 	public function get_customised_global_settings() {
-		$default_settings = $this->default_settings['globalSettings'];
 		$custom_settings  = array();
 
 		foreach ( $this->global_settings as $key => $val ) {
-			if ( isset( $default_settings[ $key ] )
-				 && $default_settings[ $key ] != $val ) {
+			if ( isset( $this->default_blog_settings[ $key ] )
+				 && $this->default_blog_settings[ $key ] !== $val ) {
 				$custom_settings[ $key ] = $val;
 			}
 		}
@@ -193,16 +193,15 @@ class Settings {
 		}
 
 		$this->logger->log( 'Save settings' );
-		foreach ( $this->global_settings as $key => $value ) {
-			if ( $this->is_network_enabled() ) {
-				update_site_option( self::GLOBAL_OPTION_PREFIX . $key, $value );
-			} else {
-				update_option( self::GLOBAL_OPTION_PREFIX . $key, $value );
-			}
+
+		if ( $this->is_network_enabled() ) {
+			update_site_option( self::OPTION_GLOBAL, $this->global_settings );
+		} else {
+			update_option( self::OPTION_GLOBAL, $this->global_settings );
 		}
-		foreach ( $this->settings as $key => $value ) {
-			update_option( self::OPTION_PREFIX . $key, $value );
-		}
+
+
+		update_option( self::OPTION, $this->blog_settings );
 
 		$this->settings_changed = false;
 	}
@@ -221,8 +220,8 @@ class Settings {
 			return $this->global_settings[ $key ];
 		}
 
-		if ( isset( $this->default_settings['globalSettings'][ $key ] ) ) {
-			return $this->default_settings['globalSettings'][ $key ];
+		if ( isset( $this->default_global_settings[ $key ] ) ) {
+			return $this->default_global_settings[ $key ];
 		}
 	}
 
@@ -235,12 +234,12 @@ class Settings {
 	 * @api
 	 */
 	public function get_option( $key ) {
-		if ( isset( $this->settings[ $key ] ) ) {
-			return $this->settings[ $key ];
+		if ( isset( $this->blog_settings[ $key ] ) ) {
+			return $this->blog_settings[ $key ];
 		}
 
-		if ( isset( $this->default_settings['settings'][ $key ] ) ) {
-			return $this->default_settings['settings'][ $key ];
+		if ( isset( $this->default_blog_settings[ $key ] ) ) {
+			return $this->default_blog_settings[ $key ];
 		}
 	}
 
@@ -265,7 +264,7 @@ class Settings {
 	public function set_option( $key, $value ) {
 		$this->settings_changed = true;
 		$this->logger->log( 'Changed option ' . $key . ': ' . $value );
-		$this->settings[ $key ] = $value;
+		$this->blog_settings[ $key ] = $value;
 	}
 
 	/**
@@ -296,12 +295,12 @@ class Settings {
 	 */
 	public function apply_changes( $settings ) {
 		$this->logger->log( 'Apply changed settings:' );
-		foreach ( $this->global_settings as $key => $val ) {
+		foreach ( $this->default_global_settings as $key => $val ) {
 			if ( isset( $settings[ $key ] ) ) {
 				$this->set_global_option( $key, $settings[ $key ] );
 			}
 		}
-		foreach ( $this->settings as $key => $val ) {
+		foreach ( $this->default_blog_settings as $key => $val ) {
 			if ( isset( $settings[ $key ] ) ) {
 				$this->set_option( $key, $settings[ $key ] );
 			}

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -48,8 +48,8 @@ class Settings {
 	 */
 	private $default_global_settings = array(
 		// Plugin settings
-		'last_settings_update'                     => '0',
-		self::OPTION_LAST_TRACKING_SETTINGS_CHANGE => '0',
+		'last_settings_update'                     => 0,
+		self::OPTION_LAST_TRACKING_SETTINGS_CHANGE => 0,
 		self::OPTION_KEY_STEALTH                   => array(),
 		self::OPTION_KEY_CAPS_ACCESS               => array(),
 		// User settings: Stats configuration
@@ -103,7 +103,7 @@ class Settings {
 	);
 
 	private $global_settings = array();
-	private $blog_settings = array();
+	private $blog_settings   = array();
 
 	private $settings_changed = false;
 
@@ -133,20 +133,20 @@ class Settings {
 			$global_settings = get_option( self::OPTION_GLOBAL, array() );
 		}
 
-		if (!empty($global_settings) && is_array($global_settings)) {
+		if ( ! empty( $global_settings ) && is_array( $global_settings ) ) {
 			$this->global_settings = $global_settings;
 		} else {
 			// temporarily check if data is still stored the old way
 			// remove this before the final release on the marketplace!
-			foreach ($this->default_global_settings as $key => $value) {
+			foreach ( $this->default_global_settings as $key => $value ) {
 				if ( $this->is_network_enabled() ) {
 					$saved = get_site_option( self::GLOBAL_OPTION_PREFIX . $key );
 				} else {
 					$saved = get_option( self::GLOBAL_OPTION_PREFIX . $key );
 				}
-				if ($saved !== false) {
+				if ( $saved !== false ) {
 					$this->global_settings[ $key ] = $value;
-					$this->settings_changed = true;
+					$this->settings_changed        = true;
 				}
 			}
 			$this->save();
@@ -154,16 +154,16 @@ class Settings {
 
 		$settings = get_option( self::OPTION, array() );
 
-		if (!empty($settings) && is_array($settings)) {
+		if ( ! empty( $settings ) && is_array( $settings ) ) {
 			$this->blog_settings = $settings;
 		} else {
 			// temporarily check if data is still stored the old way
 			// remove this before the final release on the marketplace!
-			foreach ($this->default_blog_settings as $key => $value) {
+			foreach ( $this->default_blog_settings as $key => $value ) {
 				$saved = get_option( self::OPTION_PREFIX . $key );
 				if ( $saved !== false ) {
 					$this->blog_settings[ $key ] = $saved;
-					$this->settings_changed = true;
+					$this->settings_changed      = true;
 				}
 			}
 			$this->save();
@@ -171,7 +171,7 @@ class Settings {
 	}
 
 	public function get_customised_global_settings() {
-		$custom_settings  = array();
+		$custom_settings = array();
 
 		foreach ( $this->global_settings as $key => $val ) {
 			if ( isset( $this->default_global_settings[ $key ] )
@@ -269,6 +269,15 @@ class Settings {
 		}
 	}
 
+	private function convert_type( $value, $type ) {
+		if ( $type === 'array' && empty( $value ) ) {
+			$value = array(); // prevent eg converting '' to array('')
+		} else {
+			settype( $value, $type );
+		}
+		return $value;
+	}
+
 	/**
 	 * Set a global option's value
 	 *
@@ -276,9 +285,9 @@ class Settings {
 	 * @param string|array $value new option value
 	 */
 	public function set_global_option( $key, $value ) {
-		if (isset($this->default_global_settings[$key])) {
-			$type = gettype($this->default_global_settings[$key]);
-			settype($value, $type);
+		if ( isset( $this->default_global_settings[ $key ] ) ) {
+			$type  = gettype( $this->default_global_settings[ $key ] );
+			$value = $this->convert_type( $value, $type );
 		}
 
 		$this->settings_changed = true;
@@ -293,9 +302,9 @@ class Settings {
 	 * @param string $value new option value
 	 */
 	public function set_option( $key, $value ) {
-		if (isset($this->default_blog_settings[$key])) {
-			$type = gettype($this->default_blog_settings[$key]);
-			settype($value, $type);
+		if ( isset( $this->default_blog_settings[ $key ] ) ) {
+			$type  = gettype( $this->default_blog_settings[ $key ] );
+			$value = $this->convert_type( $value, $type );
 		}
 
 		$this->settings_changed = true;

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -48,8 +48,8 @@ class Settings {
 	 */
 	private $default_global_settings = array(
 		// Plugin settings
-		'last_settings_update'                     => 0,
-		self::OPTION_LAST_TRACKING_SETTINGS_CHANGE => 0,
+		'last_settings_update'                     => '0',
+		self::OPTION_LAST_TRACKING_SETTINGS_CHANGE => '0',
 		self::OPTION_KEY_STEALTH                   => array(),
 		self::OPTION_KEY_CAPS_ACCESS               => array(),
 		// User settings: Stats configuration
@@ -74,9 +74,9 @@ class Settings {
 		'set_download_classes'                     => '',
 		'disable_cookies'                          => false,
 		'limit_cookies'                            => false,
-		'limit_cookies_visitor'                    => '34186669', // Matomo default 13 months
-		'limit_cookies_session'                    => '1800', // Matomo default 30 minutes
-		'limit_cookies_referral'                   => '15778463', // Matomo default 6 months
+		'limit_cookies_visitor'                    => 34186669, // Matomo default 13 months
+		'limit_cookies_session'                    => 1800, // Matomo default 30 minutes
+		'limit_cookies_referral'                   => 15778463, // Matomo default 6 months
 		'track_admin'                              => false,
 		'track_across'                             => false,
 		'track_across_alias'                       => false,
@@ -276,6 +276,11 @@ class Settings {
 	 * @param string|array $value new option value
 	 */
 	public function set_global_option( $key, $value ) {
+		if (isset($this->default_global_settings[$key])) {
+			$type = gettype($this->default_global_settings[$key]);
+			settype($value, $type);
+		}
+
 		$this->settings_changed = true;
 		$this->logger->log( 'Changed global option ' . $key . ': ' . ( is_array( $value ) ? wp_json_encode( $value ) : $value ) );
 		$this->global_settings[ $key ] = $value;
@@ -288,6 +293,11 @@ class Settings {
 	 * @param string $value new option value
 	 */
 	public function set_option( $key, $value ) {
+		if (isset($this->default_blog_settings[$key])) {
+			$type = gettype($this->default_blog_settings[$key]);
+			settype($value, $type);
+		}
+
 		$this->settings_changed = true;
 		$this->logger->log( 'Changed option ' . $key . ': ' . $value );
 		$this->blog_settings[ $key ] = $value;

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -135,12 +135,38 @@ class Settings {
 
 		if (!empty($global_settings) && is_array($global_settings)) {
 			$this->global_settings = $global_settings;
-		} 
+		} else {
+			// temporarily check if data is still stored the old way
+			// remove this before the final release on the marketplace!
+			foreach ($this->default_global_settings as $key => $value) {
+				if ( $this->is_network_enabled() ) {
+					$saved = get_site_option( self::GLOBAL_OPTION_PREFIX . $key );
+				} else {
+					$saved = get_option( self::GLOBAL_OPTION_PREFIX . $key );
+				}
+				if ($saved !== false) {
+					$this->global_settings[ $key ] = $value;
+					$this->settings_changed = true;
+				}
+			}
+			$this->save();
+		}
 
 		$settings = get_option( self::OPTION, array() );
 
 		if (!empty($settings) && is_array($settings)) {
 			$this->blog_settings = $settings;
+		} else {
+			// temporarily check if data is still stored the old way
+			// remove this before the final release on the marketplace!
+			foreach ($this->default_blog_settings as $key => $value) {
+				$saved = get_option( self::OPTION_PREFIX . $key );
+				if ( $saved !== false ) {
+					$this->blog_settings[ $key ] = $saved;
+					$this->settings_changed = true;
+				}
+			}
+			$this->save();
 		}
 	}
 
@@ -148,8 +174,8 @@ class Settings {
 		$custom_settings  = array();
 
 		foreach ( $this->global_settings as $key => $val ) {
-			if ( isset( $this->default_blog_settings[ $key ] )
-				 && $this->default_blog_settings[ $key ] !== $val ) {
+			if ( isset( $this->default_global_settings[ $key ] )
+				 && $this->default_global_settings[ $key ] !== $val ) {
 				$custom_settings[ $key ] = $val;
 			}
 		}

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -132,9 +132,10 @@ class Settings {
 		} else {
 			$global_settings = get_option( self::OPTION_GLOBAL, array() );
 		}
+
 		if (!empty($global_settings) && is_array($global_settings)) {
-			$this->default_global_settings = $global_settings;
-		}
+			$this->global_settings = $global_settings;
+		} 
 
 		$settings = get_option( self::OPTION, array() );
 
@@ -199,7 +200,6 @@ class Settings {
 		} else {
 			update_option( self::OPTION_GLOBAL, $this->global_settings );
 		}
-
 
 		update_option( self::OPTION, $this->blog_settings );
 

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -175,7 +175,7 @@ class Settings {
 
 		foreach ( $this->global_settings as $key => $val ) {
 			if ( isset( $this->default_global_settings[ $key ] )
-				 && $this->default_global_settings[ $key ] !== $val ) {
+				 && $this->default_global_settings[ $key ] != $val ) {
 				$custom_settings[ $key ] = $val;
 			}
 		}

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -263,9 +263,9 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="' . $container_ur
 			$options[] = "_paq.push(['setSessionCookieTimeout', " . wp_json_encode( $this->settings->get_global_option( 'limit_cookies_session' ) ) . ']);';
 			$options[] = "_paq.push(['setReferralCookieTimeout', " . wp_json_encode( $this->settings->get_global_option( 'limit_cookies_referral' ) ) . ']);';
 		}
-		if ( $this->settings->get_global_option( 'track_content' ) == 'all' ) {
+		if ( $this->settings->get_global_option( 'track_content' ) === 'all' ) {
 			$options[] = "_paq.push(['trackAllContentImpressions']);";
-		} elseif ( $this->settings->get_global_option( 'track_content' ) == 'visible' ) {
+		} elseif ( $this->settings->get_global_option( 'track_content' ) === 'visible' ) {
 			$options[] = "_paq.push(['trackVisibleContentImpressions']);";
 		}
 		if ( (int) $this->settings->get_global_option( 'track_heartbeat' ) > 0 ) {

--- a/tests/phpunit/wpmatomo/test-settings.php
+++ b/tests/phpunit/wpmatomo/test-settings.php
@@ -50,6 +50,38 @@ class SettingsTest extends MatomoUnit_TestCase {
 		$this->assertEquals( 'manually', $this->make_settings()->get_global_option( 'track_mode' ) );
 	}
 
+	public function test_set_global_option_converts_type() {
+		$this->settings->apply_tracking_related_changes(
+			array(
+				'track_ecommerce'         => '0',
+				'track_search'            => 1,
+				'track_404'               => '',
+				'limit_cookies_visitor'   => '3434343',
+				'tagmanger_container_ids' => '',
+				'add_post_annotations'    => array( 'foo' ),
+			)
+		);
+
+		$this->assertSame( false, $this->settings->get_global_option( 'track_ecommerce' ) );
+		$this->assertSame( true, $this->settings->get_global_option( 'track_search' ) );
+		$this->assertSame( false, $this->settings->get_global_option( 'track_404' ) );
+		$this->assertSame( 3434343, $this->settings->get_global_option( 'limit_cookies_visitor' ) );
+		$this->assertSame( array(), $this->settings->get_global_option( 'tagmanger_container_ids' ) );
+		$this->assertSame( array( 'foo' ), $this->settings->get_global_option( 'add_post_annotations' ) );
+	}
+
+	public function test_set_option_converts_type() {
+		$this->settings->apply_changes(
+			array(
+				'noscript_code'                            => 2392,
+				Settings::OPTION_LAST_TRACKING_CODE_UPDATE => '3493939',
+			)
+		);
+
+		$this->assertSame( '2392', $this->settings->get_option( 'noscript_code' ) );
+		$this->assertSame( 3493939, $this->settings->get_option( Settings::OPTION_LAST_TRACKING_CODE_UPDATE ) );
+	}
+
 	public function test_get_customised_global_settings_nothing_customised() {
 		$this->assertSame( array(), $this->settings->get_customised_global_settings() );
 	}

--- a/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
+++ b/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
@@ -64,7 +64,7 @@ g.type=\'text/javascript\'; g.async=true; g.defer=true; g.src="\/\/example.org\/
 				'track_js_endpoint'         => 'restapi',
 				'track_api_endpoint'        => 'restapi',
 				'track_noscript'            => true,
-				'track_content'             => true,
+				'track_content'             => 'all',
 				'add_download_extensions'   => 'zip|waf',
 				'set_link_classes'          => 'clickme|foo',
 				'disable_cookies'           => true,


### PR DESCRIPTION
For performance reasons as recommended by WordPress.