### PR TITLE
Fix incompatibility with Akeeba Backup plugin

### DIFF
--- a/plugins/WordPress/Logger.php
+++ b/plugins/WordPress/Logger.php
@@ -92,6 +92,46 @@ class Logger extends AbstractLogger implements LoggerInterface
 		return $level;
 	}
 
+	public function emergency($message, array $context = [])
+	{
+		$this->log(self::EMERGENCY, $message, $context);
+	}
+
+	public function alert($message, array $context = [])
+	{
+		$this->log(self::ALERT, $message, $context);
+	}
+
+	public function critical($message, array $context = array())
+	{
+		$this->log(self::CRITICAL, $message, $context);
+	}
+
+	public function error($message, array $context = [])
+	{
+		$this->log(self::ERROR, $message, $context);
+	}
+
+	public function warning($message, array $context = [])
+	{
+		$this->log(self::WARNING, $message, $context);
+	}
+
+	public function debug($message, array $context = [])
+	{
+		$this->log(self::DEBUG, $message, $context);
+	}
+
+	public function notice($message, array $context = [])
+	{
+		$this->log(self::NOTICE, $message, $context);
+	}
+
+	public function info($message, array $context = [])
+	{
+		$this->log(self::INFO, $message, $context);
+	}
+
 	/**
 	 * Logs with an arbitrary level.
 	 *


### PR DESCRIPTION
see https://forum.matomo.org/t/matomo-wordpress-akeeba-backup-resources-problem/41112

Problem was they also defined an `abstract class AbstractLogger implements LoggerInterface` but eg the method looked like this:

```php
	public function info($message, array $context = [])
	{
		$this->info($message, $context);
	}
```

instead of what our PSR AbstractLogger does:

```
    public function info($message, array $context = array())
    {
        $this->log(LogLevel::INFO, $message, $context);
    }
```

Hoping adding these methods won't cause issues where people might use yet a different version of AbstractLogger and different parameter definition or so.