### PR TITLE
Add possibility to configure log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 1.3.1 =
+* Log less messages by default
+* Add possibility to disable logging and enable logging of all messages through wp-config.php
+
 = 1.3.0 =
 * Changed opt out shortcode to no longer use an iframe and instead print the content directly
 * Automatically use a primary key for log tmp table when required

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -615,19 +615,18 @@ class SystemReport {
 
 		if ( ! \WpMatomo::is_safe_mode() ) {
 			Bootstrap::do_bootstrap();
-
-			$tracking_failures = new Failures();
-
+			$trackfailures = [];
 			try {
-				$tracking_failures = $tracking_failures->getAllFailures();
+				$tracking_failures = new Failures();
+				$trackfailures = $tracking_failures->getAllFailures();
 			} catch (\Exception $e) {
-				$tracking_failures = [];
+				// ignored in case not set up yet etc.
 			}
-			if (!empty($tracking_failures)) {
+			if (!empty($trackfailures)) {
 				$rows[] = array(
 					'section' => 'Tracking failures',
 				);
-				foreach ($tracking_failures as $failure) {
+				foreach ($trackfailures as $failure) {
 					$comment = sprintf('Solution: %s<br>More info: %s<br>Date: %s<br>Request URL: %s',
 										$failure['solution'], $failure['solution_url'],
 										$failure['pretty_date_first_occurred'], $failure['request_url']);

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -617,7 +617,12 @@ class SystemReport {
 			Bootstrap::do_bootstrap();
 
 			$tracking_failures = new Failures();
-			$tracking_failures = $tracking_failures->getAllFailures();
+
+			try {
+				$tracking_failures = $tracking_failures->getAllFailures();
+			} catch (\Exception $e) {
+				$tracking_failures = [];
+			}
 			if (!empty($tracking_failures)) {
 				$rows[] = array(
 					'section' => 'Tracking failures',

--- a/classes/WpMatomo/Logger.php
+++ b/classes/WpMatomo/Logger.php
@@ -16,8 +16,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Logger {
+	const LEVEL_NONE = 99;
+	const LEVEL_DEBUG = 1;
+	const LEVEL_INFO = 3;
 
-	public function log( $message ) {
+	private function get_log_level()
+	{
+		if ( defined('MATOMO_DEBUG')) {
+			if (MATOMO_DEBUG) {
+				return self::LEVEL_DEBUG;
+			}
+			return self::LEVEL_NONE;
+		}
+
+		return self::LEVEL_INFO;
+	}
+
+	public function log( $message , $mode = 3) {
+		$log_level = $this->get_log_level();
+
+		if ($log_level > $mode) {
+			return;
+		}
+
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG === true ) {
 			if ( is_array( $message ) || is_object( $message ) ) {
 				error_log( 'Matomo: ' . print_r( $message, true ) );

--- a/classes/WpMatomo/TrackingCode.php
+++ b/classes/WpMatomo/TrackingCode.php
@@ -90,14 +90,14 @@ class TrackingCode {
 	 */
 	public function add_javascript_code() {
 		if ( $this->is_hidden_user() ) {
-			$this->logger->log( 'Do not add tracking code to site (user should not be tracked) Blog ID: ' . get_current_blog_id() );
+			$this->logger->log( 'Do not add tracking code to site (user should not be tracked) Blog ID: ' . get_current_blog_id(), Logger::LEVEL_DEBUG );
 
 			return;
 		}
 
 		$tracking_code = $this->generator->get_tracking_code();
 
-		$this->logger->log( 'Add tracking code. Blog ID: ' . get_current_blog_id() );
+		$this->logger->log( 'Add tracking code. Blog ID: ' . get_current_blog_id(), Logger::LEVEL_DEBUG );
 
 		if ( $this->settings->is_network_enabled()
 			 && 'manually' === $this->settings->get_global_option( 'track_mode' ) ) {
@@ -120,7 +120,7 @@ class TrackingCode {
 	 */
 	public function add_noscript_code() {
 		if ( $this->is_hidden_user() ) {
-			$this->logger->log( 'Do not add noscript code to site (user should not be tracked) Blog ID: ' . get_current_blog_id() );
+			$this->logger->log( 'Do not add noscript code to site (user should not be tracked) Blog ID: ' . get_current_blog_id(), Logger::LEVEL_DEBUG );
 
 			return;
 		}
@@ -128,10 +128,10 @@ class TrackingCode {
 		$code = $this->generator->get_noscript_code();
 
 		if ( ! empty( $code ) ) {
-			$this->logger->log( 'Add noscript code. Blog ID: ' . get_current_blog_id() );
+			$this->logger->log( 'Add noscript code. Blog ID: ' . get_current_blog_id(), Logger::LEVEL_DEBUG );
 			echo $code . "\n";
 		} else {
-			$this->logger->log( 'No noscript code present. Blog ID: ' . get_current_blog_id() );
+			$this->logger->log( 'No noscript code present. Blog ID: ' . get_current_blog_id(), Logger::LEVEL_DEBUG );
 		}
 	}
 

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -211,7 +211,9 @@ g.type=\'text/javascript\'; g.async=true; g.src="' . $container_url . '"; s.pare
 	 * @return array
 	 */
 	public function prepare_tracking_code( $idsite ) {
-		$this->logger->log( 'Apply tracking code changes:' );
+		$logLevel = is_admin() ? Logger::LEVEL_DEBUG : Logger::LEVEL_INFO;
+
+		$this->logger->log( 'Apply tracking code changes:', $logLevel );
 
 		$tracker_endpoint = $this->get_tracker_endpoint();
 		$js_endpoint      = $this->get_js_endpoint();
@@ -298,8 +300,8 @@ g.type='text/javascript'; g.async=true; g.src=" . wp_json_encode( $js_endpoint )
 		$script = apply_filters( 'matomo_tracking_code_script', $script, $idsite );
 		$script = apply_filters( 'matomo_tracking_code_noscript', $script, $idsite );
 
-		$this->logger->log( 'Finished tracking code: ' . $script );
-		$this->logger->log( 'Finished noscript code: ' . $no_script );
+		$this->logger->log( 'Finished tracking code: ' . $script, $logLevel );
+		$this->logger->log( 'Finished noscript code: ' . $no_script, $logLevel);
 
 		return array(
 			'script'   => $script,

--- a/tests/phpunit/wpmatomo/admin/test-systemreport.php
+++ b/tests/phpunit/wpmatomo/admin/test-systemreport.php
@@ -7,7 +7,7 @@ use WpMatomo\Admin\SystemReport;
 use WpMatomo\Roles;
 use WpMatomo\Settings;
 
-class AdminSystemReportTest extends MatomoUnit_TestCase {
+class AdminSystemReportTest extends MatomoAnalytics_TestCase {
 
 	/**
 	 * @var SystemReport

--- a/tests/phpunit/wpmatomo/admin/test-systemreport.php
+++ b/tests/phpunit/wpmatomo/admin/test-systemreport.php
@@ -7,7 +7,7 @@ use WpMatomo\Admin\SystemReport;
 use WpMatomo\Roles;
 use WpMatomo\Settings;
 
-class AdminSystemReportTest extends MatomoAnalytics_TestCase {
+class AdminSystemReportTest extends MatomoUnit_TestCase {
 
 	/**
 	 * @var SystemReport


### PR DESCRIPTION
refs https://wordpress.org/support/topic/only-log-messages-with-certain-log-level/#post-13472573

```
define( 'MATOMO_DEBUG', false );
```

will disable all logging done within the WP part

```
define( 'MATOMO_DEBUG', true );
```

will also log debug messages.