### PR TITLE
Fix travis tests fail because of SSL errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ before_script:
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+      phpunit --version
     fi
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ before_script:
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-      composer global require "phpunit/phpunit=4.8.*|5.7.*"
     fi
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
-dist: trusty
+dist: bionic
+
+services:
+  - mysql
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
   - mv matomo-for-wordpress matomo
   - cd matomo
   - MATOMO_PLUGIN_DIR_PATH=`pwd`
-  - if [[ $TRAVIS_PHP_VERSION > '7.2' ]]; then wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar; fi
-  - if [[ $TRAVIS_PHP_VERSION > '7.2' ]]; then chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit; fi
+  - wget -O ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit https://phar.phpunit.de/phpunit-7.phar
+  - chmod 755 ~/.phpenv/versions/$(phpenv version-name)/bin/phpunit
 
 notifications:
   email:


### PR DESCRIPTION
### Description:

There are SSL errors because we are using an old Ubuntu in our tests. 
![image](https://user-images.githubusercontent.com/273120/137417344-60843f23-0223-4939-9e00-71a40f67001b.png)

started updating .travis.yml to Bionic to avoid these issues.

Some path tests are still failing though.

This seems to work when running the test against the latest WordPress version but not for some builds.

![image](https://user-images.githubusercontent.com/273120/137417417-b1457a1b-e8ea-4e84-a647-b63bfa38835a.png)

See https://app.travis-ci.com/github/matomo-org/matomo-for-wordpress/jobs/543341911#L476

the other 2 builds fail because of 
![image](https://user-images.githubusercontent.com/273120/137417491-9cdee9f2-54db-4486-86c3-5851e87c4298.png)

I'm thinking we need to fix https://github.com/matomo-org/matomo-for-wordpress/issues/478 to make the test work maybe

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
