### PR TITLE
When sending email use raw content instead of multipart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 1.0.0
 - First release.
 
+0.3.15
+- Improve sending emails
+
 0.3.14
 - Improve memory management
 

--- a/classes/WpMatomo/Email.php
+++ b/classes/WpMatomo/Email.php
@@ -20,9 +20,10 @@ class Email extends \Zend_Mail_Transport_Abstract {
 	 * @var \WP_Error|null
 	 */
 	private $wpMailError;
+
 	private $wpContentType = null;
 
-	public function onError ($error) {
+	public function onError($error) {
 		$this->wpMailError = $error;
 	}
 
@@ -35,18 +36,31 @@ class Email extends \Zend_Mail_Transport_Abstract {
 	}
 
 	public function send(Zend_Mail $mail) {
+		$this->wpContentType = null;
 		$this->wpMailError = null;
+
+		if ($mail->hasAttachments) {
+			// we prefer sending the multipart message through _sendMail()
+			// see #183 the problem is that we can't attach the raw attachment to WP_Mail which is why we need to rely
+			// on the encoded message. This seems to work with built-in wp_mail but other custom implementations may have
+			// issues which is why we are using plain text/body by default below when there are no attachments
+			parent::send($mail);
+			return;
+		}
+
+		// we prefer sending the plain text or html message
 		$this->_mail = $mail;
 
-		add_action( 'wp_mail_failed' , array($this, 'onError') );
-		add_filter( 'wp_mail_content_type' , array($this, 'setContentType'));
-
-		if ($mail->getBodyHtml(true)) {
-			$content = $mail->getBodyHtml(true);
+		if ($mail->getBodyHtml() && $mail->getBodyHtml()->getRawContent()) {
+			$content = $mail->getBodyHtml()->getRawContent();
 			$this->wpContentType = 'text/html';
-		} else {
-			$content = $mail->getBodyText(true);
+		} elseif ($mail->getBodyText()) {
+			$content = $mail->getBodyText()->getRawContent();
 			$this->wpContentType = 'text/plain';
+		} else {
+			// seems no content... lets use _sendMail
+			parent::send($mail);
+			return;
 		}
 
 		$headers = $mail->getHeaders();
@@ -55,34 +69,58 @@ class Email extends \Zend_Mail_Transport_Abstract {
 		}
 		$this->_prepareHeaders($headers);
 
-		$attachments = array();
-		if ($mail->hasAttachments) {
-			for ($i = 0; $i < $mail->getPartCount(); $i++) {
-				$attachments[] = $mail->getPartContent($i);
+		$this->sendMailThroughWordPress($mail->getRecipients(), $mail->getSubject(), $content, $this->header);
+	}
+
+	public function _sendMail() {
+
+		if (!empty($this->_headers['Content-Type'][0])) {
+			$content = trim( $this->_headers['Content-Type'][0] );
+			if ( strpos( $content, ';' ) !== false ) {
+				list( $type, $charset_content ) = explode( ';', $content );
+				$type = trim( $type );
+				if (!empty($type)) {
+					$this->wpContentType = $type;
+				}
+
+			} elseif ( !empty($content) ) {
+				$this->wpContentType = $content;
 			}
 		}
 
-		$success = wp_mail( $mail->getRecipients(), $mail->getSubject(), $content, $this->header );
+		// used when we are dealing with attachment... we send the raw multipart body which includes attachments
+		$this->sendMailThroughWordPress($this->recipients, $this->_mail->getSubject(), $this->body, $this->header);
+	}
 
-		$this->wpContentType = null;
+	private function sendMailThroughWordPress($recipients, $subject, $content, $header) {
+
+		$this->wpMailError = null;
+
+		add_action( 'wp_mail_failed' , array($this, 'onError') );
+		add_filter( 'wp_mail_content_type' , array($this, 'setContentType'));
+
+		$success = wp_mail( $recipients, $subject, $content, $header );
 
 		remove_action( 'wp_mail_failed', array($this, 'onError') );
 		remove_filter('wp_mail_content_type', array($this, 'setContentType'));
 
 		if (!$success) {
-			$message = 'Error unknown';
+			$message = 'Error unknown.';
 			if (!empty($this->wpMailError) && is_object($this->wpMailError) && $this->wpMailError instanceof \WP_Error) {
 				$message = $this->wpMailError->get_error_message();
+			}
+			if ($this->_mail && $this->_mail->hasAttachments) {
+				$message .= ' (has attachments)';
+			}
+			if ($this->wpContentType) {
+				$message .= ' (type '. $this->wpContentType .')';
 			}
 			$logger = new Logger();
 			$logger->log_exception('matomo_mail', new \Exception($message));
 		}
 
+		$this->wpContentType = null;
 		$this->wpMailError = null;
-	}
-
-	public function _sendMail() {
-		// TODO: Implement _sendMail() method.
 	}
 
 }

--- a/classes/WpMatomo/Email.php
+++ b/classes/WpMatomo/Email.php
@@ -116,7 +116,8 @@ class Email extends \Zend_Mail_Transport_Abstract {
 				$message .= ' (type '. $this->wpContentType .')';
 			}
 			$logger = new Logger();
-			$logger->log_exception('matomo_mail', new \Exception($message));
+			$logger->log_exception('mail_error', new \Exception($message));
+			$logger->log('Matomo mail failed with subject '. $subject . ': ' . $message);
 		}
 
 		$this->wpContentType = null;

--- a/matomo.php
+++ b/matomo.php
@@ -4,7 +4,7 @@
  * Description: The #1 Google Analytics alternative that gives you full control over your data and protects the privacy for your users. Free, secure and open.
  * Author: Matomo
  * Author URI: https://matomo.org
- * Version: 0.3.14
+ * Version: 0.3.15
  * Domain Path: /languages
  * WC requires at least: 2.4.0
  * WC tested up to: 3.8

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: matomo,piwik,analytics,statistics,stats,tracking,ecommerce
 Requires at least: 4.8
 Tested up to: 5.3
-Stable tag: 0.3.14
+Stable tag: 0.3.15
 Requires PHP: 7.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
The way we are currently sending emails is that we pass on the encoded message (eg multipart) to `wp_mail`. This seems to work fine when the wordpress wp_mail is used but I wouldn't be surprised if not all `wp_mail` solutions handle this properly or if boundaries are added twice or other issues. 

Also someone listening to `wp_mail` hook might not be able to alter the content when everything is encoded.

Ideally, we would pass on the raw text or html content to `wp_mail` which this PR does. The problem is attachments which I can't get to work. I have two issues so far:

1. I can only get encoded attachments
2. WordPress only supports sending attachment from a file. Meaning we would need to create files for each attachment. For this we would need to use the actual file name meaning the URL for each file be guessable. And there is a risk that because of some error these files won't be deleted afterwards etc. Also restrictions in writing permissions may prevent this issue. The only thing I could think of be trying a virtual filesystem but don't really want to load yet another lib just for that.

Maybe for now when there are no attachments, then we use this way of sending mail, with attachments we would maybe need to use other way as it is implemented in master.

refs https://github.com/matomo-org/wp-matomo/issues/170