### PR TITLE
Add a dashboard widget to WP admin dashboard for visits over time

### DIFF
--- a/classes/WpMatomo/Report/views/table_map_no_dimension.php
+++ b/classes/WpMatomo/Report/views/table_map_no_dimension.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // if accessed directly
+}
+
+/** @var array $report */
+/** @var array $report_meta */
+/** @var string $first_metric_name */
+?>
+<div class="table">
+	<table class="widefat matomo-table">
+
+		<tbody>
+		<?php
+		$matomo_report_metadata = $report['reportMetadata'];
+		$matomo_tables = $report['reportData']->getDataTables();
+		foreach (array_reverse($matomo_tables)  as $matomo_report_date => $matomo_report_table ) {
+			/** @var \Piwik\DataTable\Simple $matomo_report_table  */
+			echo '<tr><td width="75%">' . esc_html( $matomo_report_date ) . '</td><td width="25%">';
+			if ($matomo_report_table->getFirstRow()) {
+				echo esc_html( $matomo_report_table->getFirstRow()->getColumn( $first_metric_name ) );
+			} else {
+				echo '-';
+			}
+			echo '</td></tr>';
+		}
+		?>
+		</tbody>
+	</table>
+</div>


### PR DESCRIPTION
refs https://wordpress.org/support/topic/add-reports-to-wordpress-dashboard/

for now can be only activated by setting a constant in wp-config.php

```php
define( 'MATOMO_SHOW_DASHBOARD_WIDGETS', true );
```

I didn't want to expose this to the UI yet as we need to see how we'll implement this in https://github.com/matomo-org/wp-matomo/issues/277