### PR TITLE
Use WP DB charset

### DIFF
--- a/app/core/Db/Schema/Mysql.php
+++ b/app/core/Db/Schema/Mysql.php
@@ -43,7 +43,7 @@ class Mysql implements SchemaInterface
         $tables = array(
             'user'    => "CREATE TABLE {$prefixTables}user (
                           login VARCHAR(100) NOT NULL,
-                          password VARCHAR(255) NOT NULL,
+                          password VARCHAR(191) NOT NULL,
                           alias VARCHAR(45) NOT NULL,
                           email VARCHAR(100) NOT NULL,
                           twofactor_secret VARCHAR(40) NOT NULL DEFAULT '',
@@ -243,7 +243,7 @@ class Mysql implements SchemaInterface
             ",
 
             'option'        => "CREATE TABLE `{$prefixTables}option` (
-                                option_name VARCHAR( 255 ) NOT NULL,
+                                option_name VARCHAR( 191 ) NOT NULL,
                                 option_value LONGTEXT NOT NULL,
                                 autoload TINYINT NOT NULL DEFAULT '1',
                                   PRIMARY KEY ( option_name ),
@@ -252,7 +252,7 @@ class Mysql implements SchemaInterface
             ",
 
             'session'       => "CREATE TABLE {$prefixTables}session (
-                                id VARCHAR( 255 ) NOT NULL,
+                                id VARCHAR( 191 ) NOT NULL,
                                 modified INTEGER,
                                 lifetime INTEGER,
                                 data TEXT,
@@ -262,7 +262,7 @@ class Mysql implements SchemaInterface
 
             'archive_numeric'     => "CREATE TABLE {$prefixTables}archive_numeric (
                                       idarchive INTEGER UNSIGNED NOT NULL,
-                                      name VARCHAR(255) NOT NULL,
+                                      name VARCHAR(190) NOT NULL,
                                       idsite INTEGER UNSIGNED NULL,
                                       date1 DATE NULL,
                                       date2 DATE NULL,
@@ -277,7 +277,7 @@ class Mysql implements SchemaInterface
 
             'archive_blob'        => "CREATE TABLE {$prefixTables}archive_blob (
                                       idarchive INTEGER UNSIGNED NOT NULL,
-                                      name VARCHAR(255) NOT NULL,
+                                      name VARCHAR(190) NOT NULL,
                                       idsite INTEGER UNSIGNED NULL,
                                       date1 DATE NULL,
                                       date2 DATE NULL,

--- a/app/core/Db/Schema/Mysql.php
+++ b/app/core/Db/Schema/Mysql.php
@@ -38,6 +38,7 @@ class Mysql implements SchemaInterface
     {
         $engine       = $this->getTableEngine();
         $prefixTables = $this->getTablePrefix();
+        $charset      = $this->getCharset();
 
         $tables = array(
             'user'    => "CREATE TABLE {$prefixTables}user (
@@ -52,7 +53,7 @@ class Mysql implements SchemaInterface
                           ts_password_modified TIMESTAMP NULL,
                             PRIMARY KEY(login),
                             UNIQUE KEY uniq_keytoken(token_auth)
-                          ) ENGINE=$engine DEFAULT CHARSET=utf8
+                          ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'twofactor_recovery_code'    => "CREATE TABLE {$prefixTables}twofactor_recovery_code (
@@ -60,7 +61,7 @@ class Mysql implements SchemaInterface
                           login VARCHAR(100) NOT NULL,
                           recovery_code VARCHAR(40) NOT NULL,
                             PRIMARY KEY(idrecoverycode)
-                          ) ENGINE=$engine DEFAULT CHARSET=utf8
+                          ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'access'  => "CREATE TABLE {$prefixTables}access (
@@ -70,7 +71,7 @@ class Mysql implements SchemaInterface
                           access VARCHAR(50) NULL,
                             PRIMARY KEY(idaccess),
                             INDEX index_loginidsite (login, idsite)
-                          ) ENGINE=$engine DEFAULT CHARSET=utf8
+                          ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'site'    => "CREATE TABLE {$prefixTables}site (
@@ -93,7 +94,7 @@ class Mysql implements SchemaInterface
                             keep_url_fragment TINYINT NOT NULL DEFAULT 0,
                             creator_login VARCHAR(100) NULL,
                               PRIMARY KEY(idsite)
