### PR TITLE
Make sure to make fields smaller before upgrading to utf8mb4

### DIFF
--- a/app/core/Updates/3.13.6-b1.php
+++ b/app/core/Updates/3.13.6-b1.php
@@ -21,8 +21,30 @@ class Updates_3_13_6_b1 extends PiwikUpdates
 
 	    if ($wpdb->charset === 'utf8mb4') {
 		    $db_settings = new \WpMatomo\Db\Settings();
+            $wpdb->query(sprintf('ALTER TABLE `%s` CHANGE `%s` `%s` %s',
+		                $db_settings->prefix_table_name('session'),
+		                'id', 'id', 'VARCHAR(191)'
+		    ));
+            $wpdb->query(sprintf('ALTER TABLE `%s` CHANGE `%s` `%s` %s',
+		                $db_settings->prefix_table_name('site_url'),
+		                'url', 'url', 'VARCHAR(190)'
+		    ));
+            $wpdb->query(sprintf('ALTER TABLE `%s` CHANGE `%s` `%s` %s',
+		                $db_settings->prefix_table_name('option'),
+		                'option_name', 'option_name', 'VARCHAR(191)'
+		    ));
+
 		    $installed_tables = $db_settings->get_installed_matomo_tables();
+
 		    if (!empty($installed_tables)) {
+			    foreach ($installed_tables as $table) {
+				    if (preg_match('/archive_/', $table) == 1) {
+					    $wpdb->query(sprintf('ALTER TABLE `%s` CHANGE `%s` `%s` %s',
+						    $table, 'name', 'name', 'VARCHAR(190)'
+					    ));
+				    }
+			    }
+
 			    foreach ($installed_tables as $installed_table) {
 			    	try {
 					    $wpdb->query('ALTER TABLE `'.$installed_table.'` CONVERT TO CHARACTER SET utf8mb4');


### PR DESCRIPTION
Fixes an upgrade issue mentioned in https://wordpress.org/support/topic/failed-to-login-with-version-1-1-0/#post-12884590 when Mysql setting is set to `innodb_large_prefix=0`.