### PR TITLE
avoid execution if wp_get_order return false

### DIFF
--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -185,7 +185,10 @@ class Woocommerce extends Base {
 		$this->logger->log( sprintf( 'Matomo new order %d', $order_id ) );
 
 		$order = wc_get_order( $order_id );
-
+		// @see https://github.com/matomo-org/matomo-for-wordpress/issues/514
+		if ( ! $order ) {
+			return;
+		}
 		$order_id_to_track = $order_id;
 		if ( method_exists( $order, 'get_order_number' ) ) {
 			$order_id_to_track = $order->get_order_number();


### PR DESCRIPTION
fix #514 
I did not try to find the origin of this null parameter as it can be a lot of origins.
