### PR TITLE
sites sync fix

### DIFF
--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -146,17 +146,22 @@ class Sync {
 					// we have one record in the matomo_site table but the mapping does not exist. Force usage of the ID found.
 					$idsite = $matomo_id_site;
 					$this->logger->log( "Can't find the id site in the mapping, but there is already an existing site. Use its ID " . $idsite . ' for blog' );
+					wp_cache_flush();
+					add_site_option( Site::SITE_MAPPING_PREFIX . $blog_id, $idsite );
 				} else {
 					if ( (int) $idsite !== $matomo_id_site ) {
 						// the mapped id in the WP config is different from the id in the matomo_site table: we force usage of the matomo table site ID
 						$idsite = $matomo_id_site;
 						$this->logger->log( 'The id site in the mapping is different from the id site in the matomo table. Force usage of Matomo ID ' . $idsite . ' for blog' );
+						Site::map_matomo_site_id( $blog_id, $idsite );
 					}
 				}
 			} else {
-				// there are more than one record: we'll have to identify which one has data and which one must be removed from the matomo_site table
-				$this->logger->log( 'There is a problem in your configuration. Please contact support at wordpress@matomo.org' );
-				return false;
+				if ( count( $matomo_id_sites ) > 1 ) {
+					// there are more than one record: we'll have to identify which one has data and which one must be removed from the matomo_site table
+					$this->logger->log( 'There is a problem in your configuration. Please contact support at wordpress@matomo.org' );
+					return false;
+				}
 			}
 		}
 

--- a/tests/phpunit/wpmatomo/site/test-sync.php
+++ b/tests/phpunit/wpmatomo/site/test-sync.php
@@ -7,7 +7,7 @@ use Piwik\Plugins\SitesManager\Model;
 use WpMatomo\Settings;
 use WpMatomo\Site;
 use WpMatomo\Site\Sync;
