### PR TITLE
fix trusted_host set on install doesn't work when wordpress is installed in a subfolder

### DIFF
--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -258,6 +258,7 @@ class Installer {
 	private function create_config( $db_info ) {
 		$this->logger->log( 'Matomo is now creating the config' );
 		$domain  = home_url();
+		$domain = parse_url($domain, PHP_URL_HOST) ?: $domain;
 		$general = [
 			'trusted_hosts' => [ $domain ],
 			'salt'          => Common::generateUniqId(),

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -257,15 +257,15 @@ class Installer {
 
 	private function create_config( $db_info ) {
 		$this->logger->log( 'Matomo is now creating the config' );
-		$homeUrl = home_url();
-		$domain = wp_parse_url($homeUrl, PHP_URL_HOST);
-		$domain = $domain ? $homeUrl : $domain;
-		$general = [
+		$home_url = home_url();
+		$domain   = wp_parse_url( $home_url, PHP_URL_HOST );
+		$domain   = $domain ? $home_url : $domain;
+		$general  = [
 			'trusted_hosts' => [ $domain ],
 			'salt'          => Common::generateUniqId(),
 		];
-		$config  = Config::getInstance();
-		$path    = $config->getLocalPath();
+		$config   = Config::getInstance();
+		$path     = $config->getLocalPath();
 		if ( ! is_dir( dirname( $path ) ) ) {
 			wp_mkdir_p( dirname( $path ) );
 		}

--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -257,8 +257,9 @@ class Installer {
 
 	private function create_config( $db_info ) {
 		$this->logger->log( 'Matomo is now creating the config' );
-		$domain  = home_url();
-		$domain = parse_url($domain, PHP_URL_HOST) ?: $domain;
+		$homeUrl = home_url();
+		$domain = wp_parse_url($homeUrl, PHP_URL_HOST);
+		$domain = $domain ? $homeUrl : $domain;
 		$general = [
 			'trusted_hosts' => [ $domain ],
 			'salt'          => Common::generateUniqId(),


### PR DESCRIPTION
### Description:

The matomo installer code that creates config.ini.php currently adds the entire `home_url()` return value as the subdomain. If wordpress is in a subfolder, like `http://localhost/path/to/wordpress`, the entire URL is added as the trusted host, which fails. Fixed by getting the domain of the URL and using that (unless that fails for some reason).

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
