### PR TITLE
Only register scheduled tasks if Matomo looks like it is installed

### DIFF
--- a/classes/WpMatomo/ScheduledTasks.php
+++ b/classes/WpMatomo/ScheduledTasks.php
@@ -100,7 +100,7 @@ class ScheduledTasks {
 			);
 		}
 
-		register_deactivation_hook( MATOMO_ANALYTICS_FILE, [ $this, 'uninstall' ] );
+		register_deactivation_hook( MATOMO_ANALYTICS_FILE, array( $this, 'uninstall' ) );
 	}
 
 	public function get_last_time_before_cron( $event_name ) {

--- a/classes/WpMatomo/ScheduledTasks.php
+++ b/classes/WpMatomo/ScheduledTasks.php
@@ -64,7 +64,6 @@ class ScheduledTasks {
 		register_deactivation_hook( MATOMO_ANALYTICS_FILE, [ $this, 'uninstall' ] );
 		
 		$installer = new Installer( $this->settings );
-		$installer->register_hooks();
 		if ( ! $installer->looks_like_it_is_installed() ) {
 			return;
 		}

--- a/classes/WpMatomo/ScheduledTasks.php
+++ b/classes/WpMatomo/ScheduledTasks.php
@@ -60,6 +60,15 @@ class ScheduledTasks {
 	}
 
 	public function schedule() {
+
+		register_deactivation_hook( MATOMO_ANALYTICS_FILE, [ $this, 'uninstall' ] );
+		
+		$installer = new Installer( $this->settings );
+		$installer->register_hooks();
+		if ( ! $installer->looks_like_it_is_installed() ) {
+			return;
+		}
+
 		add_action( self::EVENT_UPDATE, array( $this, 'perform_update' ) );
 		add_filter( 'cron_schedules', array( $this, 'add_weekly_schedule' ) );
 
@@ -94,8 +103,6 @@ class ScheduledTasks {
 				$accepted_args = 0
 			);
 		}
-
-		register_deactivation_hook( MATOMO_ANALYTICS_FILE, array( $this, 'uninstall' ) );
 	}
 
 	public function get_last_time_before_cron( $event_name ) {


### PR DESCRIPTION
### Description:

Preventing issues where it would try to run scheduled tasks when Matomo isn't installed yet or just before installing or so.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
