### PR TITLE
Remove hard coded table names

### DIFF
--- a/classes/WpMatomo/Db/Settings.php
+++ b/classes/WpMatomo/Db/Settings.php
@@ -42,8 +42,6 @@ class Settings {
 		// list of existing temp tables
 		$table_names_to_look_for = array(
 			'access',
-			'archive_blob_2010_01',
-			'archive_numeric_2010_01',
 			'brute_force_log',
 			'goal',
 			'locks',


### PR DESCRIPTION
Was once needed I think to make the tests work but seems no longer needed. Tests work without it on travis and locally.