### PR TITLE
Use correct protocol for jQuery WP assets

### DIFF
--- a/plugins/WordPress/WpAssetManager.php
+++ b/plugins/WordPress/WpAssetManager.php
@@ -11,6 +11,7 @@ namespace Piwik\Plugins\WordPress;
 
 use Piwik\AssetManager;
 use Piwik\Plugins\WordPress\AssetManager\NeverDeleteOnDiskUiAsset;
+use Piwik\ProxyHttp;
 use Piwik\Translate;
 use Piwik\Version;
 
@@ -58,6 +59,11 @@ class WpAssetManager extends AssetManager
 
 		foreach ($jsFiles as $jsFile) {
 			$jQueryPath = includes_url('js/' . $jsFile);
+			if (ProxyHttp::isHttps()) {
+				$jQueryPath = str_replace('http://', 'https://', $jQueryPath);
+			} else {
+				$jQueryPath = str_replace('http://', '//', $jQueryPath);
+			}
 			$result .= sprintf(self::JS_IMPORT_DIRECTIVE, $jQueryPath);
 		}
 


### PR DESCRIPTION
refs https://github.com/matomo-org/wp-matomo/issues/358

Seems WordPress is falsely returning an http URL. If HTTPS is used, we can force HTTPS over HTTP. Otherwise use same protocol as requested in case it is behind proxy or similar.