### PR TITLE
Replace the hexadecimal colours in the HTML per their rgb values

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -777,8 +777,8 @@ class SystemReport {
 					$error['comment'] = '';
 				}
 
-				if (strpos($error['comment'], '<head>')) {
-					$error['comment'] = esc_html($error['comment']);
+				if ( strpos( $error['comment'], '<head>' ) ) {
+					$error['comment'] = esc_html( $error['comment'] );
 					$error['comment'] = $this->replace_hexadecimal_colors( $error['comment'] );
 				}
 
@@ -1729,37 +1729,37 @@ class SystemReport {
 
 	/**
 	 * Convert the hexadecimal colors in the content into their rgb values
+	 *
 	 * @param string $content
 	 *
 	 * @return string
 	 */
-	private function replace_hexadecimal_colors($content) {
+	private function replace_hexadecimal_colors( $content ) {
 		$matches = array();
-		if (preg_match_all('/ (#(([a-f0-9]{8})|([a-f0-9]{4})))[ ;]/i', $content, $matches)) {
-			foreach($matches[1] as $hexadecimal_color) {
-				switch(strlen($hexadecimal_color)) {
+		if ( preg_match_all( '/ (#(([a-f0-9]{8})|([a-f0-9]{4})))[ ;]/i', $content, $matches ) ) {
+			foreach ( $matches[1] as $hexadecimal_color ) {
+				switch ( strlen( $hexadecimal_color ) ) {
 					case 9:
-						list($r, $g, $b, $a) = sscanf($hexadecimal_color, "#%02x%02x%02x%02x");
+						list($r, $g, $b, $a) = sscanf( $hexadecimal_color, '#%02x%02x%02x%02x' );
 						break;
 					case 5:
-						list($r, $g, $b, $a) = sscanf($hexadecimal_color, "#%01x%01x%01x%01x");
+						list($r, $g, $b, $a) = sscanf( $hexadecimal_color, '#%01x%01x%01x%01x' );
 						break;
 				}
-				$content = str_replace($hexadecimal_color, 'rgb('.$r.','.$g.','.$b.','.$a.')', $content);
+				$content = str_replace( $hexadecimal_color, 'rgb(' . $r . ',' . $g . ',' . $b . ',' . $a . ')', $content );
 			}
 		}
-		if (preg_match_all('/ (#(([a-f0-9]{6})|([a-f0-9]{3})))[ ;]/i', $content, $matches)) {
-			foreach($matches[1] as $hexadecimal_color) {
-				switch(strlen($hexadecimal_color)) {
+		if ( preg_match_all( '/ (#(([a-f0-9]{6})|([a-f0-9]{3})))[ ;]/i', $content, $matches ) ) {
+			foreach ( $matches[1] as $hexadecimal_color ) {
+				switch ( strlen( $hexadecimal_color ) ) {
 					case 7:
-						list($r, $g, $b) = sscanf($hexadecimal_color, "#%02x%02x%02x");
+						list($r, $g, $b) = sscanf( $hexadecimal_color, '#%02x%02x%02x' );
 						break;
 					case 4:
-						list($r, $g, $b) = sscanf($hexadecimal_color, "#%01x%01x%01x");
+						list($r, $g, $b) = sscanf( $hexadecimal_color, '#%01x%01x%01x' );
 						break;
-
 				}
-				$content = str_replace($hexadecimal_color, 'rgb('.$r.','.$g.','.$b.')', $content);
+				$content = str_replace( $hexadecimal_color, 'rgb(' . $r . ',' . $g . ',' . $b . ')', $content );
 			}
 		}
 		return $content;

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -777,6 +777,11 @@ class SystemReport {
 					$error['comment'] = '';
 				}
 
+				if (strpos($error['comment'], '<head>')) {
+					$error['comment'] = esc_html($error['comment']);
+					$error['comment'] = $this->replace_hexadecimal_colors( $error['comment'] );
+				}
+
 				$error['value']      = $this->convert_time_to_date( $error['value'], true, false );
 				$error['is_warning'] = ! empty( $error['name'] ) && stripos( $error['name'], 'archiv' ) !== false && 'archive_boot' !== $error['name'];
 				$error['is_error']   = $is_plugin_update_error;
@@ -1720,5 +1725,43 @@ class SystemReport {
 		}
 
 		return $rows;
+	}
+
+	/**
+	 * Convert the hexadecimal colors in the content into their rgb values
+	 * @param string $content
+	 *
+	 * @return string
+	 */
+	private function replace_hexadecimal_colors($content) {
+		$matches = array();
+		if (preg_match_all('/ (#(([a-f0-9]{8})|([a-f0-9]{4})))[ ;]/i', $content, $matches)) {
+			foreach($matches[1] as $hexadecimal_color) {
+				switch(strlen($hexadecimal_color)) {
+					case 9:
+						list($r, $g, $b, $a) = sscanf($hexadecimal_color, "#%02x%02x%02x%02x");
+						break;
+					case 5:
+						list($r, $g, $b, $a) = sscanf($hexadecimal_color, "#%01x%01x%01x%01x");
+						break;
+				}
+				$content = str_replace($hexadecimal_color, 'rgb('.$r.','.$g.','.$b.','.$a.')', $content);
+			}
+		}
+		if (preg_match_all('/ (#(([a-f0-9]{6})|([a-f0-9]{3})))[ ;]/i', $content, $matches)) {
+			foreach($matches[1] as $hexadecimal_color) {
+				switch(strlen($hexadecimal_color)) {
+					case 7:
+						list($r, $g, $b) = sscanf($hexadecimal_color, "#%02x%02x%02x");
+						break;
+					case 4:
+						list($r, $g, $b) = sscanf($hexadecimal_color, "#%01x%01x%01x");
+						break;
+
+				}
+				$content = str_replace($hexadecimal_color, 'rgb('.$r.','.$g.','.$b.')', $content);
+			}
+		}
+		return $content;
 	}
 }

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1736,20 +1736,21 @@ class SystemReport {
 	 */
 	private function replace_hexadecimal_colors( $content ) {
 		$matches = array();
-		if ( preg_match_all( '/ (#(([a-f0-9]{8})|([a-f0-9]{4})))[ ;]/i', $content, $matches ) ) {
+		if ( preg_match_all( '/ (#(([a-f0-9]{8})|([a-f0-9]{4}[ ;])))/i', $content, $matches ) ) {
 			foreach ( $matches[1] as $hexadecimal_color ) {
 				switch ( strlen( $hexadecimal_color ) ) {
 					case 9:
 						list($r, $g, $b, $a) = sscanf( $hexadecimal_color, '#%02x%02x%02x%02x' );
 						break;
-					case 5:
+					case 6:
+						$hexadecimal_color = substr($hexadecimal_color, 0, 5);
 						list($r, $g, $b, $a) = sscanf( $hexadecimal_color, '#%01x%01x%01x%01x' );
 						break;
 				}
 				$content = str_replace( $hexadecimal_color, 'rgb(' . $r . ',' . $g . ',' . $b . ',' . $a . ')', $content );
 			}
 		}
-		if ( preg_match_all( '/ (#(([a-f0-9]{6})|([a-f0-9]{3})))[ ;]/i', $content, $matches ) ) {
+		if ( preg_match_all( '/ (#(([a-f0-9]{6})|([a-f0-9]{3})))/i', $content, $matches ) ) {
 			foreach ( $matches[1] as $hexadecimal_color ) {
 				switch ( strlen( $hexadecimal_color ) ) {
 					case 7:

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1743,7 +1743,7 @@ class SystemReport {
 						list($r, $g, $b, $a) = sscanf( $hexadecimal_color, '#%02x%02x%02x%02x' );
 						break;
 					case 6:
-						$hexadecimal_color = substr($hexadecimal_color, 0, 5);
+						$hexadecimal_color   = substr( $hexadecimal_color, 0, 5 );
 						list($r, $g, $b, $a) = sscanf( $hexadecimal_color, '#%01x%01x%01x%01x' );
 						break;
 				}


### PR DESCRIPTION
Fixes #698 and fixes also a regression when there is HTML content in the line comment.

To test:
- add one of the incompatible plugins, such as the backwpup plugin. 
- add the wp-control plugin to be able to edit the cron tasks
- force the cli async mode by editing the app/core/CliMulti.php file: add line 179 the following content:
`$this->supportsAsync= true;`
- delete your wp_matomo_archive_blob and wp_matomo_archive_numeric tables
- edit the archive schedule time to reduce time to wait for this task (/wp-admin/tools.php?page=crontrol_admin_manage_page, hook name "matomo_scheduled_archive")
- let execute the archive process

You might have now a conflict error. It should be displayed in your system report.
Confirm in your system report (both the copied one and the one which is displayed in the diagnostic page) that the hexadecimal colours have been replaced by their rgb values.
