### PR TITLE
exclude wp-rocket from incompatible list if lower than 3.11.5

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1685,6 +1685,11 @@ class SystemReport {
 			];
 
 			$used_not_compatible = array_intersect( $active_plugins, $this->not_compatible_plugins );
+			if ( in_array( 'wp-rocket', $used_not_compatible, true ) ) {
+				if ( defined( 'WP_ROCKET_VERSION' ) && ( version_compare( WP_ROCKET_VERSION, '3.11.5' ) <= 0 ) ) {
+					unset( $used_not_compatible[ array_search( 'wp-rocket', $used_not_compatible, true ) ] );
+				}
+			}
 
 			if ( ! empty( $used_not_compatible ) ) {
 				$additional_comment = '';


### PR DESCRIPTION
Fixes #745 
https://innocraft.atlassian.net/browse/WBS-1363