### PR TITLE
redirect to the getting started page after activation if the tracking…

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -27,13 +27,13 @@ use \WpMatomo\Updater;
 use \WpMatomo\Roles;
 use \WpMatomo\Annotations;
 use \WpMatomo\TrackingCode;
-use \WpMatomo\Admin\TrackingSettings;
 use \WpMatomo\Settings;
 use \WpMatomo\Capabilities;
 use \WpMatomo\Ecommerce\Woocommerce;
 use \WpMatomo\Report\Renderer;
 use WpMatomo\API;
 use \WpMatomo\Admin\Admin;
+use WpMatomo\RedirectOnActivation;
 
 class WpMatomo {
 
@@ -96,6 +96,12 @@ class WpMatomo {
 			if ( $referral->should_show() ) {
 				$referral->register_hooks();
 			}
+
+			/*
+			 * @see https://github.com/matomo-org/matomo-for-wordpress/issues/434
+			 */
+			$redirect = new RedirectOnActivation($this);
+			$redirect->register_hooks();
 		}
 
 		$tracking_code = new TrackingCode( self::$settings );
@@ -241,28 +247,5 @@ class WpMatomo {
 
 	public static function should_disable_addhandler() {
 		return defined( 'MATOMO_DISABLE_ADDHANDLER' ) && MATOMO_DISABLE_ADDHANDLER;
-	}
-
-	/**
-	 * We don't test the result of the wp_redirect method and we silent this method
-	 * as this method will not work during unit tests.
-	 * We just return if yes or no we should redirect
-	 *
-	 * @see https://github.com/matomo-org/matomo-for-wordpress/issues/434
-	 * @return boolean
-	 */
-	public function redirect_to_getting_started() {
-		$redirect = false;
-		if(!isset($_GET['activate-multi'])) {
-			if
-			(
-				( self::$settings->get_global_option( Settings::SHOW_GET_STARTED_PAGE ) === 1 ) &&
-				( self::$settings->get_global_option( 'track_mode' ) === TrackingSettings::TRACK_MODE_DISABLED )
-			) {
-				$redirect = true;
-				@wp_redirect( admin_url( 'admin.php?page=matomo-get-started' ) );
-			}
-		}
-		return $redirect;
 	}
 }

--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -257,7 +257,7 @@ class WpMatomo {
 			if
 			(
 				( self::$settings->get_global_option( Settings::SHOW_GET_STARTED_PAGE ) === 1 ) &&
-				( self::$settings->get_global_option( 'track_mode' ) !== TrackingSettings::TRACK_MODE_DISABLED )
+				( self::$settings->get_global_option( 'track_mode' ) === TrackingSettings::TRACK_MODE_DISABLED )
 			) {
 				$redirect = true;
 				@wp_redirect( admin_url( 'admin.php?page=matomo-get-started' ) );

--- a/classes/WpMatomo/RedirectOnActivation.php
+++ b/classes/WpMatomo/RedirectOnActivation.php
@@ -22,8 +22,7 @@ class RedirectOnActivation {
 	}
 
 	public function register_hooks() {
-		$file = realpath(dirname(__FILE__).'/../../matomo.php');
-		register_activation_hook($file, [ $this, 'matomo_activate' ] );
+		register_activation_hook(MATOMO_ANALYTICS_FILE, [ $this, 'matomo_activate' ] );
 		add_action( 'admin_init', [ $this, 'matomo_plugin_redirect' ] );
 	}
 

--- a/classes/WpMatomo/RedirectOnActivation.php
+++ b/classes/WpMatomo/RedirectOnActivation.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+namespace WpMatomo;
+class RedirectOnActivation {
+	/**
+	 * @var WpMatomo
+	 */
+	public $wpMatomo;
+
+	public function __construct(\WpMatomo $wpMatomo) {
+		$this->wpMatomo = $wpMatomo;
+	}
+
+	public function register_hooks() {
+		$file = realpath(dirname(__FILE__).'/../../matomo.php');
+		register_activation_hook($file, [ $this, 'matomo_activate' ] );
+		add_action( 'admin_init', [ $this, 'matomo_plugin_redirect' ] );
+	}
+
+	public function matomo_activate() {
+		add_option( 'matomo_plugin_do_activation_redirect', true );
+	}
+
+	public function matomo_plugin_redirect() {
+		if ( get_option( 'matomo_plugin_do_activation_redirect', false ) ) {
+			delete_option( 'matomo_plugin_do_activation_redirect' );
+			$this->wpMatomo->redirect_to_getting_started();
+		}
+	}
+}

--- a/classes/WpMatomo/RedirectOnActivation.php
+++ b/classes/WpMatomo/RedirectOnActivation.php
@@ -8,14 +8,17 @@
  */
 
 namespace WpMatomo;
+
+use \WpMatomo\Admin\TrackingSettings;
+
 class RedirectOnActivation {
 	/**
-	 * @var WpMatomo
+	 * @var Settings
 	 */
-	public $wpMatomo;
+	public static $settings;
 
-	public function __construct(\WpMatomo $wpMatomo) {
-		$this->wpMatomo = $wpMatomo;
+	public function __construct() {
+		self::$settings = new Settings();
 	}
 
 	public function register_hooks() {
@@ -31,7 +34,29 @@ class RedirectOnActivation {
 	public function matomo_plugin_redirect() {
 		if ( get_option( 'matomo_plugin_do_activation_redirect', false ) ) {
 			delete_option( 'matomo_plugin_do_activation_redirect' );
-			$this->wpMatomo->redirect_to_getting_started();
+			$this->redirect_to_getting_started();
 		}
+	}
+	/**
+	 * We don't test the result of the wp_redirect method and we silent this method
+	 * as this method will not work during unit tests.
+	 * We just return if yes or no we should redirect
+	 *
+	 * @see https://github.com/matomo-org/matomo-for-wordpress/issues/434
+	 * @return boolean
+	 */
+	public function redirect_to_getting_started() {
+		$redirect = false;
+		if(!isset($_GET['activate-multi'])) {
+			if
+			(
+				( self::$settings->get_global_option( Settings::SHOW_GET_STARTED_PAGE ) === 1 ) &&
+				( self::$settings->get_global_option( 'track_mode' ) === TrackingSettings::TRACK_MODE_DISABLED )
+			) {
+				$redirect = true;
+				@wp_redirect( admin_url( 'admin.php?page=matomo-get-started' ) );
+			}
+		}
+		return $redirect;
 	}
 }

--- a/matomo.php
+++ b/matomo.php
@@ -15,8 +15,6 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  * @package matomo
  */
-use WpMatomo\RedirectOnActivation;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // if accessed directly
 }
@@ -207,10 +205,4 @@ if (matomo_is_app_request() || !empty($GLOBALS['MATOMO_LOADED_DIRECTLY'])) {
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'WpMatomo.php';
 require 'shared.php';
 matomo_add_plugin( __DIR__ . '/plugins/WordPress', MATOMO_ANALYTICS_FILE );
-$wpMatomo = new WpMatomo();
-
-/*
- * @see https://github.com/matomo-org/matomo-for-wordpress/issues/434
- */
-$redirect = new RedirectOnActivation($wpMatomo);
-$redirect->register_hooks();
+new WpMatomo();

--- a/matomo.php
+++ b/matomo.php
@@ -15,6 +15,7 @@
  * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
  * @package matomo
  */
+use WpMatomo\RedirectOnActivation;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // if accessed directly
@@ -211,16 +212,5 @@ $wpMatomo = new WpMatomo();
 /*
  * @see https://github.com/matomo-org/matomo-for-wordpress/issues/434
  */
-register_activation_hook(__FILE__, 'matomo_activate');
-add_action('admin_init', 'matomo_plugin_redirect');
-
-function matomo_activate() {
-    add_option('matomo_plugin_do_activation_redirect', true);
-}
-function matomo_plugin_redirect() {
-    if (get_option('matomo_plugin_do_activation_redirect', false)) {
-        delete_option('matomo_plugin_do_activation_redirect');
-            global $wpMatomo;
-            $wpMatomo->redirect_to_getting_started();
-    }
-}
+$redirect = new RedirectOnActivation($wpMatomo);
+$redirect->register_hooks();

--- a/matomo.php
+++ b/matomo.php
@@ -206,4 +206,21 @@ if (matomo_is_app_request() || !empty($GLOBALS['MATOMO_LOADED_DIRECTLY'])) {
 require_once __DIR__ . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'WpMatomo.php';
 require 'shared.php';
 matomo_add_plugin( __DIR__ . '/plugins/WordPress', MATOMO_ANALYTICS_FILE );
-new WpMatomo();
+$wpMatomo = new WpMatomo();
+
+/*
+ * @see https://github.com/matomo-org/matomo-for-wordpress/issues/434
+ */
+register_activation_hook(__FILE__, 'matomo_activate');
+add_action('admin_init', 'matomo_plugin_redirect');
+
+function matomo_activate() {
+    add_option('matomo_plugin_do_activation_redirect', true);
+}
+function matomo_plugin_redirect() {
+    if (get_option('matomo_plugin_do_activation_redirect', false)) {
+        delete_option('matomo_plugin_do_activation_redirect');
+            global $wpMatomo;
+            $wpMatomo->redirect_to_getting_started();
+    }
+}

--- a/tests/phpunit/wpmatomo/admin/test-install.php
+++ b/tests/phpunit/wpmatomo/admin/test-install.php
@@ -9,7 +9,7 @@ use \WpMatomo\Admin\TrackingSettings;
 
 class AdminInstallTest extends MatomoUnit_TestCase {
     /**
-     * @var
+     * @var |WpMatomo
      */
     private $_wpMatomo;
 
@@ -43,11 +43,11 @@ class AdminInstallTest extends MatomoUnit_TestCase {
         $settings->set_global_option(Settings::SHOW_GET_STARTED_PAGE, 1);
         $settings->set_global_option('track_mode', TrackingSettings::TRACK_MODE_DISABLED);
         $settings->save();
-        $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
+        $this->assertTrue($this->_wpMatomo->redirect_to_getting_started());
         // show getting started and track mode different of disabled
         $settings->set_global_option('track_mode', TrackingSettings::TRACK_MODE_DEFAULT);
         $settings->save();
-        $this->assertTrue($this->_wpMatomo->redirect_to_getting_started());
+        $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
 	    $_GET['activate-multi'] = true;
 	    $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
 	    // restore initial configuration

--- a/tests/phpunit/wpmatomo/admin/test-install.php
+++ b/tests/phpunit/wpmatomo/admin/test-install.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @package matomo
+ */
+
+use WpMatomo\Roles;
+use \WpMatomo\Settings;
+use \WpMatomo\Admin\TrackingSettings;
+
+class AdminInstallTest extends MatomoUnit_TestCase {
+    /**
+     * @var
+     */
+    private $_wpMatomo;
+
+    public function setUp() {
+        parent::setUp();
+
+        $this->_wpMatomo = new WpMatomo();
+
+        wp_get_current_user()->add_role( Roles::ROLE_SUPERUSER );
+
+        $this->assume_admin_page();
+    }
+
+    public function tearDown() {
+        $this->reset_roles();
+        parent::tearDown();
+    }
+
+    public function test_redirect_to_getting_started() {
+        // load the options of the wpmatomo object. otherwise it's another instance and updating configuration will do nothing
+    	$settings = $this->_wpMatomo::$settings;
+        $original_show_get_started_page = $settings->get_global_option( Settings::SHOW_GET_STARTED_PAGE);
+        $original_tracking_mode = $settings->get_global_option('track_mode');
+	    $is_multi = isset($_GET['activate-multi']) ? $_GET['activate-multi'] : false;
+	    unset($_GET['activate-multi']);
+        // show starting page is disabled
+        $settings->set_global_option(Settings::SHOW_GET_STARTED_PAGE, 0);
+        $settings->save();
+        $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
+        // show starting page is enabled but track mode is disabled
+        $settings->set_global_option(Settings::SHOW_GET_STARTED_PAGE, 1);
+        $settings->set_global_option('track_mode', TrackingSettings::TRACK_MODE_DISABLED);
+        $settings->save();
+        $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
+        // show getting started and track mode different of disabled
+        $settings->set_global_option('track_mode', TrackingSettings::TRACK_MODE_DEFAULT);
+        $settings->save();
+        $this->assertTrue($this->_wpMatomo->redirect_to_getting_started());
+	    $_GET['activate-multi'] = true;
+	    $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
+	    // restore initial configuration
+        $settings->set_global_option('track_mode',  $original_tracking_mode);
+        $settings->set_global_option(Settings::SHOW_GET_STARTED_PAGE,  $original_show_get_started_page);
+        if ($is_multi !== false) {
+        	$_GET['activate-multi'] = $is_multi;
+        } else {
+        	unset($_GET['activate-multi']);
+        }
+        $settings->save();
+    }
+}

--- a/tests/phpunit/wpmatomo/admin/test-install.php
+++ b/tests/phpunit/wpmatomo/admin/test-install.php
@@ -6,17 +6,18 @@
 use WpMatomo\Roles;
 use \WpMatomo\Settings;
 use \WpMatomo\Admin\TrackingSettings;
+use \WpMatomo\RedirectOnActivation;
 
 class AdminInstallTest extends MatomoUnit_TestCase {
-    /**
-     * @var |WpMatomo
-     */
-    private $_wpMatomo;
+	/**
+	 * @var \WpMatomo\RedirectOnActivation
+	 */
+    private $_redirect;
 
     public function setUp() {
         parent::setUp();
 
-        $this->_wpMatomo = new WpMatomo();
+        $this->_redirect = new RedirectOnActivation();
 
         wp_get_current_user()->add_role( Roles::ROLE_SUPERUSER );
 
@@ -30,7 +31,7 @@ class AdminInstallTest extends MatomoUnit_TestCase {
 
     public function test_redirect_to_getting_started() {
         // load the options of the wpmatomo object. otherwise it's another instance and updating configuration will do nothing
-    	$settings = $this->_wpMatomo::$settings;
+    	$settings = $this->_redirect::$settings;
         $original_show_get_started_page = $settings->get_global_option( Settings::SHOW_GET_STARTED_PAGE);
         $original_tracking_mode = $settings->get_global_option('track_mode');
 	    $is_multi = isset($_GET['activate-multi']) ? $_GET['activate-multi'] : false;
@@ -38,18 +39,18 @@ class AdminInstallTest extends MatomoUnit_TestCase {
         // show starting page is disabled
         $settings->set_global_option(Settings::SHOW_GET_STARTED_PAGE, 0);
         $settings->save();
-        $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
+        $this->assertFalse($this->_redirect->redirect_to_getting_started());
         // show starting page is enabled but track mode is disabled
         $settings->set_global_option(Settings::SHOW_GET_STARTED_PAGE, 1);
         $settings->set_global_option('track_mode', TrackingSettings::TRACK_MODE_DISABLED);
         $settings->save();
-        $this->assertTrue($this->_wpMatomo->redirect_to_getting_started());
+        $this->assertTrue($this->_redirect->redirect_to_getting_started());
         // show getting started and track mode different of disabled
         $settings->set_global_option('track_mode', TrackingSettings::TRACK_MODE_DEFAULT);
         $settings->save();
-        $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
+        $this->assertFalse($this->_redirect->redirect_to_getting_started());
 	    $_GET['activate-multi'] = true;
-	    $this->assertFalse($this->_wpMatomo->redirect_to_getting_started());
+	    $this->assertFalse($this->_redirect->redirect_to_getting_started());
 	    // restore initial configuration
         $settings->set_global_option('track_mode',  $original_tracking_mode);
         $settings->set_global_option(Settings::SHOW_GET_STARTED_PAGE,  $original_show_get_started_page);


### PR DESCRIPTION
Redirect to the getting started page when the module is activated if the getting started page can be displayed and if the tracking mode is not disabled. fix #434 