### PR TITLE
Fix warning shown on Windows tag manager upload dir not writable

### DIFF
--- a/classes/WpMatomo/Paths.php
+++ b/classes/WpMatomo/Paths.php
@@ -110,8 +110,8 @@ class Paths {
 
 	public function get_relative_dir_to_matomo( $target_dir ) {
 		$matomo_dir         = plugin_dir_path( MATOMO_ANALYTICS_FILE ) . 'app';
-		$matomo_dir_parts   = explode( '/', $matomo_dir );
-		$target_dir_parts   = explode( '/', $target_dir );
+		$matomo_dir_parts   = explode( DIRECTORY_SEPARATOR, $matomo_dir );
+		$target_dir_parts   = explode( DIRECTORY_SEPARATOR, $target_dir );
 		$relative_directory = '';
 		$add_at_the_end     = array();
 		$was_previous_same  = false;

--- a/matomo.php
+++ b/matomo.php
@@ -117,8 +117,8 @@ function matomo_add_plugin( $plugins_directory, $wp_plugin_file, $is_marketplace
 	}
 
 	$matomo_dir       = __DIR__ . '/app';
-	$matomo_dir_parts = explode( '/', $matomo_dir );
-	$root_dir_parts   = explode( '/', $root_dir );
+	$matomo_dir_parts = explode( DIRECTORY_SEPARATOR, $matomo_dir );
+	$root_dir_parts   = explode( DIRECTORY_SEPARATOR, $root_dir );
 	$webroot_dir      = '';
 	foreach ( $matomo_dir_parts as $index => $part ) {
 		if ( isset( $root_dir_parts[ $index ] ) && $root_dir_parts[ $index ] === $part ) {


### PR DESCRIPTION
refs https://wordpress.org/support/topic/directories-with-write-access-for-tag-manager/