### PR TITLE
Install Matomo by forcing WordPress usage

### DIFF
--- a/config/common.config.ini.php
+++ b/config/common.config.ini.php
@@ -1,6 +1,9 @@
 ; <?php exit; ?> DO NOT REMOVE THIS LINE
 ; Configuration settings which are applied to all Piwik instances.
 
+[database]
+adapter = WordPress
+
 [General]
 enable_update_communication = 0
 enable_auto_update = 0

--- a/config/config.php
+++ b/config/config.php
@@ -46,12 +46,12 @@ return array(
 			$previous->General = $general;
 		}
 
+		// we overwrite DB on demand only once installed... otherwise Matomo may think it is installed already
+		$database = $previous->database;
+		$previous->database = \WpMatomo\Installer::get_db_infos($database);
+
 		$paths = new Paths();
 		if ( file_exists( $paths->get_config_ini_path() ) ) {
-			// we overwrite DB on demand only once installed... otherwise Matomo may think it is installed already
-			$database = $previous->database;
-			$previous->database = \WpMatomo\Installer::get_db_infos($database);
-
 			$general = $previous->General;
 
 			if (defined('MATOMO_TRIGGER_BROWSER_ARCHIVING')) {

--- a/config/config.php
+++ b/config/config.php
@@ -46,7 +46,6 @@ return array(
 			$previous->General = $general;
 		}
 
-		// we overwrite DB on demand only once installed... otherwise Matomo may think it is installed already
 		$database = $previous->database;
 		$previous->database = \WpMatomo\Installer::get_db_infos($database);
 


### PR DESCRIPTION
refs https://wordpress.org/support/topic/critical-error-wp-admin-admin-phppagematomo-reportinggotomatomo-admin/

In the support case it tried to use Zend DB. I'm not 100% sure how this happens but maybe it has to do with the config file somehow or so. It's still kind of to be seen what is actually happening there. 