### PR TITLE
WBS-1565 Exclude grep from the system report

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -400,8 +400,8 @@ class SystemReport {
 		$rows = [];
 
 		if ( $this->shell_exec_available ) {
-			$phpcli_version = $this->get_phpcli_output( '-v | grep built | cut -d " " -f 2' );
-			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			$phpcli_version = $this->get_phpcli_output( '-r "echo phpversion();"' );
+            // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			global $piwik_minimumPHPVersion;
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			if ( version_compare( $phpcli_version, $piwik_minimumPHPVersion ) <= 0 ) {
@@ -418,13 +418,10 @@ class SystemReport {
 				'is_error' => $is_error,
 			];
 
-			switch ( $this->get_phpcli_output( '-m | grep mysqli' ) ) {
-				case 'mysqli':
-					$is_error = false;
-					$value    = __( 'ok', 'matomo' );
-					$comment  = '';
-					break;
-				default:
+			$is_error = false;
+			$value    = __( 'ok', 'matomo' );
+			$comment  = '';
+			if ( ! intval( $this->get_phpcli_output( '-r "echo extension_loaded(\'mysqli\');"' ) ) ) {
 					$value    = __( 'missing', 'matomo' );
 					$is_error = true;
 					$comment  = esc_html__( 'Your PHP cli does not load the MySQLi extension. You might have archiving problems in Matomo but also others problems in your WordPress cron tasks. You should enable this extension', 'matomo' );


### PR DESCRIPTION
https://innocraft.atlassian.net/browse/WBS-1564
https://innocraft.atlassian.net/browse/WBS-1565

A quick fix as there is an upcoming Matomo release (and so a plugin one): this problem has been reported 3 times (including one in GitHub).
Fixes https://github.com/matomo-org/matomo-for-wordpress/issues/805
Fixes https://github.com/matomo-org/matomo-for-wordpress/issues/803
