### PR TITLE
Track ecommerce data using direct tracker call when tag manager is being used

### DIFF
--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -9,6 +9,7 @@
 
 namespace WpMatomo\Ecommerce;
 
+use WpMatomo\Admin\TrackingSettings;
 use WpMatomo\Logger;
 use WpMatomo\Settings;
 use WpMatomo\AjaxTracker;
@@ -70,12 +71,13 @@ class Base {
 		update_post_meta( $order_id, $this->key_order_tracked, 1 );
 	}
 
-	protected function is_doing_ajax() {
-		return defined( 'DOING_AJAX' ) && DOING_AJAX;
+	protected function should_track_background() {
+		return (defined( 'DOING_AJAX' ) && DOING_AJAX)
+		     || \WpMatomo::$settings->get_global_option('track_mode') === TrackingSettings::TRACK_MODE_TAGMANAGER;
 	}
 
 	protected function make_matomo_js_tracker_call( $params ) {
-		if ( $this->is_doing_ajax() ) {
+		if ( $this->should_track_background() ) {
 			$this->ajax_tracker_calls[] = $params;
 		}
 
@@ -83,7 +85,7 @@ class Base {
 	}
 
 	protected function wrap_script( $script ) {
-		if ( $this->is_doing_ajax() ) {
+		if ( $this->should_track_background() ) {
 			foreach ( $this->ajax_tracker_calls as $call ) {
 				$methods = array(
 					'addEcommerceItem'         => 'addEcommerceItem',

--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -31,7 +31,7 @@ class Woocommerce extends Base {
 		add_action( 'woocommerce_cart_item_set_quantity', array( $this, 'on_cart_updated_safe' ), 99999, 0 );
 		add_action('woocommerce_thankyou',  array($this, 'anonymise_orderid_in_url'), 1, 1);
 
-		if (!$this->is_doing_ajax()) {
+		if (!$this->should_track_background()) {
 			// prevent possibly executing same event twice where eg first a PHP Matomo tracker request is created
 			// because of woocommerce_applied_coupon and then also because of woocommerce_update_cart_action_cart_updated itself
 			// causing two tracking requests to be issues from the server. refs #215


### PR DESCRIPTION
refs https://wordpress.org/support/topic/archive-warning-error-unserializing-wp_matomo_logtmpsegment/#post-14030042

This be only a workaround for the original problem of using `_paq.push` when also using tag manager.

What happens when using tag manager and tracking ecommerce data:

* _paq.push('setEcommerceView') (or addEcommerceItem etc) is called
* The container is loaded
* At the beginning of container the Matomo tracking code is initaliazed
* It notices a _paq.push and creates a new tracker but there is no idSite and no tracking URL so it sets the ecommerce view or tracks ecommerce cart and checkouts on an unconfigured tracker
* Then the tag manager is initialised and it creates a new tracker for the given idSite and trackerURL and it won't be notified about this _paq.push

I've been looking for a fix for this for a long time trying various different approaches but they all don't work so far. I will create an issue for this in the tag manager repository where we need to see if/how this can be fixed. It might need a big refactoring of tracking code and/or tag manager.