### PR TITLE
WBS-771 - hide 'show export URL' link from the export popin

### DIFF
--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -414,6 +414,7 @@ class WordPress extends Plugin
 	{
 		$files[] = "../plugins/WordPress/stylesheets/user.css";
 		$files[] = "../plugins/WordPress/stylesheets/optout.css";
+		$files[] = "../plugins/WordPress/stylesheets/export.css";
 	}
 
 }

--- a/plugins/WordPress/stylesheets/export.css
+++ b/plugins/WordPress/stylesheets/export.css
@@ -1,0 +1,3 @@
+.report-export-popover .toggle-export-url {
+    display: none;
+}


### PR DESCRIPTION
https://innocraft.atlassian.net/browse/WBS-771
In Matomo, when you click on the link "Export Data set in other formats" from a report, the "Show Export URL" link must be hidden.
![image](https://user-images.githubusercontent.com/86216084/228368669-abe93d0f-cce4-4627-b0f4-d20a66edb582.png)
