### PR TITLE
remove the wp-defender plugin from the incompatible plugins list

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -175,8 +175,7 @@ class WpMatomo {
 		// we are not using is_plugin_active() for performance reasons
 		$active_plugins = self::get_active_plugins();
 
-		if ( in_array( 'wp-rss-aggregator/wp-rss-aggregator.php', $active_plugins, true )
-			 || in_array( 'wp-defender/wp-defender.php', $active_plugins, true ) ) {
+		if ( in_array( 'wp-rss-aggregator/wp-rss-aggregator.php', $active_plugins, true ) ) {
 			return true;
 		}
 

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -79,8 +79,6 @@ class SystemReport {
 		// uses a newer version of monolog
 		'wp-rss-aggregator',
 		// see https://wordpress.org/support/topic/critical-error-after-upgrade/ conflict re php-di version
-		'wp-defender',
-		// see https://wordpress.org/support/topic/critical-error-after-upgrade/ conflict re php-di version
 		'age-verification-for-woocommerce',
 		// see https://github.com/matomo-org/wp-matomo/issues/428
 		'minify-html-markup',


### PR DESCRIPTION
the user has tested his configuration in a patched version which removes the safe mode and it works well with both plugins enabled.
I've removed this plugin from the incompatibility list: https://matomo.org/faq/wordpress/which-plugins-is-matomo-for-wordpress-known-to-be-not-compatible-with/