### PR TITLE
allow links in system report comments

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -358,7 +358,7 @@ class SystemReport {
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			if ( version_compare( $phpcli_version, $piwik_minimumPHPVersion ) <= 0 ) {
 				$is_error = true;
-				$comment  = __( 'Your PHP cli version is not compatible with the Matomo requirements https://matomo.org/faq/on-premise/matomo-requirements/. Please upgrade your PHP cli version, otherwise, you might have some archiving errors', 'matomo' );
+				$comment  = sprintf( esc_html__( 'Your PHP cli version is not compatible with the %s. Please upgrade your PHP cli version, otherwise, you might have some archiving errors', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/on-premise/matomo-requirements/', esc_html__( 'Matomo requirements', 'matomo' ) ) );
 			} else {
 				$is_error = false;
 				$comment  = '';
@@ -379,7 +379,7 @@ class SystemReport {
 				default:
 					$value    = __( 'missing', 'matomo' );
 					$is_error = true;
-					$comment  = __( 'Your PHP cli does not load the MySQLi extension. You might have archiving problems in Matomo but also others problems in your WordPress cron tasks. You should enable this extension', 'matomo' );
+					$comment  = esc_html__( 'Your PHP cli does not load the MySQLi extension. You might have archiving problems in Matomo but also others problems in your WordPress cron tasks. You should enable this extension', 'matomo' );
 			}
 
 			$rows[] = [
@@ -659,7 +659,7 @@ class SystemReport {
 								'name'       => 'Proxy header',
 								'value'      => $header,
 								'is_warning' => true,
-								'comment'    => 'A proxy header is set which means you maybe need to configure a proxy header in the Advanced settings to make location reporting work. If the location in your reports is detected correctly, you can ignore this warning. Learn more: https://matomo.org/faq/wordpress/how-do-i-fix-the-proxy-header-warning-in-the-matomo-for-wordpress-system-report/',
+								'comment'    => sprintf( esc_html__( 'A proxy header is set which means you maybe need to configure a proxy header in the Advanced settings to make location reporting work. If the location in your reports is detected correctly, you can ignore this warning. %s', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/how-do-i-fix-the-proxy-header-warning-in-the-matomo-for-wordpress-system-report/', esc_html__( 'Learn more', 'matomo' ) ) ),
 							];
 						}
 					}
@@ -674,7 +674,7 @@ class SystemReport {
 							'name'     => 'Plugin has missing dependencies',
 							'value'    => $plugin->getPluginName(),
 							'is_error' => true,
-							'comment'  => $plugin->getMissingDependenciesAsString( Version::VERSION ) . ' If the plugin requires a different Matomo version you may need to update it. If you no longer use it consider uninstalling it.',
+							'comment'  => sprintf( esc_html__( '%s If the plugin requires a different Matomo version you may need to update it. If you no longer use it consider uninstalling it.', 'matomo' ), $plugin->getMissingDependenciesAsString( Version::VERSION ) ),
 						];
 					}
 				}
@@ -682,11 +682,12 @@ class SystemReport {
 
 			$num_days_check_visits = 5;
 			$had_visits            = $this->had_visits_in_last_days( $num_days_check_visits );
+
 			if ( false === $had_visits || true === $had_visits ) {
 				// do not show info if we could not detect it (had_visits === null)
 				$comment = '';
 				if ( ! $had_visits ) {
-					$comment = 'It looks like there were no visits in the last ' . $num_days_check_visits . ' days. This may be expected if tracking is disabled, you have not added the tracking code, or your website does not have many visitors in general and you exclude your own visits.';
+					$comment = sprintf( esc_html__( 'It looks like there were no visits in the last %s days. This may be expected if tracking is disabled, you have not added the tracking code, or your website does not have many visitors in general and you exclude your own visits.', 'matomo' ), $num_days_check_visits );
 				}
 
 				$rows[] = [
@@ -778,9 +779,9 @@ class SystemReport {
 				$error['is_warning'] = ! empty( $error['name'] ) && stripos( $error['name'], 'archiv' ) !== false && 'archive_boot' !== $error['name'];
 				$error['is_error']   = $is_plugin_update_error;
 				if ( $is_plugin_update_error ) {
-					$error['comment'] = 'Please reach out to us and include the copied system report (see https://matomo.org/faq/wordpress/how-do-i-troubleshoot-a-failed-database-upgrade-in-matomo-for-wordpress/ for more info)<br><br>You can also retry the update manually by clicking in the top on the "Troubleshooting" tab and then clicking on the "Run updater" button.' . $error['comment'];
+					$error['comment'] = sprintf( esc_html__( 'Please reach out to us and include the copied system report (%s)<br><br>You can also retry the update manually by clicking in the top on the "Troubleshooting" tab and then clicking on the "Run updater" button.', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/how-do-i-troubleshoot-a-failed-database-upgrade-in-matomo-for-wordpress/', esc_html__( 'more info', 'matomo' ) ) ) . $error['comment'];
 				} elseif ( $skip_plugin_update ) {
-					$error['comment'] = 'As there are no outstanding plugin updates it looks like this log can be ignored.<br><br>' . $error['comment'];
+					$error['comment'] = esc_html__( 'As there are no outstanding plugin updates it looks like this log can be ignored.', 'matomo' ) . '<br><br>' . $error['comment'];
 				}
 				$error['comment'] = matomo_anonymize_value( $error['comment'] );
 				$rows[]           = $error;
@@ -793,7 +794,7 @@ class SystemReport {
 					$rows[] = [
 						'name'     => 'Cli has no MySQL',
 						'value'    => true,
-						'comment'  => 'It looks like MySQL is not available on CLI. Please read our FAQ on how to fix this issue: https://matomo.org/faq/wordpress/how-do-i-fix-the-error-your-php-installation-appears-to-be-missing-the-mysql-extension-which-is-required-by-wordpress-in-matomo-system-report/ ',
+						'comment'  => sprintf( esc_html__( 'It looks like MySQL is not available on CLI. Please read our FAQ on how to %s', 'matomo' ), sprintf( ' <a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/how-do-i-fix-the-error-your-php-installation-appears-to-be-missing-the-mysql-extension-which-is-required-by-wordpress-in-matomo-system-report/', esc_html__( 'fix this issue', 'matomo' ) ) ),
 						'is_error' => true,
 					];
 				}
@@ -828,7 +829,8 @@ class SystemReport {
 						$failure['pretty_date_first_occurred'],
 						$failure['request_url']
 					);
-					$rows[]  = [
+					// do not esc_html the comment: we want the br
+					$rows[] = [
 						'name'       => $failure['problem'],
 						'is_warning' => true,
 						'value'      => '',
@@ -1042,7 +1044,7 @@ class SystemReport {
 				'name'       => 'WP-Matomo (WP-Piwik) activated',
 				'value'      => true,
 				'is_warning' => true,
-				'comment'    => 'It is usually not recommended or needed to run Matomo for WordPress and WP-Matomo at the same time. To learn more about the differences between the two plugins view this URL: https://matomo.org/faq/wordpress/why-are-there-two-different-matomo-for-wordpress-plugins-what-is-the-difference-to-wp-matomo-integration-plugin/',
+				'comment'    => sprintf( esc_html__( 'It is usually not recommended or needed to run Matomo for WordPress and WP-Matomo at the same time. To learn more about the differences between the two plugins view this %s', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/why-are-there-two-different-matomo-for-wordpress-plugins-what-is-the-difference-to-wp-matomo-integration-plugin/', esc_html__( 'URL', 'matomo' ) ) ),
 			];
 
 			$mode = get_option( 'wp-piwik_global-piwik_mode' );
@@ -1054,7 +1056,7 @@ class SystemReport {
 					'name'       => 'WP-Matomo mode',
 					'value'      => $mode,
 					'is_warning' => 'php' === $mode || 'PHP' === $mode,
-					'comment'    => 'WP-Matomo is configured in "PHP mode". This is known to cause issues with Matomo for WordPress. We recommend you either deactivate WP-Matomo or you go "Settings => WP-Matomo" and change the "Matomo Mode" in the "Connect to Matomo" section to "Self-hosted HTTP API".',
+					'comment'    => esc_html__( 'WP-Matomo is configured in "PHP mode". This is known to cause issues with Matomo for WordPress. We recommend you either deactivate WP-Matomo or you go "Settings => WP-Matomo" and change the "Matomo Mode" in the "Connect to Matomo" section to "Self-hosted HTTP API".', 'matomo' ),
 				];
 			}
 		}
@@ -1070,7 +1072,7 @@ class SystemReport {
 				'name'       => 'Compatible content directory',
 				'value'      => $compatible_content_dir,
 				'is_warning' => true,
-				'comment'    => __( 'It looks like you are maybe using a custom WordPress content directory. The Matomo reporting/admin pages might not work. You may be able to workaround this.', 'matomo' ) . ' ' . __( 'Learn more', 'matomo' ) . ': https://matomo.org/faq/wordpress/how-do-i-make-matomo-for-wordpress-work-when-i-have-a-custom-content-directory/',
+				'comment'    => esc_html__( 'It looks like you are maybe using a custom WordPress content directory. The Matomo reporting/admin pages might not work. You may be able to workaround this.', 'matomo' ) . ' ' . sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/how-do-i-make-matomo-for-wordpress-work-when-i-have-a-custom-content-directory/', esc_html__( 'Learn more', 'matomo' ) ),
 			];
 		}
 
@@ -1081,7 +1083,7 @@ class SystemReport {
 		$rows[] = [
 			'name'       => esc_html__( 'PHP Maxmind DB extension', 'matomo' ),
 			'value'      => $maxmind_db_loaded ? __( 'Loaded', 'matomo' ) : __( 'Not loaded', 'matomo' ),
-			'comment'    => $maxmind_db_loaded ? sprintf( __( 'You may encounter the following problem %s', 'matomo' ), 'https://matomo.org/faq/troubleshooting/how-do-i-fix-the-error-call-to-undefined-method-maxminddbreadergetwithprefixlen/' ) : '',
+			'comment'    => $maxmind_db_loaded ? sprintf( esc_html__( 'You may encounter %s', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/troubleshooting/how-do-i-fix-the-error-call-to-undefined-method-maxminddbreadergetwithprefixlen/', esc_html__( 'the following problem', 'matomo' ) ) ) : '',
 			'is_warning' => $maxmind_db_loaded,
 		];
 	}
@@ -1113,7 +1115,7 @@ class SystemReport {
 						switch ( (int) $result['response']['code'] ) {
 							case 500:
 								$value    = __( 'To be confirmed', 'matomo' );
-								$comment  = __( 'The AddHandler Apache directive maybe disabled. If you get a 500 error code when accessing Matomo, please read this FAQ https://matomo.org/faq/wordpress/how-do-i-fix-the-error-addhandler-not-allowed-here/', 'matomo' );
+								$comment  = sprintf( esc_html__( 'The AddHandler Apache directive maybe disabled. If you get a 500 error code when accessing Matomo, please read this %s', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s<a/>', 'https://matomo.org/faq/wordpress/how-do-i-fix-the-error-addhandler-not-allowed-here/', esc_html__( 'FAQ', 'matomo' ) ) );
 								$is_error = true;
 								break;
 							default:
@@ -1197,7 +1199,7 @@ class SystemReport {
 		$rows[] = [
 			'name'    => 'Memory Limit',
 			'value'   => @ini_get( 'memory_limit' ),
-			'comment' => 'At least 128MB recommended. Depending on your traffic 256MB or more may be needed.',
+			'comment' => sprintf( esc_html__( 'At least %1$dMB recommended. Depending on your traffic %2$dMB or more may be needed.', 'matomo' ), 128, 256 ),
 		];
 
 		$rows[] = [
@@ -1256,7 +1258,7 @@ class SystemReport {
 
 		if ( '1' === $zlib_compression ) {
 			$row['is_error'] = true;
-			$row['comment']  = 'You need to set "zlib.output_compression" in your php.ini to "Off".';
+			$row['comment']  = esc_html__( 'You need to set "zlib.output_compression" in your php.ini to "Off".', 'matomo' );
 		}
 		$rows[] = $row;
 
@@ -1302,7 +1304,7 @@ class SystemReport {
 							'name'       => 'Browser Compatibility',
 							'is_warning' => true,
 							'value'      => 'Yes',
-							'comment'    => 'Because you are using MS Edge browser, you may see a warning like "This site has been reported as unsafe" from "Microsoft Defender SmartScreen" when you view the Matomo Reporting, Admin or Tag Manager page. This is a false alert and you can safely ignore this warning by clicking on the icon next to the URL (in the address bar) and choosing either "Report as safe" (preferred) or "Show unsafe content". We are hoping to get this false warning removed in the future.',
+							'comment'    => esc_html__( 'Because you are using MS Edge browser, you may see a warning like "This site has been reported as unsafe" from "Microsoft Defender SmartScreen" when you view the Matomo Reporting, Admin or Tag Manager page. This is a false alert and you can safely ignore this warning by clicking on the icon next to the URL (in the address bar) and choosing either "Report as safe" (preferred) or "Show unsafe content". We are hoping to get this false warning removed in the future.', 'matomo' ),
 						];
 					}
 				}
@@ -1392,7 +1394,7 @@ class SystemReport {
 		$rows[]             = [
 			'name'     => 'DB tables exist',
 			'value'    => ( ! $has_missing_tables ),
-			'comment'  => $has_missing_tables ? sprintf( __( 'Some tables may be missing: %s', 'matomo' ), implode( ', ', $missing_tables ) ) : '',
+			'comment'  => $has_missing_tables ? sprintf( esc_html__( 'Some tables may be missing: %s', 'matomo' ), implode( ', ', $missing_tables ) ) : '',
 			'is_error' => $has_missing_tables,
 		];
 
@@ -1439,7 +1441,7 @@ class SystemReport {
 				$rows[] = [
 					'name'       => esc_html__( 'Required permissions', 'matomo' ),
 					'value'      => esc_html__( 'Error', 'matomo' ),
-					'comment'    => esc_html__( 'Missing permissions', 'matomo' ) . ': ' . implode( ', ', $grants_missing ) . '. ' . __( 'Please check if any of these MySQL permission (grants) are missing and add them if needed.', 'matomo' ) . ' ' . __( 'Learn more', 'matomo' ) . ': https://matomo.org/faq/troubleshooting/how-do-i-check-if-my-mysql-user-has-all-required-grants/',
+					'comment'    => esc_html__( 'Missing permissions', 'matomo' ) . ': ' . implode( ', ', $grants_missing ) . '. ' . esc_html__( 'Please check if any of these MySQL permission (grants) are missing and add them if needed.', 'matomo' ) . ' ' . sprintf( '<a href="https://matomo.org/faq/troubleshooting/how-do-i-check-if-my-mysql-user-has-all-required-grants/" target="_blank">%s</a>', __( 'Learn more', 'matomo' ) ),
 					'is_warning' => true,
 				];
 			} else {
@@ -1598,7 +1600,7 @@ class SystemReport {
 			foreach ( $mu_plugins as $mu_pin ) {
 				$comment = '';
 				if ( ! empty( $plugin['Network'] ) ) {
-					$comment = 'Network enabled';
+					$comment = esc_html__( 'Network enabled', 'matomo' );
 				}
 				$rows[] = [
 					'name'    => $mu_pin['Name'],
@@ -1617,7 +1619,7 @@ class SystemReport {
 		foreach ( $plugins as $plugin ) {
 			$comment = '';
 			if ( ! empty( $plugin['Network'] ) ) {
-				$comment = 'Network enabled';
+				$comment = esc_html__( 'Network enabled', 'matomo' );
 			}
 			$rows[] = [
 				'name'    => $plugin['Name'],
@@ -1636,16 +1638,17 @@ class SystemReport {
 			];
 
 			$used_not_compatible = array_intersect( $active_plugins, $this->not_compatible_plugins );
+
 			if ( ! empty( $used_not_compatible ) ) {
 				$additional_comment = '';
 				if ( in_array( 'tweet-old-post-pro', $used_not_compatible, true ) ) {
-					$additional_comment .= '<br><br>A workaround for Revive Old Posts Pro may be to add the following line to your "wp-config.php". <br><code>define( \'MATOMO_SUPPORT_ASYNC_ARCHIVING\', false );</code>.';
+					$additional_comment .= '<br><br>' . esc_html__( 'A workaround for Revive Old Posts Pro may be to add the following line to your "wp-config.php"', 'matomo' ) . '<br><code>define( \'MATOMO_SUPPORT_ASYNC_ARCHIVING\', false );</code>.';
 				}
 				if ( in_array( 'post-smtp', $used_not_compatible, true ) ) {
-					$additional_comment .= '<br><br>The PDF report files from the email reports will be missing when the PostSMTP mode is selected but it works when the PHPMailer mode is selected.';
+					$additional_comment .= '<br><br>' . esc_html__( 'The PDF report files from the email reports will be missing when the PostSMTP mode is selected but it works when the PHPMailer mode is selected.', 'matomo' );
 				}
 				if ( in_array( 'wp-rocket', $used_not_compatible, true ) ) {
-					$additional_comment .= '<br><br>WP-Rocket is incompatible from version 3.12. Until fixes, please reinstall version 3.11.5 if you have a newer version. For more information please visit https://github.com/matomo-org/matomo-for-wordpress/wiki/Downgrade-wp-rocket-to-a-version-compatible-with-the-Matomo-plugin';
+					$additional_comment .= '<br><br>' . sprintf( esc_html__( 'WP-Rocket is incompatible from version 3.12. Until fixes, please reinstall version 3.11.5 if you have a newer version. For more information please visit %s', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://github.com/matomo-org/matomo-for-wordpress/wiki/Downgrade-wp-rocket-to-a-version-compatible-with-the-Matomo-plugin', esc_html__( 'How to downgrade Wp-rocket to be compatible with Matomo', 'matomo' ) ) );
 				}
 				$is_warning = false;
 				$is_error   = false;
@@ -1660,7 +1663,7 @@ class SystemReport {
 					$rows[] = [
 						'name'       => __( 'Not compatible plugins', 'matomo' ),
 						'value'      => count( $used_not_compatible ),
-						'comment'    => implode( ', ', $used_not_compatible ) . '<br><br> Matomo may work fine when using these plugins but there may be some issues. For more information see<br>https://matomo.org/faq/wordpress/which-plugins-is-matomo-for-wordpress-known-to-be-not-compatible-with/ ' . $additional_comment,
+						'comment'    => implode( ', ', $used_not_compatible ) . '<br><br>' . sprintf( esc_html__( 'Matomo may work fine when using these plugins but there may be some issues. For more information %1$sSee %2$s', 'matomo' ), '<br/>', sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/which-plugins-is-matomo-for-wordpress-known-to-be-not-compatible-with/', esc_html__( 'this FAQ', 'matomo' ) ) ) . $additional_comment,
 						'is_warning' => $is_warning,
 						'is_error'   => $is_error,
 					];
@@ -1682,7 +1685,7 @@ class SystemReport {
 						$rows[] = [
 							'name'     => "iThemes Security 'Long URLs' Enabled",
 							'value'    => true,
-							'comment'  => 'Tracking might not work because it looks like you have Long URLs disabled in iThemes Security. To fix this please go to "Security -> Settings -> System Tweaks" and disable the setting "Long URL Strings".',
+							'comment'  => esc_html__( 'Tracking might not work because it looks like you have Long URLs disabled in iThemes Security. To fix this please go to "Security -> Settings -> System Tweaks" and disable the setting "Long URL Strings".', 'matomo' ),
 							'is_error' => true,
 						];
 					}
@@ -1690,7 +1693,7 @@ class SystemReport {
 						$rows[] = [
 							'name'     => "iThemes Security 'Disable PHP in plugins' Enabled",
 							'value'    => true,
-							'comment'  => 'You have disabled the PHP usage in the plugins folder from your ithemes security plugin. Matomo won\'t work in this configuration. You must uncheck the checkbox "Security > Settings > Advanced > System tweaks > Disable PHP in plugins."',
+							'comment'  => esc_html__( 'You have disabled the PHP usage in the plugins folder from your ithemes security plugin. Matomo won\'t work in this configuration. You must uncheck the checkbox "Security > Settings > Advanced > System tweaks > Disable PHP in plugins."', 'matomo' ),
 							'is_error' => true,
 						];
 					}
@@ -1706,7 +1709,7 @@ class SystemReport {
 						$rows[] = [
 							'name'     => "Secupress 'Block Bad Request Methods' Enabled",
 							'value'    => true,
-							'comment'  => "If reports aren't being generated then you may need to disable the feature \"Firewall -> Block Bad Request Methods\" in SecuPress (if it is enabled) or add the following line to your \"wp-config.php\": <br><code>define( 'MATOMO_SUPPORT_ASYNC_ARCHIVING', false );</code>.",
+							'comment'  => esc_html__( "If reports aren't being generated then you may need to disable the feature \"Firewall -> Block Bad Request Methods\" in SecuPress (if it is enabled) or add the following line to your \"wp-config.php\"", 'matomo' ) . ": <br><code>define( 'MATOMO_SUPPORT_ASYNC_ARCHIVING', false );</code>.",
 							'is_error' => true,
 						];
 					}

--- a/classes/WpMatomo/Admin/views/systemreport.php
+++ b/classes/WpMatomo/Admin/views/systemreport.php
@@ -159,10 +159,9 @@ if ( ! function_exists( 'matomo_format_value_text' ) ) {
 					];
 					$matomo_comment           = isset( $matomo_row['comment'] ) ? $matomo_row['comment'] : '';
 					$matomo_replaced          = str_replace( array_keys( $matomo_replaced_elements ), array_values( $matomo_replaced_elements ), $matomo_comment );
-					// note: the text is not escaped anymore. Instead the escaping is made when generating the comment. It allows then to add links in the output.
-					$matomo_escaped = $matomo_replaced;
+					// note: the text is not escaped anymore. Instead, the escaping is made when generating the comment. It allows then to add links in the output.
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo "<td width='50%' class='matomo-systemreport-comment'>" . str_replace( array_values( $matomo_replaced_elements ), array_keys( $matomo_replaced_elements ), $matomo_escaped ) . '</td>';
+					echo "<td width='50%' class='matomo-systemreport-comment'>" . str_replace( array_values( $matomo_replaced_elements ), array_keys( $matomo_replaced_elements ), $matomo_replaced )  . '</td>';
 				}
 
 				echo '</tr>';

--- a/classes/WpMatomo/Admin/views/systemreport.php
+++ b/classes/WpMatomo/Admin/views/systemreport.php
@@ -161,7 +161,7 @@ if ( ! function_exists( 'matomo_format_value_text' ) ) {
 					$matomo_replaced          = str_replace( array_keys( $matomo_replaced_elements ), array_values( $matomo_replaced_elements ), $matomo_comment );
 					// note: the text is not escaped anymore. Instead, the escaping is made when generating the comment. It allows then to add links in the output.
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo "<td width='50%' class='matomo-systemreport-comment'>" . str_replace( array_values( $matomo_replaced_elements ), array_keys( $matomo_replaced_elements ), $matomo_replaced )  . '</td>';
+					echo "<td width='50%' class='matomo-systemreport-comment'>" . str_replace( array_values( $matomo_replaced_elements ), array_keys( $matomo_replaced_elements ), $matomo_replaced ) . '</td>';
 				}
 
 				echo '</tr>';

--- a/classes/WpMatomo/Admin/views/systemreport.php
+++ b/classes/WpMatomo/Admin/views/systemreport.php
@@ -13,7 +13,14 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
+?>
+<style type="text/css">
+	.matomo-systemreport a {
+		color: inherit;
+		text-decoration: underline;
+	}
+</style>
+<?php
 use WpMatomo\Access;
 use WpMatomo\Admin\Menu;
 use WpMatomo\Admin\SystemReport;
@@ -104,7 +111,9 @@ if ( ! function_exists( 'matomo_format_value_text' ) ) {
 							}
 							echo "\n* " . esc_html( $matomo_class ) . esc_html( $matomo_row['name'] ) . ': ' . esc_html( matomo_anonymize_value( matomo_format_value_text( $matomo_value ) ) );
 							if ( isset( $matomo_row['comment'] ) && '' !== $matomo_row['comment'] ) {
-								echo ' (' . esc_html( matomo_anonymize_value( matomo_format_value_text( $matomo_row['comment'] ) ) ) . ')';
+								 // We want to add links in the comments
+                                 // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+								echo ' (' . matomo_anonymize_value( matomo_format_value_text( $matomo_row['comment'] ) ) . ')';
 							}
 						}
 						echo "\n\n";
@@ -150,7 +159,8 @@ if ( ! function_exists( 'matomo_format_value_text' ) ) {
 					];
 					$matomo_comment           = isset( $matomo_row['comment'] ) ? $matomo_row['comment'] : '';
 					$matomo_replaced          = str_replace( array_keys( $matomo_replaced_elements ), array_values( $matomo_replaced_elements ), $matomo_comment );
-					$matomo_escaped           = esc_html( $matomo_replaced );
+					// note: the text is not escaped anymore. Instead the escaping is made when generating the comment. It allows then to add links in the output.
+					$matomo_escaped = $matomo_replaced;
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo "<td width='50%' class='matomo-systemreport-comment'>" . str_replace( array_values( $matomo_replaced_elements ), array_keys( $matomo_replaced_elements ), $matomo_escaped ) . '</td>';
 				}


### PR DESCRIPTION
https://innocraft.atlassian.net/browse/WBS-615

After reflection, not sure if this is a regression.

But now, the links are clickable in the system report.
It has required to review the escaping management for the comment: now the strings are escaped when generating the comment, excluding the links. It has also the advantage to allow our translation system to identify strings to translate, which it was not the case with the previous approach.

To test, the easiest way is to edit the code to force going in the conditions (otherwise, you'll have to force specific configurations, which could be time-consuming).
