### PR TITLE
Allow enabling tag manager when running in multi site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 1.0.0
 - First release.
 
+0.4.1
+- Allow enable tag manager when running in multi site (won't work when network enabled)
+
 0.4.0
 - Update core to 3.13.1
 - No longer show Tag Manager in menu for multi site installations

--- a/matomo.php
+++ b/matomo.php
@@ -4,7 +4,7 @@
  * Description: The #1 Google Analytics alternative that gives you full control over your data and protects the privacy for your users. Free, secure and open.
  * Author: Matomo
  * Author URI: https://matomo.org
- * Version: 0.4.0
+ * Version: 0.4.1
  * Domain Path: /languages
  * WC requires at least: 2.4.0
  * WC tested up to: 3.8
@@ -47,8 +47,8 @@ function matomo_is_app_request() {
 }
 
 function matomo_has_tag_manager() {
-	if ( defined( 'MATOMO_DISABLE_TAG_MANAGER' ) && MATOMO_DISABLE_TAG_MANAGER ) {
-		return false;
+	if ( defined( 'MATOMO_ENABLE_TAG_MANAGER' ) ) {
+		return !empty(MATOMO_ENABLE_TAG_MANAGER);
 	}
 
 	$is_multisite = function_exists( 'is_multisite' ) && is_multisite();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: matomo,piwik,analytics,statistics,stats,tracking,ecommerce
 Requires at least: 4.8
 Tested up to: 5.3
-Stable tag: 0.4.0
+Stable tag: 0.4.1
 Requires PHP: 7.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
@@ -114,7 +114,7 @@ and we need your help to make Matomo better… Why not participate in a useful p
 The Matomo project uses an ever-expanding comprehensive set of thousands of unit tests and hundreds of automated integration tests, system tests, JavaScript tests, and screenshot UI tests, running on a continuous integration server as part of its software quality assurance. [Learn more](https://developer.matomo.org/guides/tests)
 
 = Can I disable the Tag Manager?
-The Tag Manager can be disabled by placing `define('MATOMO_DISABLE_TAG_MANAGER', true);` in your `wp-config.php`.
+The Tag Manager can be disabled by placing `define('MATOMO_ENABLE_TAG_MANAGER', false);` in your `wp-config.php`.
 
 The Tag Manager does currently not work in WP Multisite mode.
 


### PR DESCRIPTION
This won't work though in network mode... see https://github.com/matomo-org/wp-matomo/issues/191#issuecomment-577972147