### PR TITLE
Wbs 614 memberpress and stripe

### DIFF
--- a/classes/WpMatomo/Ecommerce/MemberPress.php
+++ b/classes/WpMatomo/Ecommerce/MemberPress.php
@@ -85,6 +85,7 @@ class MemberPress extends Base {
 
 	public function on_order() {
 		if ( isset( $_GET['membership'] )
+		     && ( isset( $_GET['trans_num'] ) || isset( $_GET['transaction_id'] ) )
 			 && class_exists( '\MeprTransaction' ) ) {
 			$txn = null;
 			if ( isset( $_GET['trans_num'] ) ) {

--- a/classes/WpMatomo/Ecommerce/MemberPress.php
+++ b/classes/WpMatomo/Ecommerce/MemberPress.php
@@ -85,7 +85,7 @@ class MemberPress extends Base {
 
 	public function on_order() {
 		if ( isset( $_GET['membership'] )
-		     && ( isset( $_GET['trans_num'] ) || isset( $_GET['transaction_id'] ) )
+			 && ( isset( $_GET['trans_num'] ) || isset( $_GET['transaction_id'] ) )
 			 && class_exists( '\MeprTransaction' ) ) {
 			$txn = null;
 			if ( isset( $_GET['trans_num'] ) ) {

--- a/classes/WpMatomo/Ecommerce/MemberPress.php
+++ b/classes/WpMatomo/Ecommerce/MemberPress.php
@@ -85,10 +85,17 @@ class MemberPress extends Base {
 
 	public function on_order() {
 		if ( isset( $_GET['membership'] )
-			 && isset( $_GET['trans_num'] )
 			 && class_exists( '\MeprTransaction' ) ) {
-			$txn = MeprTransaction::get_one_by_trans_num( sanitize_text_field( wp_unslash( $_GET['trans_num'] ) ) );
-			if ( isset( $txn->id ) && $txn->id > 0 ) {
+			$txn = null;
+			if ( isset( $_GET['trans_num'] ) ) {
+				$txn = MeprTransaction::get_one_by_trans_num( sanitize_text_field( wp_unslash( $_GET['trans_num'] ) ) );
+			} else {
+				if ( isset( $_GET['transaction_id'] ) ) {
+					$txn = MeprTransaction::get_one( sanitize_text_field( wp_unslash( $_GET['transaction_id'] ) ) );
+				}
+			}
+
+			if ( $txn && isset( $txn->id ) && $txn->id > 0 ) {
 				if ( $this->has_order_been_tracked_already( $txn->id ) ) {
 					return;
 				}


### PR DESCRIPTION
https://innocraft.atlassian.net/browse/WBS-614
fixes #656 

The problem is the new API does not send anymore the required parameters. So we did not enter into the on order method, and so the order is not reported to Matomo. Unfortunately, we have only one support request so far regarding this subject, and we guess that we have many others users with this configuration (Memberpress + stripe). We suspected with Thomas that the old API is still in use.
This is why I set up both configurations in the MemberPress class.

To test, please follow this doc instruction: https://innocraft.atlassian.net/wiki/spaces/DW/pages/2088501249/How+to+debug+MemberPress+support+in+the+WordPress+plugin