### PR TITLE
Fix Zend falsely assumes a session is already started

### DIFF
--- a/app/libs/Zend/Session.php
+++ b/app/libs/Zend/Session.php
@@ -478,13 +478,6 @@ class Zend_Session extends Zend_Session_Abstract
                . " output started in {$filename}/{$linenum}");
         }
 
-        // See http://www.php.net/manual/en/ref.session.php for explanation
-        if (!self::$_unitTestEnabled && defined('SID')) {
-            /** @see Zend_Session_Exception */
-            // require_once 'Zend/Session/Exception.php';
-            throw new Zend_Session_Exception('session has already been started by session.auto-start or session_start()');
-        }
-
         /**
          * Hack to throw exceptions on start instead of php errors
          * @see http://framework.zend.com/issues/browse/ZF-1325


### PR DESCRIPTION
fix https://wordpress.org/support/topic/an-error-occurred-session-already-started/#topic-12961322-replies