### PR TITLE
Incompatible plugins update

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -172,13 +172,6 @@ class WpMatomo {
 			return MATOMO_SAFE_MODE;
 		}
 
-		// we are not using is_plugin_active() for performance reasons
-		$active_plugins = self::get_active_plugins();
-
-		if ( in_array( 'wp-rss-aggregator/wp-rss-aggregator.php', $active_plugins, true ) ) {
-			return true;
-		}
-
 		return false;
 	}
 

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -73,8 +73,6 @@ class SystemReport {
 		// Uses an old version of Twig and plugin is no longer maintained.
 		'all-in-one-event-calendar',
 		// Uses an old version of Twig
-		'data-tables-generator-by-supsystic',
-		// uses an old version of twig causing some styles to go funny in the reporting and admin
 		'tweet-old-post-pro',
 		// uses a newer version of monolog
 		'wp-rss-aggregator',

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -76,7 +76,7 @@ class SystemReport {
 		'tweet-old-post-pro',
 		// uses a newer version of monolog
 		'wp-rss-aggregator',
-		// see https://wordpress.org/support/topic/critical-error-after-upgrade/ conflict re php-di version
+		// twig conflict
 		'age-verification-for-woocommerce',
 		// see https://github.com/matomo-org/wp-matomo/issues/428
 		'minify-html-markup',

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -85,8 +85,6 @@ class SystemReport {
 		// see https://wordpress.org/support/topic/20-total-errors-during-this-script-execution/
 		'google-listings-and-ads',
 		// see https://wordpress.org/support/topic/20-total-errors-during-this-script-execution/
-		'accelerated-mobile-pages',
-		// see https://wordpress.org/support/topic/receiving-errors-from-my-plesk-server/
 		'post-smtp',
 		// see https://wordpress.org/support/topic/activation-of-another-plugin-breaks-matomo/#post-15045079
 		'adshares',


### PR DESCRIPTION
Update the incompatibility plugins list: updates:

- data-tables-generator-by-supsystic: remove from the list: they use now a custom version of twig which cannot be in conflict with our own one.
- wp-rss-aggregator: update documentation: There is no more conflict with the php-di component as they don't use it anymore, but there is a conflict in the twig version which leads to 500 errors in Matomo.
- AMP: remove the AMP plugin from the incompatibility list. it does not embed anymore Monolog.

I did not remove plugins from the plugins list for now, wait for an approval of this PR.