### PR TITLE
Fix token is not valid when certain plugins are used

### DIFF
--- a/app/plugins/Morpheus/templates/_jsGlobalVariables.twig
+++ b/app/plugins/Morpheus/templates/_jsGlobalVariables.twig
@@ -16,7 +16,7 @@
         symbolDecimal: "{{ 'Intl_NumberSymbolDecimal'|translate }}"
     };
 
-    piwik.relativePluginWebDirs = {{ relativePluginWebDirs|json_encode|raw }}
+    piwik.relativePluginWebDirs = {{ relativePluginWebDirs|json_encode|raw }};
 
     {% if userLogin %}piwik.userLogin = "{{ userLogin|e('js')}}";{% endif %}
 


### PR DESCRIPTION
fix https://github.com/matomo-org/wp-matomo/issues/236#issuecomment-623163249

eg 2FAS Light — Google Authenticator and "data-tables-generator-by-supsystic/"