-
+use WpMatomo\Db\Settings as DbSettings;
 class MockMatomoSiteSync extends Sync {
 	public $synced_sites = array();
 
@@ -30,13 +30,17 @@ class SiteSyncTest extends MatomoAnalytics_TestCase {
 	 * @var MockMatomoSiteSync
 	 */
 	private $mock;
-
+	/**
+	 * @var Site
+	 */
+	private $site;
 	public function setUp() {
 		parent::setUp();
 
 		$settings   = new Settings();
 		$this->sync = new Sync( $settings );
 		$this->mock = new MockMatomoSiteSync( $settings );
+		$this->site = new Site();
 	}
 
 	public function test_sync_all_does_not_fail() {
@@ -156,7 +160,17 @@ class SiteSyncTest extends MatomoAnalytics_TestCase {
 		);
 	}
 
-	public function test_sync_site_creates_new_matomo_site_when_blogid_is_unknown_and_updates_when_needed() {
+	/**
+	 * In this case (multisite mode), we can create and update existing sites,
+	 * Matomo data will be updated then.
+	 *
+	 * @return void
+	 */
+	public function test_sync_site_creates_new_matomo_site_when_blogid_is_unknown_and_updates_when_needed_in_multisite_mode() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
 		$matomo_sites = new Model();
 		$this->assertCount( 1, $matomo_sites->getAllSites() );
 
@@ -189,4 +203,153 @@ class SiteSyncTest extends MatomoAnalytics_TestCase {
 		$this->assertSame( 'https://changed1.foobar.com', $sites[1]['main_url'] );
 	}
 
+	/**
+	 * In this case (non-multisite mode), we can update anything we want,
+	 * we'll still have only one Matomo site and we'll only update that one.
+	 *
+	 * @return void
+	 */
+	public function test_sync_site_creates_new_matomo_site_when_blogid_is_unknown_and_updates_when_needed_in_non_multisite_mode() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Multisite.' );
+			return;
+		}
+		$matomo_sites = new Model();
+		$this->assertCount( 1, $matomo_sites->getAllSites() );
+
+		$blogid = 243;
+		$this->assertEmpty( Site::get_matomo_site_id( $blogid ) );
+		$this->assertTrue( $this->sync->sync_site( $blogid, 'myname422', 'https://baz1.foobar.com' ) );
+
+		$matomo_sites_records = $this->get_matomo_sites_records();
+		$expected_id_site     = Site::get_matomo_site_id( $blogid );
+		$this->assertEquals( $matomo_sites_records[0]->idsite, $expected_id_site );
+
+		$sites = $matomo_sites->getAllSites();
+
+		$this->assertCount( 1, $sites );
+		$this->assertSame( 'myname422', $sites[0]['name'] );
+		$this->assertSame( 'https://baz1.foobar.com', $sites[0]['main_url'] );
+		$this->assertSame( 'UTC', $sites[0]['timezone'] );
+		$this->assertEquals( '1', $sites[0]['ecommerce'] );
+
+		// now we updated
+		$this->assertTrue( $this->sync->sync_site( $blogid, 'myname422changed', 'https://changed1.foobar.com' ) );
+
+		$expected_id_site = Site::get_matomo_site_id( $blogid );
+		$this->assertEquals( 1, $expected_id_site );
+
+		$sites = $matomo_sites->getAllSites();
+		$this->assertCount( 1, $sites );
+		$this->assertEquals( $expected_id_site, $sites[0]['idsite'] );
+		$this->assertSame( 'myname422changed', $sites[0]['name'] );
+		$this->assertSame( 'https://changed1.foobar.com', $sites[0]['main_url'] );
+	}
+
+	/**
+	 * In non-multisite mode, we expect to have only one record in the matomo_site table
+	 * and the mapping of this id in the wp_option table.
+	 * When the sync process is not able to find the mapping value, it creates a new Matomo site record.
+	 * This case should not exist in a non-multisite context.
+	 *
+	 * This case can happen for example when some configuration options have been deleted by a plugin.
+	 *
+	 * We check with this test that the sync process is able to find the expected matomo site id,
+	 * and restore the expected configuration option
+	 *
+	 * @return void
+	 */
+	public function test_create_id_mapping_from_matomo_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Multisite.' );
+			return;
+		}
+		global $wpdb;
+		$options_table_name = $wpdb->prefix . 'options';
+        // @phpcs:ignore WordPress.DB
+		$wpdb->query( "DELETE FROM $options_table_name WHERE option_name LIKE '" . $this->site::SITE_MAPPING_PREFIX . "%'" );
+		wp_cache_flush();
+		$this->assertCount( 0, $this->get_wp_site_mapping_records() );
+
+		$sites = $this->get_matomo_sites_records();
+		$this->assertCount( 1, $sites );
+
+		$wp_mapping = $this->get_wp_site_mapping_records();
+		$this->assertCount( 0, $wp_mapping );
+		// here we don't have idsite mapping in WordPress, and one site in the Matomo table
+		$idsite = (int) $sites[0]->idsite;
+		// sync
+		$this->assertTrue( $this->sync->sync_current_site() );
+
+		// check if the WordPress mapping is not made on the Matomo site
+		$wp_mapping = $this->get_wp_site_mapping_records();
+		$this->assertCount( 1, $wp_mapping );
+		$this->assertEquals( $idsite, (int) $wp_mapping[0]->option_value );
+	}
+
+	/**
+	 * Same thing than the previous test case but in this one the mapping id does not match the
+	 * Matomo site record. It can happen when a database has been migrated from one environment to another.
+	 *
+	 * In this case (non-multisite, one record in Matomo site, one mapping option in wp_options but with a different id
+	 * than the expected one), we expect that the sync process will restore the expected value in the wp_option.
+	 *
+	 * @return void
+	 */
+	public function test_sync_id_mapping_from_matomo_site() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Multisite.' );
+			return;
+		}
+		global $wpdb;
+		$options_table_name = $wpdb->prefix . 'options';
+        // @phpcs:ignore WordPress.DB
+		$wpdb->query( "DELETE FROM $options_table_name WHERE option_name LIKE '" . $this->site::SITE_MAPPING_PREFIX . "%'" );
+		wp_cache_flush();
+		$this->assertCount( 0, $this->get_wp_site_mapping_records() );
+
+		$sites = $this->get_matomo_sites_records();
+		$this->assertCount( 1, $sites );
+		$idsite = (int) $sites[0]->idsite;
+
+		$false_mapping_idsite = $idsite + 1;
+		// create a false mapping
+		$this->assertTrue( add_site_option( $this->site::SITE_MAPPING_PREFIX . get_current_blog_id(), $false_mapping_idsite ) );
+		wp_cache_flush();
+        // @phpcs:ignore WordPress.DB
+		$mappings = $wpdb->get_results( "SELECT * FROM $options_table_name WHERE option_name = '" . $this->site::SITE_MAPPING_PREFIX . get_current_blog_id() . "' LIMIT 1" );
+		$this->assertEquals( $false_mapping_idsite, (int) $mappings[0]->option_value );
+		// here the mapping is not correct in the WP DB
+		// sync
+		$this->assertTrue( $this->sync->sync_current_site() );
+
+		$wp_mapping = $this->get_wp_site_mapping_records();
+		$this->assertCount( 1, $wp_mapping );
+		$this->assertEquals( $idsite, (int) $wp_mapping[0]->option_value );
+	}
+
+	/**
+	 * get the mapping options in the wp_options table
+	 *
+	 * @return stdClass[]|null
+	 */
+	private function get_wp_site_mapping_records() {
+		global $wpdb;
+		$options_table_name = $wpdb->prefix . 'options';
+        // @phpcs:ignore WordPress.DB
+		return $wpdb->get_results( "SELECT * FROM $options_table_name WHERE option_name LIKE '" . $this->site::SITE_MAPPING_PREFIX . "%'" );
+	}
+
+	/**
+	 * get the records in the matomo_site table
+	 *
+	 * @return stdClass[]|null
+	 */
+	private function get_matomo_sites_records() {
+		global $wpdb;
+		$db_settings     = new DbSettings();
+		$site_table_name = $db_settings->prefix_table_name( 'site' );
+        // @phpcs:ignore WordPress.DB
+		return $wpdb->get_results( "SELECT idsite, main_url FROM $site_table_name" );
+	}
 }


### PR DESCRIPTION
Hello @lance-matomo 
When testing the WordPress upgrades, I've identified a bug in the PR I've made for the site sync: it was not detected by the current unit tests.
So I've made the fix, and created new unit tests to detect these cases.
Please let me know if you have any question.

It would be nice if you could review this PR soon, to be able to include it with the future release which will include:
- tested for WP 6.2
- tested for WC 7.5
- Matomo 4.13.4

related to https://innocraft.atlassian.net/browse/WBS-1317