### PR TITLE
Remove privacy badge

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -67,9 +67,6 @@ class WpMatomo {
 		$scheduled_tasks = new ScheduledTasks( self::$settings );
 		$scheduled_tasks->schedule();
 
-		$privacy_badge = new PrivacyBadge();
-		$privacy_badge->register_hooks();
-
 		$privacy_badge = new OptOut();
 		$privacy_badge->register_hooks();
 

--- a/classes/WpMatomo/Admin/views/privacy_gdpr.php
+++ b/classes/WpMatomo/Admin/views/privacy_gdpr.php
@@ -91,8 +91,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<li>height - eg 200, 200px or 20%</li>
 </ul>
 <p><?php esc_html_e( 'Example', 'matomo' ); ?>: <code><?php echo esc_html( PrivacySettings::EXAMPLE_FULL ); ?></code></p>
-<h2><?php esc_html_e( 'You earned it!', 'matomo' ); ?></h2>
-<p>
-	<?php echo sprintf( esc_html__( 'Use the shortcode %1$s to show that your website respects your visitors\' privacy.', 'matomo' ), '<code>[matomo_privacy_badge size=120]</code>' ); ?>
-	<?php echo do_shortcode( '[matomo_privacy_badge size=120 align=left]' ); ?>
-</p>

--- a/tests/phpunit/wpmatomo/test-privacybadge.php
+++ b/tests/phpunit/wpmatomo/test-privacybadge.php
@@ -7,6 +7,13 @@ use WpMatomo\PrivacyBadge;
 
 class PrivacyBadgeTest extends MatomoUnit_TestCase {
 
+	public function setUp() {
+		return parent::setUp();
+
+		$badge = new PrivacyBadge();
+		$badge->register_hooks();
+	}
+
 	public function test_privacy_badge_shortcode_no_options() {
 		$this->assertSame( '<img alt="Your privacy protected! This website uses Matomo." src="http://example.org/wp-content/plugins/matomo/assets/img/privacybadge.png"  width="120" height="120">', do_shortcode( '[matomo_privacy_badge]' ) );
 	}

--- a/tests/phpunit/wpmatomo/test-privacybadge.php
+++ b/tests/phpunit/wpmatomo/test-privacybadge.php
@@ -8,7 +8,7 @@ use WpMatomo\PrivacyBadge;
 class PrivacyBadgeTest extends MatomoUnit_TestCase {
 
 	public function setUp() {
-		return parent::setUp();
+		parent::setUp();
 
 		$badge = new PrivacyBadge();
 		$badge->register_hooks();


### PR DESCRIPTION
The text in the badge is too small and is barely readable which is why we are removing it.