### PR TITLE
Fix bug in get_db_grants() not returning correct grants

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1427,11 +1427,11 @@ class SystemReport {
 			foreach ( [ ' ON ', ' TO ', ' IDENTIFIED ', ' BY ' ] as $keyword ) {
 				if ( stripos( $values[ $index ][0], $keyword ) !== false ) {
 					// make sure to never show by any accident a db user or password by cutting anything after on/to
-					$values[ $index ][0] = substr( $value[0], 0, stripos( $value[0], $keyword ) );
+					$values[ $index ][0] = substr( $values[ $index ][0], 0, stripos( $values[ $index ][0], $keyword ) );
 				}
 				if ( stripos( $values[ $index ][0], 'GRANT' ) !== false ) {
 					// otherwise we end up having "grant select"... instead of just "select"
-					$values[ $index ][0] = substr( $value[0], stripos( $values[ $index ][0], 'GRANT' ) + 5 );
+					$values[ $index ][0] = substr( $values[ $index ][0], stripos( $values[ $index ][0], 'GRANT' ) + 5 );
 				}
 			}
 			// make sure to never show by any accident a db user or password


### PR DESCRIPTION
Change $values[ $index ][0] instead of $value[0] to preserve alterations from previous if statement, where it deletes everything after certain keywords (' ON ', ' TO ', ' IDENTIFIED ', ' BY ').

$value is a different variable than $value[ $index ]. Example:

    $values = array( 'foo' );

    foreach( $values as $index => $value ) {
        echo $value; // foo
        echo $values[ $index ]; // foo
        $values[ $index ] = 'baz';
        echo $value; // foo
        echo $values[ $index ]; // baz
    }

### Description:

The "System report" page reported missing MySQL user privileges, even though the MySQL user had the required privileges. This PR fixes the issue.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
