### PR TITLE
Fix backend may not be accessible

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -64,6 +64,9 @@ class WpMatomo {
 		$roles = new Roles( self::$settings );
 		$roles->register_hooks();
 
+		$compatibility = new \WpMatomo\Compatibility();
+		$compatibility->register_hooks();
+
 		$scheduled_tasks = new ScheduledTasks( self::$settings );
 		$scheduled_tasks->schedule();
 

--- a/classes/WpMatomo/Compatibility.php
+++ b/classes/WpMatomo/Compatibility.php
@@ -28,6 +28,9 @@ class Compatibility {
 	 * then the Matomo backend doesn't work
 	 */
 	private function ithemes_security() {
+		if (defined('MATOMO_COMPATIBIILITY_ITHEMES_SECURITY_DISABLE') && MATOMO_COMPATIBIILITY_ITHEMES_SECURITY_DISABLE) {
+			return;
+		}
 		add_filter('itsec_filter_apache_server_config_modification',  function ($rules)
 		{
 			// otherwise the path below won't be compatible

--- a/classes/WpMatomo/Compatibility.php
+++ b/classes/WpMatomo/Compatibility.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+namespace WpMatomo;
+
+use WP_Roles;
+use WpMatomo\Admin\Menu;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // if accessed directly
+}
+
+class Compatibility {
+
+	public function register_hooks() {
+		add_action( 'init', array( $this, 'init' ) );
+	}
+
+	public function init() {
+		$this->ithemes_security();
+	}
+
+	/**
+	 * refs https://github.com/matomo-org/wp-matomo/issues/131
+	 * When user disables feature "Disable PHP in plugins" in system tweaks
+	 * then the Matomo backend doesn't work
+	 */
+	private function ithemes_security() {
+		add_filter('itsec_filter_apache_server_config_modification',  function ($rules)
+		{
+			if ($rules
+			    && is_string($rules)
+			    && strpos($rules, 'RewriteEngine On') > 0
+			    && strpos($rules, 'content') > 0
+			    && strpos($rules, 'plugins') > 0) {
+				$rules = '
+	<IfModule mod_rewrite.c>
+		RewriteEngine On
+		# Allow Matomo Backend
+		RewriteRule ^wp\-content/plugins/matomo/app/(index|piwik|matomo)\.php$ $0 [NC,L]
+	</IfModule>
+' . $rules;
+			}
+			return $rules;
+		}, 9999999991, $acceptedArgs = 1);
+	}
+
+}

--- a/classes/WpMatomo/Compatibility.php
+++ b/classes/WpMatomo/Compatibility.php
@@ -19,10 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Compatibility {
 
 	public function register_hooks() {
-		add_action( 'init', array( $this, 'init' ) );
-	}
-
-	public function init() {
 		$this->ithemes_security();
 	}
 

--- a/classes/WpMatomo/Compatibility.php
+++ b/classes/WpMatomo/Compatibility.php
@@ -34,7 +34,13 @@ class Compatibility {
 	private function ithemes_security() {
 		add_filter('itsec_filter_apache_server_config_modification',  function ($rules)
 		{
+			// otherwise the path below won't be compatible
+			// todo ideally we would make the plugins path relative and match the specific path...
+			// like preg_quote(relative_wp_content_dir)...
+			$is_wp_content_dir_compatible = defined( 'WP_CONTENT_DIR' )
+			                                 && ABSPATH . 'wp-content' === rtrim( WP_CONTENT_DIR, '/' );
 			if ($rules
+			    && $is_wp_content_dir_compatible
 			    && is_string($rules)
 			    && strpos($rules, 'RewriteEngine On') > 0
 			    && strpos($rules, 'content') > 0
@@ -42,8 +48,9 @@ class Compatibility {
 				$rules = '
 	<IfModule mod_rewrite.c>
 		RewriteEngine On
+
 		# Allow Matomo Backend
-		RewriteRule ^wp\-content/plugins/matomo/app/(index|piwik|matomo)\.php$ $0 [NC,L]
+		RewriteRule ^wp\-content/plugins/matomo/app/(index|piwik|matomo)\.php$ \$0 [NC,L]
 	</IfModule>
 ' . $rules;
 			}

--- a/scripts/update-core.sh
+++ b/scripts/update-core.sh
@@ -21,6 +21,7 @@ echo -e "Downloading $URL..."
 wget $URL -P "$SCRIPTPATH" || die "Got an error while downloading this Matomo version"
 
 cp $MATOMO_ROOT/bootstrap.php bootstrap.php
+cp $MATOMO_ROOT/.htaccess .htaccess
 rm -rf $MATOMO_ROOT/*
 rm -r matomo/ 2> /dev/null
 unzip -o -q matomo-$VERSION.zip
@@ -46,6 +47,7 @@ find $MATOMO_ROOT/core/Updates -name '*.php' ! -name '3.12.0-b1.php' ! -name '3.
 # important to remove pclzip as it is shipped with WP and would need to use their lib
 rm -rf $MATOMO_ROOT/vendor/piwik/decompress/libs/PclZip
 mv bootstrap.php $MATOMO_ROOT/bootstrap.php
+mv .htaccess $MATOMO_ROOT/.htaccess
 
 sed -i -e 's/libs\/bower_components\/jquery\/dist\/jquery.min.js/..\/..\/..\/..\/..\/..\/..\/wp-includes\/js\/jquery\/jquery.js/' $MATOMO_ROOT/plugins/Overlay/client/client.js
 

--- a/tests/phpunit/wpmatomo/test-release.php
+++ b/tests/phpunit/wpmatomo/test-release.php
@@ -33,6 +33,7 @@ class ReleaseTest extends MatomoUnit_TestCase {
 			array( 'app/plugins/TagManager/javascripts/previewmodedetection.js' ),
 			array( 'app/plugins/TagManager/javascripts/tagmanager.js' ),
 			array( 'app/plugins/TagManager/javascripts/tagmanager.min.js' ),
+			array( 'app/.htaccess' ),
 			array( 'app/core/.htaccess' ),
 			array( 'app/js/.htaccess' ),
 			array( 'app/lang/.htaccess' ),


### PR DESCRIPTION
fix #131 see https://github.com/matomo-org/wp-matomo/issues/131#issuecomment-563490079

I noticed iThemes does not use mod_rewrite_rules filter but implements their own logic around htaccess. The below htaccess worked for me. 

@rezwiebel could you add below content at the very beginning of your `$wordpressdir/.htaccess` file and see if that fixes it?

```apache
	<IfModule mod_rewrite.c>
		RewriteEngine On

		# Disable PHP in Plugins - Security > Settings > System Tweaks > PHP in Plugins
		RewriteRule ^wp\-content/plugins/matomo/app/(index|piwik|matomo)\.php$ $0 [NC,L]
	</IfModule>
```

Edit: For some reason it only seems to work when I create an empty `.htaccess` file in the `wp-content/plugins/matomo/app/.htaccess` with no content. Weird!

There is a more permanent solution that would work with other security plugins as well and be even a lot easier. It would be as easy as adding these few lines to our existing [`.htaccess` in our plugin](https://github.com/matomo-org/wp-matomo/blob/develop/.htaccess) so no other logic is needed:

```apache
<IfModule mod_rewrite.c>
    RewriteEngine On
    RewriteRule ^app/(index|piwik|matomo)\.php$ $0 [NC,L]
</IfModule>
```

However, I'm not sure if this maybe causes any issues? Eg under windows for example? Or under Apache 2.2? Are there any mod_rewrite experts here?  

Trying to find changes between Apache 2.2 and Apache 2.4 but there don't seem to be many. Also scared it would maybe turn RewriteEngine on when the user wants it maybe disabled so not adding it for now maybe just fyi and only fixing it for ithemes