### PR TITLE
Log which version a user was on

### DIFF
--- a/app/plugins/TagManager/TagManager.php
+++ b/app/plugins/TagManager/TagManager.php
@@ -32,6 +32,7 @@ use Piwik\Plugins\TagManager\Model\Container\ContainerIdGenerator;
 use Piwik\Plugins\TagManager\Model\Salt;
 use Piwik\Site;
 use Piwik\View;
+use Piwik\Context;
 
 class TagManager extends \Piwik\Plugin
 {
@@ -249,7 +250,9 @@ class TagManager extends \Piwik\Plugin
                 $containers = $containerModel->getActiveContainersInfo();
                 foreach ($containers as $container) {
                     try {
-                        $containerModel->generateContainer($container['idsite'], $container['idcontainer']);
+	                    Context::changeIdSite($container['idsite'], function () use ($containerModel, $container) {
+		                    $containerModel->generateContainer( $container['idsite'], $container['idcontainer'] );
+	                    });
                     } catch (UnexpectedWebsiteFoundException $e) {
                         // website was removed, ignore
                     }

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -400,7 +400,11 @@ class SystemReport {
 		// mostly only numeric values and booleans to not eg accidentally show anything that would store a token etc
 		// like we don't want to show license key etc
 		foreach ( $this->settings->get_customised_global_settings() as $key => $val ) {
-			if ( is_numeric( $val ) || is_bool( $val ) || 'track_content' === $key || 'track_user_id' === $key || 'core_version' === $key ) {
+			if ( is_numeric( $val ) || is_bool( $val ) || 'track_content' === $key || 'track_user_id' === $key || 'core_version' === $key || 'version_history' === $key ) {
+				if (is_array($val)) {
+					$val = implode(', ', $val);
+				}
+
 				$rows[] = array(
 					'name'    => ucfirst( str_replace( '_', ' ', $key ) ),
 					'value'   => $val,

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -73,6 +73,9 @@ class Settings {
 		'set_link_classes'                         => '',
 		'set_download_classes'                     => '',
 		'core_version'                             => '',
+		'current_version'                          => '',
+		'prev_version'                             => '',
+		'prev2_version'                            => '',
 		'disable_cookies'                          => false,
 		'limit_cookies'                            => false,
 		'limit_cookies_visitor'                    => 34186669, // Matomo default 13 months

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -73,9 +73,7 @@ class Settings {
 		'set_link_classes'                         => '',
 		'set_download_classes'                     => '',
 		'core_version'                             => '',
-		'current_version'                          => '',
-		'prev_version'                             => '',
-		'prev2_version'                            => '',
+		'version_history'                          => array(),
 		'disable_cookies'                          => false,
 		'limit_cookies'                            => false,
 		'limit_cookies_visitor'                    => 34186669, // Matomo default 13 months

--- a/tests/phpunit/wpmatomo/test-settings.php
+++ b/tests/phpunit/wpmatomo/test-settings.php
@@ -85,7 +85,9 @@ class SettingsTest extends MatomoUnit_TestCase {
 	public function test_get_customised_global_settings_nothing_customised() {
 		$settings = $this->settings->get_customised_global_settings();
 		$this->assertNotEmpty($settings['core_version']);
+		$this->assertNotEmpty($settings['version_history']);
 		unset($settings['core_version']); // always changes every time we update core so we dont want to look at exact value
+		unset($settings['version_history']); // always changes every time we update core so we dont want to look at exact value
 
 		$this->assertSame( array( ), $settings);
 	}
@@ -96,7 +98,9 @@ class SettingsTest extends MatomoUnit_TestCase {
 
 		$settings = $this->settings->get_customised_global_settings();
 		$this->assertNotEmpty($settings['core_version']);
+		$this->assertNotEmpty($settings['version_history']);
 		unset($settings['core_version']); // always changes every time we update core so we dont want to look at exact value
+		unset($settings['version_history']); // always changes every time we update core so we dont want to look at exact value
 
 		$this->assertEquals(
 			array(


### PR DESCRIPTION
Often users reported that something regressed and I would usually ask from which version a user updated. This is often hard to know though and sometimes users might not remember correctly or it might be triggered by an even earlier update. I figured therefore it would be good to log which versions a user was on. For now logging the last few versions which will automatically be printed in the system report.

Also applying some patch for tag manager.