### PR TITLE
When doing ajax, do not execute cart update event twice in WooCommerce

### DIFF
--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -70,7 +70,7 @@ class Base {
 		update_post_meta( $order_id, $this->key_order_tracked, 1 );
 	}
 
-	private function is_doing_ajax() {
+	protected function is_doing_ajax() {
 		return defined( 'DOING_AJAX' ) && DOING_AJAX;
 	}
 


### PR DESCRIPTION
refs https://github.com/matomo-org/wp-matomo/issues/215#issuecomment-587339645

Also makes sure we return correct value for the cart updated filter. 