-                            ) ENGINE=$engine DEFAULT CHARSET=utf8
+                            ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'plugin_setting' => "CREATE TABLE {$prefixTables}plugin_setting (
@@ -105,7 +106,7 @@ class Mysql implements SchemaInterface
                               `idplugin_setting` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                               PRIMARY KEY (idplugin_setting),
                               INDEX(plugin_name, user_login)
-                            ) ENGINE=$engine DEFAULT CHARSET=utf8
+                            ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'site_setting'    => "CREATE TABLE {$prefixTables}site_setting (
@@ -117,14 +118,14 @@ class Mysql implements SchemaInterface
                               `idsite_setting` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                               PRIMARY KEY (idsite_setting),
                               INDEX(idsite, plugin_name)
-                            ) ENGINE=$engine DEFAULT CHARSET=utf8
+                            ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'site_url'    => "CREATE TABLE {$prefixTables}site_url (
                               idsite INTEGER(10) UNSIGNED NOT NULL,
                               url VARCHAR(255) NOT NULL,
                                 PRIMARY KEY(idsite, url)
-                              ) ENGINE=$engine DEFAULT CHARSET=utf8
+                              ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'goal'       => "CREATE TABLE `{$prefixTables}goal` (
@@ -141,7 +142,7 @@ class Mysql implements SchemaInterface
                               `deleted` tinyint(4) NOT NULL default '0',
                               `event_value_as_revenue` tinyint(4) NOT NULL default '0',
                                 PRIMARY KEY  (`idsite`,`idgoal`)
-                              ) ENGINE=$engine DEFAULT CHARSET=utf8
+                              ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'logger_message'      => "CREATE TABLE {$prefixTables}logger_message (
@@ -151,7 +152,7 @@ class Mysql implements SchemaInterface
                                       level VARCHAR(16) NULL,
                                       message TEXT NULL,
                                         PRIMARY KEY(idlogger_message)
-                                      ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'log_action'          => "CREATE TABLE {$prefixTables}log_action (
@@ -162,7 +163,7 @@ class Mysql implements SchemaInterface
                                       url_prefix TINYINT(2) NULL,
                                         PRIMARY KEY(idaction),
                                         INDEX index_type_hash (type, hash)
-                                      ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'log_visit'   => "CREATE TABLE {$prefixTables}log_visit (
@@ -176,7 +177,7 @@ class Mysql implements SchemaInterface
                                 INDEX index_idsite_config_datetime (idsite, config_id, visit_last_action_time),
                                 INDEX index_idsite_datetime (idsite, visit_last_action_time),
                                 INDEX index_idsite_idvisitor (idsite, idvisitor)
-                              ) ENGINE=$engine DEFAULT CHARSET=utf8
+                              ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'log_conversion_item'   => "CREATE TABLE `{$prefixTables}log_conversion_item` (
@@ -197,7 +198,7 @@ class Mysql implements SchemaInterface
                                         deleted TINYINT(1) UNSIGNED NOT NULL,
                                           PRIMARY KEY(idvisit, idorder, idaction_sku),
                                           INDEX index_idsite_servertime ( idsite, server_time )
-                                        ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                        ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'log_conversion'      => "CREATE TABLE `{$prefixTables}log_conversion` (
@@ -215,7 +216,7 @@ class Mysql implements SchemaInterface
                                         PRIMARY KEY (idvisit, idgoal, buster),
                                         UNIQUE KEY unique_idsite_idorder (idsite, idorder),
                                         INDEX index_idsite_datetime ( idsite, server_time )
-                                      ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'log_link_visit_action' => "CREATE TABLE {$prefixTables}log_link_visit_action (
@@ -228,7 +229,7 @@ class Mysql implements SchemaInterface
                                         custom_float DOUBLE NULL DEFAULT NULL,
                                           PRIMARY KEY(idlink_va),
                                           INDEX index_idvisit(idvisit)
