### PR TITLE
Fix: MaxMind license key doesnt fit in WP Admin (#810)

### DIFF
--- a/classes/WpMatomo/Admin/GeolocationSettings.php
+++ b/classes/WpMatomo/Admin/GeolocationSettings.php
@@ -52,7 +52,7 @@ class GeolocationSettings implements AdminSettingsInterface {
 
 			if ( empty( $maxmind_license ) ) {
 				$maxmind_license = '';
-			} elseif ( strlen( $maxmind_license ) > 20 || strlen( $maxmind_license ) < 7 || ! ctype_graph( $maxmind_license ) ) {
+			} elseif ( strlen( $maxmind_license ) > 40 || strlen( $maxmind_license ) < 7 || ! ctype_graph( $maxmind_license ) ) {
 				return false;
 			}
 

--- a/classes/WpMatomo/Admin/views/geolocation_settings.php
+++ b/classes/WpMatomo/Admin/views/geolocation_settings.php
@@ -52,7 +52,7 @@ if ( $invalid_format ) { ?>
 				<label for="<?php echo esc_attr( GeolocationSettings::FORM_NAME ); ?>"><?php esc_html_e( 'MaxMind License Key', 'matomo' ); ?></label>:
 			</th>
 			<td>
-				<input size="20" type="text" maxlength="20"
+				<input size="40" type="text" maxlength="40"
 					   id="<?php echo esc_attr( GeolocationSettings::FORM_NAME ); ?>"
 					   name="<?php echo esc_attr( GeolocationSettings::FORM_NAME ); ?>"
 					   value="<?php echo esc_attr( $current_maxmind_license ); ?>">


### PR DESCRIPTION
### Description:

Currently, the MaxMind license key input field is limited to 20 characters. I just recently created my first MaxMind license, which had 40 characters. I'm not sure if this was changed recently.

I changed the code where Matomo restricted the key length to 20 and updated it to 40.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
