### PR TITLE
disable the diagnostic plugin

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -133,6 +133,9 @@ return array(
 		}
 		return array_values(array_filter($checks));
 	}),
+	'diagnostics.disabled'  => \DI\add([
+		\DI\get(\Piwik\Plugins\Diagnostics\Diagnostic\PageSpeedCheck::class),
+	]),
 	'observers.global' => DI\add(array(
 		array('FrontController.modifyErrorPage', DI\value(function (&$result, $ex) {
 			if (!empty($ex) && is_object($ex) && $ex instanceof \Piwik\Exception\NoWebsiteFoundException) {


### PR DESCRIPTION
When this plugin is enabled, it checks if the page speed feature is enabled. This is made by an http query.
Unfortunately, we block all these related queries in the WordPress plugin https://github.com/matomo-org/matomo-for-wordpress/blob/0e475dcbd3ceb16cdd4dafaa46c649a942f2a9d5/plugins/WordPress/WordPress.php#L338

With this update, the log trace won't be generated any more, and it will have no impact in the plugin as it is not available.

Fixes https://github.com/matomo-org/matomo/issues/20134