### PR TITLE
Show opt out screen without using iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 == Changelog ==
 
+= 1.3.0 =
+* Changed opt out shortcode to no longer use an iframe and instead print the content directly
+* Automatically use a primary key for log tmp table when required
+* Various minor edge case fixes
+
 = 1.2.0 =
 * Update core to Matomo 3.14.0
 * Compatibility with WordPress 5.5.0

--- a/assets/js/optout.js
+++ b/assets/js/optout.js
@@ -1,5 +1,17 @@
 (function () {
     var cookiename = 'mtm_consent_removed';
+
+    function listen_event(e, type, callback) {
+        if (e.addEventListener) {
+            return e.addEventListener(type, callback, false);
+        }
+
+        if (e.attachEvent) {
+            return e.attachEvent('on' + type, callback);
+        }
+
+        e['on' + type] = callback;
+    }
     function by_id(id) {
         return document.getElementById(id);
     }
@@ -60,7 +72,7 @@
             return;
         }
 
-        by_id('matomo_optout_checkbox').addEventListener('change', function () {
+        listen_event(by_id('matomo_optout_checkbox'),'change', function () {
             var trackers = [];
             if ('object' === typeof window.Piwik && 'function' === typeof Piwik.getAsyncTrackers) {
                 trackers = Piwik.getAsyncTrackers();

--- a/assets/js/optout.js
+++ b/assets/js/optout.js
@@ -1,0 +1,93 @@
+(function () {
+    var cookiename = 'mtm_consent_removed';
+    function by_id(id) {
+        return document.getElementById(id);
+    }
+    function are_cookies_disabled() {
+        return navigator && !navigator.cookieEnabled;
+    }
+    function set_display(id, status)
+    {
+        var e = by_id(id);
+        if (e) {
+            e.style.display = status;
+        }
+    }
+    function is_opted_out() {
+        // piwik_ignore check for BC.
+        return document.cookie && (document.cookie.indexOf(cookiename + '=1') !== -1 || document.cookie.indexOf('piwik_ignore=') !== -1);
+    }
+    function update_status()
+    {
+        if (are_cookies_disabled()) {
+            set_display('matomo_outout_err_cookies', 'block');
+            set_display('matomo_optout_checkbox', 'none');
+        } else if (is_opted_out()) {
+            set_display('matomo_opted_out_intro', 'block');
+            set_display('matomo_opted_in_intro', 'none');
+            set_display('matomo_opted_out_label', 'inline');
+            set_display('matomo_opted_in_label', 'none');
+            by_id('matomo_optout_checkbox').checked = false;
+        } else {
+            set_display('matomo_opted_out_intro', 'none');
+            set_display('matomo_opted_in_intro', 'block');
+            set_display('matomo_opted_out_label', 'none');
+            set_display('matomo_opted_in_label', 'inline');
+            by_id('matomo_optout_checkbox').checked = true;
+        }
+    }
+    function on_ready(callback) {
+        if (document.readyState === 'complete' || document.readyState === 'interactive') {
+            setTimeout(callback, 1);
+        } else {
+            document.addEventListener('DOMContentLoaded', callback);
+        }
+    }
+
+    function set_cookie(name, val, expires, path, domain)
+    {
+        var cookie = name + '=' + val + ';expires=' + expires + ';SameSite=Lax;path=' + (path || '/');
+        if (domain) {
+            cookie += ';domain=' + domain;
+        }
+        document.cookie = cookie;
+    }
+
+    on_ready(function () {
+        update_status();
+
+        if (are_cookies_disabled()) {
+            return;
+        }
+
+        by_id('matomo_optout_checkbox').addEventListener('change', function () {
+            var trackers = [];
+            if ('object' === typeof window.Piwik && 'function' === typeof Piwik.getAsyncTrackers) {
+                trackers = Piwik.getAsyncTrackers();
+            }
+            var value = 0;
+            var expires = 'Thu, 01 Jan 1970 00:00:01 GMT'
+            if (is_opted_out()) {
+                // for BC additionally remove any set piwik_ignore cookie
+                set_cookie('piwik_ignore', 0, expires, '/');
+            } else {
+                value = 1;
+                var expire = new Date();
+                expire.setTime(expire.getTime() + (86400 * 365 * 30 * 1000));
+                expires = expire.toGMTString();
+            }
+
+            if (trackers.length) {
+                // respect tracker settings
+                for (var i = 0; i < trackers.length; i++) {
+                    set_cookie(cookiename, value, expires, trackers[i].getCookiePath(), trackers[i].getCookieDomain());
+                }
+            } else {
+                // fallback
+                set_cookie(cookiename, value, expires, '/');
+            }
+
+            update_status();
+        });
+    })
+})();

--- a/classes/WpMatomo/Admin/PrivacySettings.php
+++ b/classes/WpMatomo/Admin/PrivacySettings.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class PrivacySettings implements AdminSettingsInterface {
 	const EXAMPLE_MINIMAL = '[matomo_opt_out]';
-	const EXAMPLE_FULL    = '[matomo_opt_out language=de background_color=red font_color=fff font_size=34 font_family=Arial width=500px height=100px]';
+	const EXAMPLE_FULL    = '[matomo_opt_out language=de]';
 
     /**
      * @var Settings

--- a/classes/WpMatomo/Admin/views/privacy_gdpr.php
+++ b/classes/WpMatomo/Admin/views/privacy_gdpr.php
@@ -86,13 +86,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php esc_html_e( 'You can use these short code options:', 'matomo' ); ?>
 </p>
 <ul class="matomo-list">
-	<li>language - eg de or
-		en. <?php esc_html_e( 'By default the language is detected automatically based on the user\'s browser', 'matomo' ); ?></li>
-	<li>background_color - eg black or #000</li>
-	<li>font_color - eg black or #000</li>
-	<li>font_size - eg 15px</li>
-	<li>font_family - eg Arial or Verdana</li>
-	<li>width - eg 600, 600px or 100%</li>
-	<li>height - eg 200, 200px or 20%</li>
+	<li>language - eg de or en. <?php esc_html_e( 'By default the language is detected automatically based on the user\'s browser', 'matomo' ); ?></li>
 </ul>
 <p><?php esc_html_e( 'Example', 'matomo' ); ?>: <code><?php echo esc_html( PrivacySettings::EXAMPLE_FULL ); ?></code></p>

--- a/classes/WpMatomo/OptOut.php
+++ b/classes/WpMatomo/OptOut.php
@@ -21,11 +21,7 @@ class OptOut {
 	private $language = null;
 
 	public function register_hooks() {
-		// keeping this one temporarily so people can switch to iframe as a workaround until there's a fix for below solution
-		// just in case...
-		add_shortcode( 'matomo_opt_out_iframe', array( $this, 'show_opt_out_iframe' ) );
-
-		add_shortcode( 'matomo_opt_out', array( $this, 'show_opt_out_embedded' ) );
+		add_shortcode( 'matomo_opt_out', array( $this, 'show_opt_out' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'load_scripts' )  );
 	}
 
@@ -40,7 +36,7 @@ class OptOut {
 		return esc_html(Piwik::translate($id, array(), $this->language));
 	}
 
-	public function show_opt_out_embedded( $atts ) {
+	public function show_opt_out( $atts ) {
 		$a = shortcode_atts(
 			array(
 				'language' => null,
@@ -92,55 +88,6 @@ class OptOut {
 		$content .= '<noscript><p><strong style="color: #ff0000;">This opt out feature requires JavaScript.</strong></p></noscript>';
 		$content .= '<p id="matomo_outout_err_cookies" style="display: none;"><strong>' . $this->translate('CoreAdminHome_OptOutErrorNoCookies') . '</strong></p>';
 		return $content;
-	}
-
-	public function show_opt_out_iframe( $atts ) {
-		$a = shortcode_atts(
-			array(
-				'language'         => '',
-				'background_color' => '',
-				'font_color'       => '',
-				'font_size'        => '',
-				'font_family'      => '',
-				'width'            => '600',
-				'height'           => '200',
-			),
-			$atts
-		);
-
-		$url = plugins_url( 'app', MATOMO_ANALYTICS_FILE ) . '/index.php';
-
-		$map    = array(
-			'background_color' => 'backgroundColor',
-			'font_color'       => 'fontColor',
-			'font_size'        => 'fontSize',
-			'font_family'      => 'fontFamily',
-		);
-		$params = array(
-			'action' => 'matomo_optout',
-		);
-		if ( ! empty( $a['language'] ) ) {
-			$params['language'] = $a['language'];
-		}
-		foreach ( $map as $param => $urlparam ) {
-			if ( ! empty( $a[ $param ] ) ) {
-				$params[ $urlparam ] = rawurlencode( $a[ $param ] );
-			}
-		}
-
-		$url       = $url . '?' . http_build_query( $params );
-		$sizes     = array( 'width', 'height' );
-		$add_style = '';
-		foreach ( $sizes as $size ) {
-			if ( is_numeric( $a[ $size ] ) || preg_match( '/\d+px/', $a[ $size ] ) || preg_match( '/\d+%/', $a[ $size ] ) ) {
-				if ( is_numeric( $a[ $size ] ) ) {
-					$a[ $size ] = $a[ $size ] . 'px';
-				}
-				$add_style .= $size . ':' . $a[ $size ] . ';';
-			}
-		}
-
-		return '<iframe style="border: 0; ' . $add_style . '" src="' . $url . '"></iframe>';
 	}
 
 }

--- a/classes/WpMatomo/OptOut.php
+++ b/classes/WpMatomo/OptOut.php
@@ -9,17 +9,92 @@
 
 namespace WpMatomo;
 
+use Piwik\Piwik;
+use Piwik\Plugins\PrivacyManager\DoNotTrackHeaderChecker;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // if accessed directly
 }
 
 class OptOut {
 
+	private $language = null;
+
 	public function register_hooks() {
-		add_shortcode( 'matomo_opt_out', array( $this, 'show_opt_out' ) );
+		// keeping this one temporarily so people can switch to iframe as a workaround until there's a fix for below solution
+		// just in case...
+		add_shortcode( 'matomo_opt_out_iframe', array( $this, 'show_opt_out_iframe' ) );
+
+		add_shortcode( 'matomo_opt_out', array( $this, 'show_opt_out_embedded' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'load_scripts' )  );
 	}
 
-	public function show_opt_out( $atts ) {
+	public function load_scripts() {
+		if (!is_admin()) {
+			wp_register_script( 'matomo_opt_out_js', plugins_url( 'assets/js/optout.js', MATOMO_ANALYTICS_FILE ), array(), null, true );
+		}
+	}
+	
+	private function translate($id)
+	{
+		return esc_html(Piwik::translate($id, array(), $this->language));
+	}
+
+	public function show_opt_out_embedded( $atts ) {
+		$a = shortcode_atts(
+			array(
+				'language' => null,
+			),
+			$atts
+		);
+		if (!empty($a['language']) && strlen($a['language']) < 6) {
+			$this->language = $a['language'];
+		}
+
+		try {
+			Bootstrap::do_bootstrap();
+		} catch (\Throwable $e ) {
+			$logger = new Logger();
+			$logger->log_exception('optout', $e);
+			return '<p>An error occurred. Please check Matomo system report in WP-Admin.</p>';
+		}
+
+		$dnt_checker = new DoNotTrackHeaderChecker();
+		$dnt_enabled = $dnt_checker->isDoNotTrackFound();
+
+		if (!empty($dnt_enabled)) {
+			return '<p>'. $this->translate('CoreAdminHome_OptOutDntFound').'</p>';
+		}
+
+		wp_enqueue_script( 'matomo_opt_out_js' );
+
+		$track_visits = empty($_COOKIE['mtm_consent_removed']);
+
+		$style_tracking_enabled = '';
+		$style_tracking_disabled = '';
+		$checkbox_attr = '';
+		if ($track_visits) {
+			$style_tracking_enabled = 'style="display:none;"';
+			$checkbox_attr = 'checked="checked"';
+		} else {
+			$style_tracking_disabled = 'style="display:none;"';
+		}
+
+		$content = '<p id="matomo_opted_out_intro" ' . $style_tracking_enabled . '>' . $this->translate('CoreAdminHome_OptOutComplete') . ' '  . $this->translate('CoreAdminHome_OptOutCompleteBis') . '</p>';
+		$content .= '<p id="matomo_opted_in_intro" ' .$style_tracking_disabled . '>' . $this->translate('CoreAdminHome_YouMayOptOut2') . ' ' . $this->translate('CoreAdminHome_YouMayOptOut3') . '</p>';
+
+		$content .= '<form>
+        <input type="checkbox" id="matomo_optout_checkbox" '.$checkbox_attr.'/>
+        <label for="matomo_optout_checkbox"><strong>
+        <span id="matomo_opted_in_label" '.$style_tracking_disabled.'>'.$this->translate('CoreAdminHome_YouAreNotOptedOut') .' ' . $this->translate('CoreAdminHome_UncheckToOptOut') . '</span>
+		<span id="matomo_opted_out_label" '.$style_tracking_enabled.'>'.$this->translate('CoreAdminHome_YouAreOptedOut') .' ' . $this->translate('CoreAdminHome_CheckToOptIn') . '</span>
+        </strong></label></form>';
+		$content .= '<noscript><p><strong style="color: #ff0000;">This opt out feature requires JavaScript.</strong></p></noscript>';
+		$content .= '<p id="matomo_outout_err_cookies" style="display: none;"><strong>' . $this->translate('CoreAdminHome_OptOutErrorNoCookies') . '</strong></p>';
+		return $content;
+	}
+
+	public function show_opt_out_iframe( $atts ) {
 		$a = shortcode_atts(
 			array(
 				'language'         => '',
@@ -42,8 +117,7 @@ class OptOut {
 			'font_family'      => 'fontFamily',
 		);
 		$params = array(
-			'module' => 'CoreAdminHome',
-			'action' => 'optOut',
+			'action' => 'matomo_optout',
 		);
 		if ( ! empty( $a['language'] ) ) {
 			$params['language'] = $a['language'];

--- a/matomo.php
+++ b/matomo.php
@@ -4,7 +4,7 @@
  * Description: The #1 Google Analytics alternative that gives you full control over your data and protects the privacy for your users. Free, secure and open.
  * Author: Matomo
  * Author URI: https://matomo.org
- * Version: 1.2.0
+ * Version: 1.3.0
  * Domain Path: /languages
  * WC requires at least: 2.4.0
  * WC tested up to: 4.0.0

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_i
 Tags: matomo,piwik,analytics,statistics,stats,tracking,ecommerce
 Requires at least: 4.8
 Tested up to: 5.5
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 Requires PHP: 7.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/phpunit/wpmatomo/test-optout.php
+++ b/tests/phpunit/wpmatomo/test-optout.php
@@ -5,7 +5,7 @@ use WpMatomo\Admin\PrivacySettings;
 /**
  * @package matomo
  */
-class OptOutTest extends MatomoUnit_TestCase {
+class OptOutTest extends MatomoAnalytics_TestCase {
 
 	public function setUp() {
 		parent::setUp();
@@ -19,11 +19,6 @@ class OptOutTest extends MatomoUnit_TestCase {
 	public function test_matomo_opt_out_all_options() {
 		$result = do_shortcode( PrivacySettings::EXAMPLE_FULL );
 		$this->assertSame( '<iframe style="border: 0; width:500px;height:100px;" src="http://example.org/wp-content/plugins/matomo/app/index.php?module=CoreAdminHome&action=optOut&language=de&backgroundColor=red&fontColor=fff&fontSize=34&fontFamily=Arial"></iframe>', $result );
-	}
-
-	public function test_matomo_opt_out_size_percent_px_values() {
-		$result = do_shortcode( '[matomo_opt_out width=60px height=100%]' );
-		$this->assertContains( 'width:60px;height:100%', $result );
 	}
 
 	public function test_optOutJs_exists() {

--- a/tests/phpunit/wpmatomo/test-optout.php
+++ b/tests/phpunit/wpmatomo/test-optout.php
@@ -13,12 +13,22 @@ class OptOutTest extends MatomoAnalytics_TestCase {
 
 	public function test_matomo_opt_out_no_options() {
 		$result = do_shortcode( PrivacySettings::EXAMPLE_MINIMAL );
-		$this->assertSame( '<iframe style="border: 0; width:600px;height:200px;" src="http://example.org/wp-content/plugins/matomo/app/index.php?module=CoreAdminHome&action=optOut"></iframe>', $result );
+		$this->assertSame( '<p id="matomo_opted_out_intro" style="display:none;">Opt-out complete; your visits to this website will not be recorded by the Web Analytics tool. Note that if you clear your cookies, delete the opt-out cookie, or if you change computers or Web browsers, you will need to perform the opt-out procedure again.</p><p id="matomo_opted_in_intro" >You may choose to prevent this website from aggregating and analyzing the actions you take here. Doing so will protect your privacy, but will also prevent the owner from learning from your actions and creating a better experience for you and other users.</p><form>
+        <input type="checkbox" id="matomo_optout_checkbox" checked="checked"/>
+        <label for="matomo_optout_checkbox"><strong>
+        <span id="matomo_opted_in_label" >You are not opted out. Uncheck this box to opt-out.</span>
+		<span id="matomo_opted_out_label" style="display:none;">You are currently opted out. Check this box to opt-in.</span>
+        </strong></label></form><noscript><p><strong style="color: #ff0000;">This opt out feature requires JavaScript.</strong></p></noscript><p id="matomo_outout_err_cookies" style="display: none;"><strong>The tracking opt-out feature requires cookies to be enabled.</strong></p>', $result );
 	}
 
 	public function test_matomo_opt_out_all_options() {
 		$result = do_shortcode( PrivacySettings::EXAMPLE_FULL );
-		$this->assertSame( '<iframe style="border: 0; width:500px;height:100px;" src="http://example.org/wp-content/plugins/matomo/app/index.php?module=CoreAdminHome&action=optOut&language=de&backgroundColor=red&fontColor=fff&fontSize=34&fontFamily=Arial"></iframe>', $result );
+		$this->assertSame( '<p id="matomo_opted_out_intro" style="display:none;">Deaktivierung durchgeführt! Ihre Besuche auf dieser Webseite werden von der Webanalyse nicht mehr erfasst. Bitte beachten Sie, dass auch der Matomo-Deaktivierungs-Cookie dieser Webseite gelöscht wird, wenn Sie die in Ihrem Browser abgelegten Cookies entfernen. Außerdem müssen Sie, wenn Sie einen anderen Computer oder einen anderen Webbrowser verwenden, die Deaktivierungsprozedur nochmals absolvieren.</p><p id="matomo_opted_in_intro" >Sie haben die Möglichkeit zu verhindern, dass von Ihnen hier getätigte Aktionen analysiert und verknüpft werden. Dies wird Ihre Privatsphäre schützen, aber wird auch den Besitzer daran hindern, aus Ihren Aktionen zu lernen und die Bedienbarkeit für Sie und andere Benutzer zu verbessern.</p><form>
+        <input type="checkbox" id="matomo_optout_checkbox" checked="checked"/>
+        <label for="matomo_optout_checkbox"><strong>
+        <span id="matomo_opted_in_label" >Ihr Besuch dieser Webseite wird aktuell von der Matomo Webanalyse erfasst. Diese Checkbox abwählen für Opt-Out.</span>
+		<span id="matomo_opted_out_label" style="display:none;">Ihr Besuch dieser Webseite wird aktuell von der Matomo Webanalyse nicht erfasst. Diese Checkbox aktivieren für Opt-In.</span>
+        </strong></label></form><noscript><p><strong style="color: #ff0000;">This opt out feature requires JavaScript.</strong></p></noscript><p id="matomo_outout_err_cookies" style="display: none;"><strong>The tracking opt-out feature requires cookies to be enabled.</strong></p>', $result );
 	}
 
 	public function test_optOutJs_exists() {


### PR DESCRIPTION
refs https://wordpress.org/support/topic/opt-out-triggers-microsoft-defender-smartscreen/

We can no longer use the previous logic because MS Edge 85 and newer would show an "unsafe content" warning in the address bar and not load the iframe itself. This is caused by the Microsoft Defender SmartScreen. This seems to be only the case for Matomo for WordPress but not for regular Matomo On-Premise. My assumption is that because the opt out is embedded through `wp-content/plugins/matomo/app/index.php` MS seems to recognise it is a WordPress and usually such URLs aren't embedded directly.

I've tried to get in touch with Microsoft but have little hope there.

I've tried to workaround things to still load the iframe using `wp-admin/admin-ajax.php`. There were various problems some of them fixable:

* Eg optOut.js would not load but was fixable by adding `<base href="{{piwikUrl}}">`
* The window.open wouldn't work where it opts out the user didn't work because MS Defender would block the URL as well so we would have needed to route this through WP ajax URL as well. With some effort this would have been possible
* The opt out fallback using `postMessage` for some reason wasn't working. The iframe could post to the regular matomo.js but matomo.js could never post to the iframe for some reason. Debugger this for quite a while but no idea why it wouldn't work there.
* I'm not sure if it's a good practice to use the ajax URL in frontend as people might want to hide the admin URLs and this would expose it (might not be a big issue though and could alternatively also allow using WP JSON API or something)
* Not sure what else there was

Generally speaking could maybe make it work. Eventually figured it's easier to make it work by printing the content directly meaning the opt out would automatically get the styles of the current privacy policy which is a big plus. Few potential problems with this solution:

* We need to bootstrap Matomo while rendering the privacy policy which can make the page load for that page say 250ms slower. I'm catching any error should there be some issue for some reason while bootstrapping Matomo. So far we avoided doing this. There is a bigger performance gain though because the iframe does not need to be loaded.
* If a user uses a plugin to cache the entire page, then the status of whether user is opted in or out may not be correct. To fix this we automatically check the current status additionally in JS when the page is loaded and adjust it immediately. 
* Should someone cache the entire HTML there is still a problem that when a user from say Germany visits the privacy page then the content would be cached in German and English visitors would see the German content no matter what language the website is in. There are two workarounds
  * In the shortcode use the language parameter to force a language `[matomo_opt_out language=XX]`
  * Disable caching for the privacy page
* The opt out works by setting or deleting the `mtm_consent_removed` cookie. For BC I'm also dealing with the `piwik_ignore` cookie. I wanted to initially work with the `piwik_ignore` cookie but the problem is the cookie value would need to be encrypted and this value I cannot easily get in JS. I did not want to do any XHR requests or window.open to make this work. I wanted to have this purely in JS. I couldn't rely on tracker methods because the tracking code might not be embedded on that page, or because they don't use an async tracker, etc. 
* Should someone have multiple trackers on the current page things might not work correctly as the user would be mostly always opted out of the current domain but this should have been an issue before already. It should usually work for Matomo for WordPress because Matomo is hosted on the same domain as WordPress. It's bit difficult to explain and I don't know if there are any side effects but it should be all good.
* It requires JS to be enabled to opt out. We're showing a message should JS be disabled (and also if cookies aren't enabled)
* Works in IE8 and higher

fyi @Findus23 @mattab 