-                                        ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                        ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'log_profiling'   => "CREATE TABLE {$prefixTables}log_profiling (
@@ -238,7 +239,7 @@ class Mysql implements SchemaInterface
                                   idprofiling BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
                                     PRIMARY KEY (idprofiling),
                                     UNIQUE KEY query(query(100))
-                                  ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'option'        => "CREATE TABLE `{$prefixTables}option` (
@@ -247,7 +248,7 @@ class Mysql implements SchemaInterface
                                 autoload TINYINT NOT NULL DEFAULT '1',
                                   PRIMARY KEY ( option_name ),
                                   INDEX autoload( autoload )
-                                ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'session'       => "CREATE TABLE {$prefixTables}session (
@@ -256,7 +257,7 @@ class Mysql implements SchemaInterface
                                 lifetime INTEGER,
                                 data TEXT,
                                   PRIMARY KEY ( id )
-                                ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'archive_numeric'     => "CREATE TABLE {$prefixTables}archive_numeric (
@@ -271,7 +272,7 @@ class Mysql implements SchemaInterface
                                         PRIMARY KEY(idarchive, name),
                                         INDEX index_idsite_dates_period(idsite, date1, date2, period, ts_archived),
                                         INDEX index_period_archived(period, ts_archived)
-                                      ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'archive_blob'        => "CREATE TABLE {$prefixTables}archive_blob (
@@ -285,14 +286,14 @@ class Mysql implements SchemaInterface
                                       value MEDIUMBLOB NULL,
                                         PRIMARY KEY(idarchive, name),
                                         INDEX index_period_archived(period, ts_archived)
-                                      ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'sequence'        => "CREATE TABLE {$prefixTables}sequence (
                                       `name` VARCHAR(120) NOT NULL,
                                       `value` BIGINT(20) UNSIGNED NOT NULL ,
                                       PRIMARY KEY(`name`)
-                                  ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'brute_force_log'        => "CREATE TABLE {$prefixTables}brute_force_log (
@@ -301,7 +302,7 @@ class Mysql implements SchemaInterface
                                       `attempted_at` datetime NOT NULL,
                                         INDEX index_ip_address(ip_address),
                                       PRIMARY KEY(`id_brute_force_log`)
-                                      ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                      ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
 
             'tracking_failure'        => "CREATE TABLE {$prefixTables}tracking_failure (
@@ -310,14 +311,14 @@ class Mysql implements SchemaInterface
                                       `date_first_occurred` DATETIME NOT NULL ,
                                       `request_url` MEDIUMTEXT NOT NULL ,
                                       PRIMARY KEY(`idsite`, `idfailure`)
-                                  ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
             'locks'                   => "CREATE TABLE `{$prefixTables}locks` (
                                       `key` VARCHAR(".Lock::MAX_KEY_LEN.") NOT NULL,
                                       `value` VARCHAR(255) NULL DEFAULT NULL,
                                       `expiry_time` BIGINT UNSIGNED DEFAULT 9999999999,
                                       PRIMARY KEY (`key`)
-                                  ) ENGINE=$engine DEFAULT CHARSET=utf8
+                                  ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",
         );
 
@@ -384,7 +385,7 @@ class Mysql implements SchemaInterface
 
     /**
      * Get list of tables installed
-     *
+     *`
      * @param bool $forceReload Invalidate cache
      * @return array  installed Tables
      */
