### PR TITLE
Mark plugin compatible with WordPress 5.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: matomoteam
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5EJ2LHATAKCJ4&source=url
 Tags: matomo,piwik,analytics,statistics,stats,tracking,ecommerce
 Requires at least: 4.8
-Tested up to: 5.7
+Tested up to: 5.8
 Stable tag: 4.3.0
 Requires PHP: 7.2.5
 License: GPLv3 or later


### PR DESCRIPTION
Tested the plugin with 5.8 and works nicely. Tests are passing too
