### PR TITLE
Start supporting Matomo offline tracking feature

### DIFF
--- a/classes/WpMatomo/Admin/TrackingSettings.php
+++ b/classes/WpMatomo/Admin/TrackingSettings.php
@@ -9,6 +9,7 @@
 
 namespace WpMatomo\Admin;
 
+use Ds\Set;
 use WpMatomo\Capabilities;
 use WpMatomo\Settings;
 use WpMatomo\Site;
@@ -97,7 +98,8 @@ class TrackingSettings implements AdminSettingsInterface {
 			'track_js_endpoint',
 			'track_jserrors',
 			'track_api_endpoint',
-			Settings::SITE_CURRENCY
+			Settings::SITE_CURRENCY,
+			Settings::USE_OFFLINE_TRACKING
 		);
 
 		if ( matomo_has_tag_manager() ) {

--- a/classes/WpMatomo/Admin/views/tracking.php
+++ b/classes/WpMatomo/Admin/views/tracking.php
@@ -189,6 +189,9 @@ if ( $was_updated ) {
 			$matomo_is_not_tracking,
 			$matomo_full_generated_tracking_group . ' matomo-track-option-tagmanager'
 		);
+
+		$matomo_form->show_checkbox( 'enable_offline_tracking', esc_html__( 'Enable Offline Tracking (beta)', 'matomo' ), 'When enabled, will load a service worker to keep tracking users when they are offline. Will only work when using HTTPS. This feature is currently in beta. Please report any issues to us. Before using it in production please test our service worker won\'t break anything. <a href="https://matomo.org/faq/how-to/how-do-i-set-up-matomo-offline-tracking/" target="_blank" rel="noreferrer noopener">Learn more</a>', $matomo_is_not_generated_tracking, $matomo_full_generated_tracking_group );
+
 		$matomo_form->show_select(
 			'track_api_endpoint',
 			__( 'Endpoint for HTTP Tracking API', 'matomo' ),

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -33,6 +33,7 @@ class Settings {
 	const DELETE_ALL_DATA_ON_UNINSTALL         = 'delete_all_data_uninstall';
 	const SITE_CURRENCY                        = 'site_currency';
 	const NETWORK_CONFIG_OPTIONS               = 'config_options';
+	const USE_OFFLINE_TRACKING                 = 'enable_offline_tracking';
 
 	public static $is_doing_action_tracking_related = false;
 	/**
@@ -96,16 +97,17 @@ class Settings {
 		'track_across'                             => false,
 		'track_across_alias'                       => false,
 		'track_crossdomain_linking'                => false,
-		'track_feed'                               => false,
-		'track_feed_addcampaign'                   => false,
-		'track_feed_campaign'                      => 'feed',
-		'track_heartbeat'                          => 0,
-		'track_user_id'                            => 'disabled',
-		'track_datacfasync'                        => false,
-		'track_jserrors'                           => false,
-		'force_protocol'                           => 'disabled',
-		'maxmind_license_key'                      => '',
-		self::SHOW_GET_STARTED_PAGE                => 1,
+		'track_feed'                => false,
+		'track_feed_addcampaign'    => false,
+		'track_feed_campaign'       => 'feed',
+		'track_heartbeat'           => 0,
+		'track_user_id'             => 'disabled',
+		'track_datacfasync'         => false,
+		'track_jserrors'            => false,
+		'force_protocol'            => 'disabled',
+		'maxmind_license_key'       => '',
+		self::SHOW_GET_STARTED_PAGE => 1,
+		self::USE_OFFLINE_TRACKING  => false,
 	);
 
 	/**

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -300,6 +300,17 @@ g.type='text/javascript'; g.async=true; g.src=" . wp_json_encode( $js_endpoint )
 
 		$no_script = '<noscript><p><img referrerpolicy="no-referrer-when-downgrade" src="' . esc_url( $tracker_endpoint ) . '?idsite=' . intval( $idsite ) . '&amp;rec=1" style="border:0;" alt="" /></p></noscript>';
 
+		if ($this->settings->get_global_option('enable_offline_tracking')) {
+			$script .= '<script>
+if (\'serviceWorker\' in navigator) {
+// todo need to create that service worker and call init etc
+    window.addEventListener(\'load\', function() {
+        navigator.serviceWorker.register(\'/your-service-worker.js\'); 
+    });
+}
+</script>';
+		}
+
 		$script = apply_filters( 'matomo_tracking_code_script', $script, $idsite );
 		$script = apply_filters( 'matomo_tracking_code_noscript', $script, $idsite );
 


### PR DESCRIPTION
Need to see if this can work and explain more. Like I think there can't be two service workers intercepting these requests etc. so it will only work in some cases.

Comment in https://wordpress.org/support/topic/new-offline-feature-for-matomo-piwik/ when it's merged