### PR TITLE
Wbs 1317 review the sync sites process and add a warning if there is an unexpected configuration

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1019,16 +1019,6 @@ class SystemReport {
 			'name'  => 'Multisite Enabled',
 			'value' => $is_multi_site,
 		];
-		if ( ! $is_multi_site ) {
-			if ( $matomo_id_sites_number > 1 ) {
-				$rows[] = [
-					'name'       => 'Matomo sites',
-					'value'      => $matomo_id_sites_number,
-					'is_warning' => true,
-					'comment'    => esc_html__( 'There is an error in your Matomo records. Please contact wordpress@matomo.org', 'matomo' ),
-				];
-			}
-		}
 		$rows[] = [
 			'name'  => 'Network Enabled',
 			'value' => $is_network_enabled,
@@ -1460,10 +1450,17 @@ class SystemReport {
 		];
 
 		foreach ( [ 'user', 'site' ] as $table ) {
-			$rows[] = [
+			$row = [
 				'name'  => 'Matomo ' . $table . 's found',
 				'value' => $this->get_num_entries_in_table( $table ),
 			];
+			if ( 'site' === $table ) {
+				if ( ( ! is_multisite() ) && ( $row['value'] > 1 ) ) {
+					$row['is_warning'] = true;
+					$row['comment']    = esc_html__( 'There is an error in your Matomo records. Please contact wordpress@matomo.org', 'matomo' );
+				}
+			}
+			$rows[] = $row;
 		}
 
 		$grants = $this->get_db_grants();

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -138,23 +138,23 @@ class Sync {
 		$sites_manager_model = new Model();
 
 		if ( ! is_multisite() ) {
-            // we should have here only one record in the matomo_site table then...
+			// we should have here only one record in the matomo_site table then...
 			$matomo_id_sites = $sites_manager_model->getSitesId();
 			if ( count( $matomo_id_sites ) === 1 ) {
 				$matomo_id_site = (int) $matomo_id_sites[0];
 				if ( empty( $idsite ) ) {
-                    // we have one record in the matomo_site table but the mapping does not exist. Force usage of the ID found.
+					// we have one record in the matomo_site table but the mapping does not exist. Force usage of the ID found.
 					$idsite = $matomo_id_site;
 					$this->logger->log( "Can't find the id site in the mapping, but there is already an existing site. Use its ID " . $idsite . ' for blog' );
 				} else {
 					if ( (int) $idsite !== $matomo_id_site ) {
-                        // the mapped id in the WP config is different from the id in the matomo_site table: we force usage of the matomo table site ID
+						// the mapped id in the WP config is different from the id in the matomo_site table: we force usage of the matomo table site ID
 						$idsite = $matomo_id_site;
 						$this->logger->log( 'The id site in the mapping is different from the id site in the matomo table. Force usage of Matomo ID ' . $idsite . ' for blog' );
 					}
 				}
 			} else {
-                // there are more than one record: we'll have to identify which one has data and which one must be removed from the matomo_site table
+				// there are more than one record: we'll have to identify which one has data and which one must be removed from the matomo_site table
 				$this->logger->log( 'There is a problem in your configuration. Please contact support at wordpress@matomo.org' );
 				return false;
 			}

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -135,6 +135,27 @@ class Sync {
 
 		$idsite = Site::get_matomo_site_id( $blog_id );
 
+		$sites_manager_model = new Model();
+
+		if ( ! is_multisite() ) {
+			$id_sites = $sites_manager_model->getSitesId();
+			if ( count( $id_sites ) === 1 ) {
+				$matomo_id_site = (int) $id_sites[0];
+				if ( empty( $idsite ) ) {
+					$idsite = $matomo_id_site;
+					$this->logger->log( "Can't find the id site in the mapping, but there is already an existing site. Use its ID " . $idsite . ' for blog' );
+				} else {
+					if ( (int) $idsite !== $matomo_id_site ) {
+						$idsite = $matomo_id_site;
+						$this->logger->log( 'The id site in the mapping is different from the id site in the matomo table. Force usage of Matomo ID ' . $idsite . ' for blog' );
+					}
+				}
+			} else {
+				$this->logger->log( 'There is a problem in your configuration. Please contact support at wordpress@matomo.org' );
+				return false;
+			}
+		}
+
 		if ( empty( $blog_name ) ) {
 			$blog_name = esc_html__( 'Default', 'matomo' );
 		} else {
@@ -154,8 +175,7 @@ class Sync {
 		if ( ! empty( $idsite ) ) {
 			$this->logger->log( 'Matomo site is known for blog (' . $idsite . ')... will update' );
 
-			$sites_manager_model = new Model();
-			$site                = $sites_manager_model->getSiteFromId( $idsite );
+			$site = $sites_manager_model->getSiteFromId( $idsite );
 			if ( ! empty( $site ) ) {
 				// if site doesn't exist for some reason then we have to create it
 				if ( $site['name'] !== $blog_name

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -138,9 +138,9 @@ class Sync {
 		$sites_manager_model = new Model();
 
 		if ( ! is_multisite() ) {
-			$id_sites = $sites_manager_model->getSitesId();
-			if ( count( $id_sites ) === 1 ) {
-				$matomo_id_site = (int) $id_sites[0];
+			$matomo_id_sites = $sites_manager_model->getSitesId();
+			if ( count( $matomo_id_sites ) === 1 ) {
+				$matomo_id_site = (int) $matomo_id_sites[0];
 				if ( empty( $idsite ) ) {
 					$idsite = $matomo_id_site;
 					$this->logger->log( "Can't find the id site in the mapping, but there is already an existing site. Use its ID " . $idsite . ' for blog' );

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -138,19 +138,23 @@ class Sync {
 		$sites_manager_model = new Model();
 
 		if ( ! is_multisite() ) {
+            // we should have here only one record in the matomo_site table then...
 			$matomo_id_sites = $sites_manager_model->getSitesId();
 			if ( count( $matomo_id_sites ) === 1 ) {
 				$matomo_id_site = (int) $matomo_id_sites[0];
 				if ( empty( $idsite ) ) {
+                    // we have one record in the matomo_site table but the mapping does not exist. Force usage of the ID found.
 					$idsite = $matomo_id_site;
 					$this->logger->log( "Can't find the id site in the mapping, but there is already an existing site. Use its ID " . $idsite . ' for blog' );
 				} else {
 					if ( (int) $idsite !== $matomo_id_site ) {
+                        // the mapped id in the WP config is different from the id in the matomo_site table: we force usage of the matomo table site ID
 						$idsite = $matomo_id_site;
 						$this->logger->log( 'The id site in the mapping is different from the id site in the matomo table. Force usage of Matomo ID ' . $idsite . ' for blog' );
 					}
 				}
 			} else {
+                // there are more than one record: we'll have to identify which one has data and which one must be removed from the matomo_site table
 				$this->logger->log( 'There is a problem in your configuration. Please contact support at wordpress@matomo.org' );
 				return false;
 			}

--- a/plugins/WordPress/stylesheets/user.css
+++ b/plugins/WordPress/stylesheets/user.css
@@ -1,3 +1,3 @@
-div.siteSelector, #defaultReportSiteSelector, div[name="username"],div[name="language"], div[name="timeformat"],div[name="defaultReport"], #newsletterSignup {
+div[name="username"],div[name="language"], div[name="timeformat"],div[name="defaultReport"], #newsletterSignup {
     display: none;
 }


### PR DESCRIPTION
https://innocraft.atlassian.net/browse/WBS-1317

We currently have a problem in Matomo for WordPress when there are more than one site in the matomo_site table: the top controls are not displayed.

There are two problems for me:
- one in Matomo (Matomo should display the top controls whatever the number of websites we have)
- one in the plugin: the synchronization should create the same number of sites than the blogs ones.

This PR fixes the second problem in the non-multisite mode: if we identify a problem during the synchronization process, we try to fix it on our own to avoid creating others records in the site table.
This PR also add a warning in the system report if we detect this use case.

Possible contexts which lead to this problem:  the user deleted the configuration option which stored the Matomo site ID to use (it will create another site record).

To test:
- enable the debug mode (add WP_DEBUG, and WP_DEBUG_LOG in the wp-config.php
- Sync the website from the troubleshooting page: Everything should be ok and no synchronization should have been made
- Update the Matomo currency from the settings and sync the website: Everything should be OK, and you should have a synchronization process.
- Update the content of the site ID mapped with your blog but adding a non-existing site ID in the WordPress option : matomo-site-id-1, and then sync the website from the troubleshooting page: You should have a message telling you that we have used the Matomo site ID instead of the mapped one.
- Insert a new site in the Matomo site table and sync the blog: You should have a warning that there is a configuration error, the synchronization is not made, and a warning should be displayed in the System report.
You can do it with this SQL query:
```
INSERT INTO `wp_matomo_site` VALUES (2,'matomo','https://test.com','2023-02-24 11:00:00',1,1,'','','UTC','EUR',0,'','','','','','website',0,'super user was set');
```

Yes, this PR does not manage the multisite configurations, but this is probably a limited part of our users and would require to review completely the sync process.
 
@tsteur I also add you as reviewer, as you've worked a lot on the synchronization processes.
