### PR TITLE
automatically use a primary key for log tmp table when required

### DIFF
--- a/app/core/DataAccess/LogAggregator.php
+++ b/app/core/DataAccess/LogAggregator.php
@@ -280,7 +280,9 @@ class LogAggregator
         if (defined('PIWIK_TEST_MODE') && PIWIK_TEST_MODE) {
             $engine = 'ENGINE=MEMORY';
         }
-        $createTableSql = 'CREATE TEMPORARY TABLE ' . $table . ' (idvisit  BIGINT(10) UNSIGNED NOT NULL) ' . $engine;
+
+	    $tempTableIdVisitColumn = 'idvisit  BIGINT(10) UNSIGNED NOT NULL';
+	    $createTableSql = 'CREATE TEMPORARY TABLE ' . $table . ' (' . $tempTableIdVisitColumn . ') ' . $engine;
         // we do not insert the data right away using create temporary table ... select ...
         // to avoid metadata lock see eg https://www.percona.com/blog/2018/01/10/why-avoid-create-table-as-select-statement/
 
@@ -290,8 +292,13 @@ class LogAggregator
         } catch (\Exception $e) {
             if ($readerDb->isErrNo($e, \Piwik\Updater\Migration\Db::ERROR_CODE_TABLE_EXISTS)) {
                 return;
+            } elseif ($readerDb->isErrNo($e, 1173) || $readerDb->isErrNo($e, 3750)) {
+	            $createTableSql = str_replace($tempTableIdVisitColumn, $tempTableIdVisitColumn . ', PRIMARY KEY (`idvisit`)', $createTableSql);
+
+	            $readerDb->query($createTableSql);
+            } else {
+	            throw $e;
             }
-            throw $e;
         }
 
         $transactionLevel = new Db\TransactionLevel($readerDb);


### PR DESCRIPTION
refs https://forum.matomo.org/t/matomo-on-digitalocean-managed-database-cluster-mysql-8-sql-require-primary-key-error/37623
refs https://github.com/matomo-org/matomo/pull/16290

if either `This table type requires a primary key SQL: CREATE TEMPORARY TABLE %s` or `General error: 3750 Unable to create or change a table without a primary key, when the system variable 'sql_require_primary_key' is set.` happens, automatically set a primary key for the log tmp table