### PR TITLE
When archiving is forced, print full error message

### DIFF
--- a/classes/WpMatomo/ScheduledTasks.php
+++ b/classes/WpMatomo/ScheduledTasks.php
@@ -306,9 +306,9 @@ class ScheduledTasks {
 			$archiver->shouldArchiveAllSites = true;
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			$archiver->disableScheduledTasks = true;
-			
+			// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound
 			if ( ! defined( 'PIWIK_ARCHIVE_NO_TRUNCATE' ) ) {
-				define( 'PIWIK_ARCHIVE_NO_TRUNCATE', true);
+				define( 'PIWIK_ARCHIVE_NO_TRUNCATE', true );
 			}
 		}
 

--- a/classes/WpMatomo/ScheduledTasks.php
+++ b/classes/WpMatomo/ScheduledTasks.php
@@ -306,6 +306,10 @@ class ScheduledTasks {
 			$archiver->shouldArchiveAllSites = true;
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			$archiver->disableScheduledTasks = true;
+			
+			if ( ! defined( 'PIWIK_ARCHIVE_NO_TRUNCATE' ) ) {
+				define( 'PIWIK_ARCHIVE_NO_TRUNCATE', true);
+			}
 		}
 
 		if ( is_multisite() ) {


### PR DESCRIPTION
### Description:

When clicking on `Archive reports` in `Diagnostics -> Troubleshooting`, then make sure to print the full error message as otherwise it would be truncated after 6000 characters in https://github.com/matomo-org/matomo-for-wordpress/blob/4.4.2/app/core/CronArchive.php#L674-L682

![image](https://user-images.githubusercontent.com/273120/135159879-9bd2d41c-5ce2-4cad-bcc8-3ac999c135d8.png)


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
