### PR TITLE
Fix starting a transaction might not work

### DIFF
--- a/classes/WpMatomo/Db/WordPressTracker.php
+++ b/classes/WpMatomo/Db/WordPressTracker.php
@@ -180,12 +180,11 @@ class WordPress extends Mysqli {
 		if ( ! $this->activeTransaction === false ) {
 			return;
 		}
-		$wpdb->query( 'START TRANSACTION' );
-		if ( $this->connection->autocommit( false ) ) {
-			$this->activeTransaction = uniqid();
 
-			return $this->activeTransaction;
-		}
+		$wpdb->query( 'START TRANSACTION' );
+		$this->activeTransaction = uniqid();
+
+		return $this->activeTransaction;
 	}
 
 	/**


### PR DESCRIPTION
Seems likely some left over code from Matomo's MySQLi transaction code

refs https://forum.matomo.org/t/content-tracking-in-wordpress-plugin-doesnt-work/36998/4

> [Tue Apr 21 15:52:51.513287 2020] [php7:error] [pid 22218] [client X:52733] PHP Fatal error: Uncaught Error: Call to a member function autocommit() on null in /var/www/X/public_html/X/wp-content/plugins/matomo/classes/WpMatomo/Db/WordPressTracker.php:184\nStack trace:\n#0 /var/www/X/public_html/X/wp-