@@ -452,7 +453,8 @@ class Mysql implements SchemaInterface
      */
     public function createTable($nameWithoutPrefix, $createDefinition)
     {
-        $statement = sprintf("CREATE TABLE IF NOT EXISTS `%s` ( %s ) ENGINE=%s DEFAULT CHARSET=utf8 ;",
+    	$charset = $this->getCharset();
+        $statement = sprintf("CREATE TABLE IF NOT EXISTS `%s` ( %s ) ENGINE=%s DEFAULT CHARSET=$charset ;",
                              Common::prefixTable($nameWithoutPrefix),
                              $createDefinition,
                              $this->getTableEngine());
@@ -549,6 +551,11 @@ class Mysql implements SchemaInterface
     private function getTablePrefix()
     {
         return $this->getDbSettings()->getTablePrefix();
+    }
+
+    private function getCharset()
+    {
+        return $this->getDbSettings()->getCharset();
     }
 
     private function getTableEngine()

--- a/app/core/Db/Schema/Mysql.php
+++ b/app/core/Db/Schema/Mysql.php
@@ -123,7 +123,7 @@ class Mysql implements SchemaInterface
 
             'site_url'    => "CREATE TABLE {$prefixTables}site_url (
                               idsite INTEGER(10) UNSIGNED NOT NULL,
-                              url VARCHAR(255) NOT NULL,
+                              url VARCHAR(190) NOT NULL,
                                 PRIMARY KEY(idsite, url)
                               ) ENGINE=$engine DEFAULT CHARSET=$charset
             ",

--- a/app/core/Db/Settings.php
+++ b/app/core/Db/Settings.php
@@ -31,7 +31,11 @@ class Settings
 
     public function getCharset()
     {
-        return $this->getDbSetting('charset');
+        $charset = $this->getDbSetting('charset');
+        if (empty($charset)) {
+        	$charset = 'utf8';
+        }
+        return $charset;
     }
 
     public function getDbName()

--- a/app/core/Db/Settings.php
+++ b/app/core/Db/Settings.php
@@ -29,6 +29,11 @@ class Settings
         return $this->getDbSetting('tables_prefix');
     }
 
+    public function getCharset()
+    {
+        return $this->getDbSetting('charset');
+    }
+
     public function getDbName()
     {
         return $this->getDbSetting('dbname');

--- a/app/core/DbHelper.php
+++ b/app/core/DbHelper.php
@@ -61,6 +61,15 @@ class DbHelper
         Schema::getInstance()->createTable($nameWithoutPrefix, $createDefinition);
     }
 
