### PR TITLE
Only delete users from Matomo user table when the WP user was deleted

### DIFF
--- a/classes/WpMatomo/User.php
+++ b/classes/WpMatomo/User.php
@@ -30,6 +30,18 @@ class User {
 		return get_option( self::USER_MAPPING_PREFIX . $wp_user_id );
 	}
 
+	public static function try_find_wp_user_id_from_matomo_login( $matomo_user_login ) {
+		global $wpdb;
+		$row = $wpdb->get_row( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE '" . self::USER_MAPPING_PREFIX . "%' and option_value = %;", $matomo_user_login );
+
+		if (!empty($row->option_name)){
+			$val = str_replace(self::USER_MAPPING_PREFIX, '', $row->option_name);
+			if (is_numeric($val)) {
+				return $val;
+			}
+		}
+	}
+
 	public static function map_matomo_user_login( $wp_user_id, $matomo_user_login ) {
 		if ( empty( $matomo_user_login ) ) {
 			delete_option( self::USER_MAPPING_PREFIX . $wp_user_id );

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -98,7 +98,7 @@ class Sync {
 		        }
 	        }
 	        if (!$found) {
-	        	$users[] = $user;
+	        	$users[] = $current_user;
 	        }
         }
 

--- a/tests/phpunit/wpmatomo/test-user.php
+++ b/tests/phpunit/wpmatomo/test-user.php
@@ -87,6 +87,14 @@ class UserTest extends MatomoUnit_TestCase {
 		$this->assertFalse( User::get_matomo_user_login( 5 ) );
 	}
 
+	public function test_try_find_wp_user_id_from_matomo_login() {
+		$this->assertNull(User::try_find_wp_user_id_from_matomo_login( 'myMatomoLogin' ) );
+
+		User::map_matomo_user_login( 5, 'myMatomoLogin' );
+
+		$this->assertEquals(5, User::try_find_wp_user_id_from_matomo_login( 'myMatomoLogin' ) );
+	}
+
 	public function test_uninstall_removes_all_mappings() {
 		User::map_matomo_user_login( 5, 'myMatomoLogin' );
 		$this->assertNotEmpty( User::get_matomo_user_login( 5 ) );

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -243,7 +243,7 @@ class UserSyncTest extends MatomoAnalytics_TestCase {
 		);
 
 		$user = get_user_by( 'login', 'admin2' );
-		wp_delete_user( $user->ID );
+		self::delete_user( $user->ID );
 		$id6 = self::factory()->user->create(
 			array(
 				'role'       => 'administrator',

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -200,6 +200,12 @@ class UserSyncTest extends MatomoAnalytics_TestCase {
 
 		$idsite = $this->get_current_site_id();
 
+		$access = $model->getUsersAccessFromSite($idsite);
+		$this->assertEquals([    'author1' => 'view',
+			'author2' => 'view',
+			'editor1' => 'write',
+			'editor2' => 'write',], $access);
+
 		$view_access = $model->getUsersSitesFromAccess( 'view' );
 		$this->assertEquals(
 			array(
@@ -255,12 +261,18 @@ class UserSyncTest extends MatomoAnalytics_TestCase {
 				'admin',
 				'admin1',
 				'admin4',
+				'author1',
+				'author2',
 				'contributor1',
 				'editor1',
 				'editor2',
 			),
 			$logins
 		);
+		$access = $model->getUsersAccessFromSite($idsite);
+		$this->assertEquals([  'contributor1' => 'view',
+			'editor1' => 'admin',
+			'editor2' => 'admin',], $access);
 
 		$view_access = $model->getUsersSitesFromAccess( 'view' );
 		$this->assertEquals( array( 'contributor1' => array( $idsite ) ), $view_access );
@@ -294,19 +306,27 @@ class UserSyncTest extends MatomoAnalytics_TestCase {
 				'admin',
 				'admin1',
 				'admin4',
+				'author1',
+				'author2',
 				'contributor1',
 				'editor1',
 				'editor2',
 			),
 			$logins
 		);
+		$access = $model->getUsersAccessFromSite($idsite);
+		$this->assertEquals([      'editor1' => 'admin',
+			'contributor1' => 'view',
+			'editor2' => 'admin',
+		], $access);
+
 
 		foreach ( array( 'admin', 'admin1', 'admin4', 'editor1' ) as $user_login ) {
 			$matomo_user = $this->get_matomo_user( $user_login );
 			$this->assertEquals( '1', $matomo_user['superuser_access'] );
 		}
 
-		foreach ( array( 'contributor1', 'editor2' ) as $user_login ) {
+		foreach ( array( 'contributor1', 'editor2', 'author1', 'author2'  ) as $user_login ) {
 			$matomo_user = $this->get_matomo_user( $user_login );
 			$this->assertEquals( '0', $matomo_user['superuser_access'] );
 		}
@@ -321,10 +341,33 @@ class UserSyncTest extends MatomoAnalytics_TestCase {
 			$matomo_user = $this->get_matomo_user( $user_login );
 			$this->assertEquals( '1', $matomo_user['superuser_access'] );
 		}
-		foreach ( array( 'editor1', 'editor2' ) as $user_login ) {
+		foreach ( array( 'editor1', 'editor2', 'author1', 'author2' ) as $user_login ) {
 			$matomo_user = $this->get_matomo_user( $user_login );
 			$this->assertEquals( '0', $matomo_user['superuser_access'] );
 		}
+
+		// now we delete a user and it should remove them from matomo user table
+		self::delete_user(get_user_by('login', 'author1')->ID);
+		self::delete_user(get_user_by('login', 'editor2')->ID);
+		self::delete_user(get_user_by('login', 'admin4')->ID);
+
+		$this->sync->sync_current_users();
+
+		$logins = $model->getUsersLogin();
+		$this->assertSame(
+			array(
+				'admin',
+				'admin1',
+				'author2',
+				'contributor1',
+				'editor1',
+			),
+			$logins
+		);
+		$access = $model->getUsersAccessFromSite($idsite);
+		$this->assertEquals([        'contributor1' => 'view',
+			'editor1' => 'admin',
+		], $access);
 
 		$caps->remove_hooks();
 	}


### PR DESCRIPTION
fix #365 