### PR TITLE
Better handling when uploads dir is not writable

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -121,12 +121,12 @@ class WpMatomo {
 			 && ! is_writable( dirname( $upload_path ) ) ) {
 			add_action(
 				'init',
-				function () {
+				function () use ($upload_path) {
 					if ( self::is_admin_user() ) {
 						add_action(
 							'admin_notices',
-							function () {
-								echo '<div class="error"><p>' . __( 'Matomo Analytics requires the uploads directory to be writable. Please make the directory writable for it to work.', 'matomo' ) . '</p></div>';
+							function () use ($upload_path) {
+								echo '<div class="error"><p>' . __( 'Matomo Analytics requires the uploads directory ('.esc_html(dirname($upload_path)).') to be writable. Please make the directory writable for it to work.', 'matomo' ) . '</p></div>';
 							}
 						);
 					}
@@ -183,6 +183,7 @@ class WpMatomo {
 	public function init_plugin() {
 		if ( ( is_admin() || matomo_is_app_request() )
 			 && ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) ) {
+
 			$installer = new Installer( self::$settings );
 			$installer->register_hooks();
 			if ( $installer->looks_like_it_is_installed() ) {
@@ -197,7 +198,9 @@ class WpMatomo {
 					wp_safe_redirect( admin_url() );
 					exit;
 				} else {
-					$installer->install();
+					if ($installer->can_be_installed()) {
+						$installer->install();
+					}
 				}
 			}
 		}

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -183,25 +183,27 @@ class SystemReport {
 		return $report_tables;
 	}
 
-	private function check_file_exists_and_writable( $rows, $path_to_check, $title ) {
+	private function check_file_exists_and_writable( $rows, $path_to_check, $title, $required ) {
 		$file_exists   = file_exists( $path_to_check );
 		$file_readable = is_readable( $path_to_check );
 		$file_writable = is_writable( $path_to_check );
-		$comment       = '"' . $path_to_check . '"';
+		$comment       = '"' . $path_to_check . '" ';
 		if ( ! $file_exists ) {
-			$comment .= sprintf( esc_html__( '%s does not exist.', 'matomo' ), $title );
+			$comment .= sprintf( esc_html__( '%s does not exist. ', 'matomo' ), $title );
 		}
 		if ( ! $file_readable ) {
-			$comment .= sprintf( esc_html__( '%s is not readable.', 'matomo' ), $title );
+			$comment .= sprintf( esc_html__( '%s is not readable. ', 'matomo' ), $title );
 		}
 		if ( ! $file_writable ) {
-			$comment .= sprintf( esc_html__( '%s is not writable.', 'matomo' ), $title );
+			$comment .= sprintf( esc_html__( '%s is not writable. ', 'matomo' ), $title );
 		}
 
 		$rows[] = array(
 			'name'    => sprintf( esc_html__( '%s exists and is writable.', 'matomo' ), $title ),
 			'value'   => $file_exists && $file_readable && $file_writable ? esc_html__( 'Yes', 'matomo' ) : esc_html__( 'No', 'matomo' ),
 			'comment' => $comment,
+			'is_error' => $required && (!$file_exists || !$file_readable),
+			'is_warning' => !$required && (!$file_exists || !$file_readable)
 		);
 
 		return $rows;
@@ -221,10 +223,10 @@ class SystemReport {
 		$paths            = new Paths();
 		$upload_dir       = $paths->get_upload_base_dir();
 		$path_config_file = $upload_dir . '/' . MATOMO_CONFIG_PATH;
-		$rows             = $this->check_file_exists_and_writable( $rows, $path_config_file, 'Config' );
+		$rows             = $this->check_file_exists_and_writable( $rows, $path_config_file, 'Config', true );
 
 		$path_tracker_file = $upload_dir . '/matomo.js';
-		$rows              = $this->check_file_exists_and_writable( $rows, $path_tracker_file, 'JS Tracker' );
+		$rows              = $this->check_file_exists_and_writable( $rows, $path_tracker_file, 'JS Tracker', false );
 
 		$rows[] = array(
 			'name'    => esc_html__( 'Plugin directories', 'matomo' ),

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -68,6 +68,14 @@ class Installer {
 		return false;
 	}
 
+	public function can_be_installed() {
+
+		$paths = new Paths();
+		$upload_dir = $paths->get_upload_base_dir();
+
+		return is_writable($upload_dir) || is_writable(dirname($upload_dir));
+	}
+
 	public function install() {
 		try {
 			// prevent session related errors during install making it more stable
@@ -83,6 +91,7 @@ class Installer {
 
 			return false;
 		} catch ( NotYetInstalledException $e ) {
+
 			$this->logger->log( 'Matomo is not yet installed... installing now' );
 
 			$db_info = $this->create_db();

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -77,6 +77,10 @@ class Installer {
 	}
 
 	public function install() {
+		if (!$this->can_be_installed()) {
+			return false;
+		}
+
 		try {
 			// prevent session related errors during install making it more stable
 			if ( ! defined( 'PIWIK_ENABLE_SESSION_START' ) ) {

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -70,7 +70,11 @@ class Sync {
 						$installed['PluginsInstalled'] = array();
 						$config->PluginsInstalled      = $installed;
 
-						$installer->install();
+						if ($installer->can_be_installed()) {
+							$installer->install();
+						} else {
+							continue;
+						}
 					}
 					$success = $this->sync_site( $site->blog_id, $site->blogname, $site->siteurl );
 				} catch ( \Exception $e ) {

--- a/tests/phpunit/wpmatomo/test-install.php
+++ b/tests/phpunit/wpmatomo/test-install.php
@@ -38,6 +38,10 @@ class InstallTest extends MatomoAnalytics_TestCase {
 		$this->assertTrue( Installer::is_intalled() );
 	}
 
+	public function test_can_be_installed() {
+		$this->assertTrue( $this->installer->can_be_installed() );
+	}
+
 	public function test_install_adds_sites_and_users() {
 		Bootstrap::set_not_bootstrapped();
 


### PR DESCRIPTION
There was already a check for uploads dir not writable and it would not even try to install the plugin but there were some edge cases where it would still attempt the install.

fix https://github.com/matomo-org/wp-matomo/issues/111