+	public static function getUsedCharset()
+	{
+		if (Config::getInstance()->database['charset']) {
+			return strtolower(Config::getInstance()->database['charset']);
+		}
+
+		return 'utf8';
+	}
+
     /**
      * Returns true if Piwik is installed
      *

--- a/app/core/Tracker/Request.php
+++ b/app/core/Tracker/Request.php
@@ -95,9 +95,6 @@ class Request
 
     protected function replaceUnsupportedUtf8Chars($value, $key=false)
     {
-    	if (DbHelper::getUsedCharset() === 'utf8mb4') {
-    		return $value;
-	    }
         if (is_string($value) && preg_match('/[\x{10000}-\x{10FFFF}]/u', $value)) {
             Common::printDebug("Unsupport character detected in $key. Replacing with \xEF\xBF\xBD");
             return preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $value);

--- a/app/core/Tracker/Request.php
+++ b/app/core/Tracker/Request.php
@@ -13,6 +13,7 @@ use Piwik\Common;
 use Piwik\Config;
 use Piwik\Container\StaticContainer;
 use Piwik\Cookie;
+use Piwik\DbHelper;
 use Piwik\Exception\InvalidRequestParameterException;
 use Piwik\Exception\UnexpectedWebsiteFoundException;
 use Piwik\IP;
@@ -94,6 +95,9 @@ class Request
 
     protected function replaceUnsupportedUtf8Chars($value, $key=false)
     {
+    	if (DbHelper::getUsedCharset() === 'utf8mb4') {
+    		return $value;
+	    }
         if (is_string($value) && preg_match('/[\x{10000}-\x{10FFFF}]/u', $value)) {
             Common::printDebug("Unsupport character detected in $key. Replacing with \xEF\xBF\xBD");
             return preg_replace('/[\x{10000}-\x{10FFFF}]/u', "\xEF\xBF\xBD", $value);

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -765,18 +765,22 @@ class SystemReport {
 			'name'  => 'Timezone',
 			'value' => date_default_timezone_get(),
 		);
-		$rows[] = array(
-			'name'  => 'WP timezone',
-			'value' => wp_timezone_string(),
-		);
+		if (function_exists('wp_timezone_string')) {
+			$rows[] = array(
+				'name'  => 'WP timezone',
+				'value' => wp_timezone_string(),
+			);
+		}
 		$rows[] = array(
 			'name'  => 'Locale',
 			'value' => get_locale(),
 		);
+		if (function_exists('get_user_locale')) {
 		$rows[] = array(
 			'name'  => 'User Locale',
 			'value' => get_user_locale(),
 		);
+		}
 
 		$rows[] = array(
 			'name'    => 'Memory Limit',

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -776,10 +776,10 @@ class SystemReport {
 			'value' => get_locale(),
 		);
 		if (function_exists('get_user_locale')) {
-		$rows[] = array(
-			'name'  => 'User Locale',
-			'value' => get_user_locale(),
-		);
+			$rows[] = array(
+				'name'  => 'User Locale',
+				'value' => get_user_locale(),
+			);
 		}
 
 		$rows[] = array(

--- a/classes/WpMatomo/Db/WordPress.php
+++ b/classes/WpMatomo/Db/WordPress.php
@@ -60,7 +60,7 @@ class WordPress extends Mysqli {
 	public function isConnectionUTF8() {
 		$value = $this->fetchOne( 'SELECT @@character_set_client;' );
 
-		return ! empty( $value ) && strtolower( $value ) === 'utf8';
+		return ! empty( $value ) && strpos(strtolower( $value ), 'utf8') === 0;
 	}
 
 	public function checkClientVersion() {

--- a/classes/WpMatomo/Db/WordPress.php
+++ b/classes/WpMatomo/Db/WordPress.php
@@ -70,7 +70,7 @@ class WordPress extends Mysqli {
 	public function getClientVersion() {
 		$value = $this->fetchOne( 'SELECT @@version;' );
 
-		return ! empty( $value ) && strtolower( $value ) === 'utf8';
+		return $value;
 	}
 
 	public function closeConnection() {

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -292,6 +292,7 @@ class Installer {
 			'username' => DB_USER,
 			'password' => DB_PASSWORD,
 			'dbname' => DB_NAME,
+			'charset' => $wpdb->charset,
 			'tables_prefix' => $wpdb->prefix . MATOMO_DATABASE_PREFIX,
 			'adapter' => 'WordPress',
 		);

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -286,13 +286,15 @@ class Installer {
 			}
 		}
 
+		$charset = $wpdb->charset ? $wpdb->charset : 'utf8';
+
 		$database = array(
 			'host' => $host,
 			'port' => $port,
 			'username' => DB_USER,
 			'password' => DB_PASSWORD,
 			'dbname' => DB_NAME,
-			'charset' => $wpdb->charset,
+			'charset' => $charset,
 			'tables_prefix' => $wpdb->prefix . MATOMO_DATABASE_PREFIX,
 			'adapter' => 'WordPress',
 		);

--- a/config/config.php
+++ b/config/config.php
@@ -58,10 +58,10 @@ return array(
 			}
 
 			$matomo_salt_key = Settings::OPTION_PREFIX . 'matomo_salt';
-			$matomo_salt = get_option($matomo_salt_key); // needs to per site!
+			$matomo_salt = get_option($matomo_salt_key); // needs to be per site!
 			if (!$matomo_salt) {
 				$matomo_salt = \Piwik\Common::getRandomString(32);
-				update_option($matomo_salt_key, $matomo_salt);
+				update_option($matomo_salt_key, $matomo_salt, true);
 			}
 
 			$general['salt'] = $matomo_salt;
@@ -150,6 +150,7 @@ return array(
 			unset($values['database']['password']);
 			unset($values['database']['dbname']);
 			unset($values['database']['tables_prefix']);
+			unset($values['database']['charset']);
 			unset($values['Plugins']);
 			unset($values['General']['enable_users_admin']);
 			unset($values['General']['enable_sites_admin']);


### PR DESCRIPTION
To keep BC for existing installs where we installed tables already using utf8 and would have then assumed it is utf8mb4 charset, we still replace all non utf8 characters in tracker request class with `''`. This way things should still work and we can fully support utf8mb4 in Matomo 4. Otherwise could have actually done this already now.