### PR TITLE
Fix archive error "Empty or invalid response"

### DIFF
--- a/app/core/CliMulti/RequestCommand.php
+++ b/app/core/CliMulti/RequestCommand.php
@@ -81,6 +81,10 @@ class RequestCommand extends ConsoleCommand
         if (!empty($process)) {
             $process->finishProcess();
         }
+        
+        while (ob_get_level()) {
+	        echo ob_get_clean();
+        }
     }
 
     private function isTestModeEnabled()


### PR DESCRIPTION
> 'Empty or invalid response \'\' for website id 1, Time elapsed: 1.941s, skipping'

in this case WP nggallery started an ob_start() handler causing the archive output to not appear on CLI.

It would have been also fixed by launching climulti without the `-q` parameter (`app/console climulti:request -q --matomo-domain...`) but not sure what removing that parameter would break. Was initially added in https://github.com/matomo-org/matomo/commit/54be28167099a063228b5707c1857deac1248feb#diff-884529fcd1f2c23383c971d5c19372ab