### PR TITLE
Add docker-compose.yml for a easy to setup local dev environment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -40,3 +40,4 @@ composer.travis.json export-ignore
 karma.conf.js export-ignore
 .DS_Store export-ignore
 .editorconfig export-ignore
+docker-compose.yml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 .php-cs-fixer.cache
 .*~
 *~
+.idea/
+
+# for local docker dev
+docker
+.env

--- a/README.md
+++ b/README.md
@@ -40,6 +40,35 @@ Now run the below command to have phpunit etc available. Requires [Composer](htt
 composer install # or composer.phar install
 ```
 
+#### Local environment through docker
+
+If you have docker and docker-compose installed, you can setup a local development environment with a single command:
+
+```bash
+docker-compose up wordpress; docker-compose stop
+```
+
+The first time the container starts it will compile php extensions within the container it needs, download wordpress
+and set it up.
+
+After starting the container, visit `https://localhost:3000/` to see the list of available wordpress versions.
+Pick one, and it will take you to the Wordpress installer.
+
+After installing Wordpress, go to the plugins page and activate Matomo for Wordpress.
+
+Note: docker related files, such as the downloaded wordpress and database files, will be stored in a new folder named `./docker`. As long
+as you are using this local dev environment, you should not delete this folder.
+
+**Customizing your local environment**
+
+You can customize your local environment by setting environment variables in a `.env` file. Currently, the following
+variables are supported:
+
+- `PHP_VERSION` - (defaults to 8.1, must be a version that has an official docker container available)
+- `BACKEND` - ('mariadb' or 'mysql', defaults to 'mariadb')
+- `WORDPRESS_VERSION` - (defaults to 6.3.1)
+- `PORT` - (the port to expose wordpress on, defaults to 3000)
+
 ## Security
 
 Security is a top priority at Matomo. As potential issues are discovered, we validate, patch and release fixes as quickly as we can. We have a security bug bounty program in place that rewards researchers for finding security issues and disclosing them to us.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,9 @@ services:
     image: "php:${PHP_VERSION:-8.1}-apache"
     volumes:
       - ./docker/wordpress:/var/www/html
-      - ./docker/wordpress_php:/usr/src/php
-      - ./docker/wordpress_php_extensions:/usr/local/lib/php/extensions
-      - ./docker/wordpress_php_conf:/usr/local/etc/php/conf.d
+      - "./docker/php-${PHP_VERSION:-8.1}/php:/usr/src/php"
+      - "./docker/php-${PHP_VERSION:-8.1}/extensions:/usr/local/lib/php/extensions"
+      - "./docker/php-${PHP_VERSION:-8.1}/conf:/usr/local/etc/php/conf.d"
       - .:/var/www/html/matomo-for-wordpress
       - /var/www/html/matomo-for-wordpress/app/tmp
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,7 @@ services:
 
         define( 'FS_CHMOD_DIR', ( 0777 & ~ umask() ) );
         define( 'FS_CHMOD_FILE', ( 0644 & ~ umask() ) );
+        define( 'FS_METHOD', 'direct' );
 
         define( 'MATOMO_ANALYTICS_FILE', __DIR__ . '/wp-content/plugins/matomo/matomo.php' );
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
 
         define( 'MATOMO_ANALYTICS_FILE', __DIR__ . '/wp-content/plugins/matomo/matomo.php' );
 
-        $$table_prefix = 'wp_';
+        \$$table_prefix = 'wp_';
 
         /* That's all, stop editing! Happy publishing. */
         

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,131 @@
+# to override the environment, you can configure environment variables in a .env file saved in this directory.
+# the following environment variables are supported:
+#   - PHP_VERSION (defaults to 8.1, must be a version that has an official docker container available)
+#   - BACKEND ('mariadb' or 'mysql', defaults to 'mariadb')
+#   - WORDPRESS_VERSION (defaults to )
+#   - PORT (the port to expose wordpress on, defaults to 3000)
+
+services:
+  wordpress:
+    image: "php:${PHP_VERSION:-8.1}-apache"
+    volumes:
+      - ./docker/wordpress:/var/www/html
+      - ./docker/wordpress_php:/usr/src/php
+      - ./docker/wordpress_php_extensions:/usr/local/lib/php/extensions
+      - ./docker/wordpress_php_conf:/usr/local/etc/php/conf.d
+      - .:/var/www/html/matomo-for-wordpress
+    ports:
+      - "${PORT:-3000}:80"
+    environment:
+      WP_DB_USER: root
+      WP_DB_PASSWORD: pass
+      WP_DB_HOST: "${BACKEND:-mariadb}"
+    entrypoint:
+      - bash
+      - -c
+      - |
+        set -e
+
+        cd /var/www/html
+        
+        LATEST_WORDPRESS_VERSION=6.3.1 # can't use the github API, too easy to get rate limited
+
+        # install PHP extensions needed
+        for extension in mysqli pdo pdo_mysql; do
+          if [ ! -f /usr/local/lib/php/extensions/*/$$extension.so ]; then
+            docker-php-ext-install $$extension
+          fi
+        done
+
+        # install wordpress if not present
+        WORDPRESS_VERSION=$${WORDPRESS_VERSION:-$$LATEST_WORDPRESS_VERSION}
+        if [ ! -d "/var/www/html/$$WORDPRESS_VERSION" ]; then
+          WORDPRESS_URL="https://wordpress.org/wordpress-$$WORDPRESS_VERSION.tar.gz"
+          echo "installing wordpress $$WORDPRESS_VERSION from $$WORDPRESS_URL..."
+
+          curl -O "$$WORDPRESS_URL"
+          tar -xvf "wordpress-$$WORDPRESS_VERSION.tar.gz"
+          mv wordpress "$$WORDPRESS_VERSION"
+
+          echo "wordpress installed!"
+        else
+          echo "wordpress $$WORDPRESS_VERSION already installed."
+        fi
+
+        # create database if it does not already exist
+        export WP_DB_NAME="wp_matomo_$$WORDPRESS_VERSION"
+        php -r "\$$pdo = new PDO('mysql:host=$$WP_DB_HOST', '$$WP_DB_USER', '$$WP_DB_PASSWORD'); \$$pdo->exec('CREATE DATABASE IF NOT EXISTS \`$$WP_DB_NAME\`');"
+
+        # setup wordpress config if not done so
+        if [ ! -f "/var/www/html/$$WORDPRESS_VERSION/wp-config.php" ]; then
+          cat > "/var/www/html/$$WORDPRESS_VERSION/wp-config.php" <<EOF
+        <?php
+        define('DB_NAME', getenv('WP_DB_NAME'));
+        define('DB_USER', getenv('WP_DB_USER'));
+        define('DB_PASSWORD', getenv('WP_DB_PASSWORD'));
+        define('DB_HOST', getenv('WP_DB_HOST'));
+        define('DB_CHARSET', 'utf8');
+        define('DB_COLLATE', '');
+        define( 'WP_DEBUG', (bool)getenv('WP_DEBUG') );
+      
+        define( 'AUTH_KEY',         'put your unique phrase here' );
+        define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+        define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+        define( 'NONCE_KEY',        'put your unique phrase here' );
+        define( 'AUTH_SALT',        'put your unique phrase here' );
+        define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+        define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+        define( 'NONCE_SALT',       'put your unique phrase here' );
+      
+        $$table_prefix = 'wp_';
+
+        /* That's all, stop editing! Happy publishing. */
+        
+        /** Absolute path to the WordPress directory. */
+        if ( ! defined( 'ABSPATH' ) ) {
+          define( 'ABSPATH', __DIR__ . '/' );
+        }
+        
+        /** Sets up WordPress vars and included files. */
+        require_once ABSPATH . 'wp-settings.php';
+        EOF
+
+          echo "setup wp-config.php!"
+        fi
+
+        # link matomo for wordpress volume as wordpress plugin
+        if [ ! -d "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo" ]; then
+          ln -s /var/www/html/matomo-for-wordpress "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo"
+        fi
+
+        # make sure the files can be edited outside of docker (for easier debugging)
+        chown -R "${UID:-1000}:${GID:-1000}" /var/www/html
+
+        # ordinarily the command is passed to the entrypoint as an argument, but this doesn't seem to work when overriding the entrypoint
+        # through docker-compose
+        apache2-foreground
+    depends_on:
+      - "${BACKEND:-mariadb}"
+    deploy:
+      restart_policy:
+        condition: on-failure
+  mariadb:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: pass
+    volumes:
+      - ./docker/mariadb:/var/lib/mysql:delegated
+      - ./docker/maria_custom_my.cnf:/etc/mysql/conf.d/mycustom.cnf
+    deploy:
+      restart_policy:
+        condition: on-failure
+  mysql:
+    image: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: pass
+    volumes:
+      - ./docker/mysql:/var/lib/mysql:delegated
+      - ./docker/container-files/mysql_custom_my.cnf:/etc/mysql/conf.d/mycustom.cnf
+    deploy:
+      restart_policy:
+        condition: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,11 +111,43 @@ services:
           ln -s /var/www/html/matomo-for-wordpress "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo"
         fi
 
+        # add index.php file listing available installs to root /var/www/html
+        if [ ! -f "/var/www/html/index.php" ]; then
+          cat > "/var/www/html/index.php" <<EOF
+        <html lang="en">
+        <head>
+        <style>
+          body { padding: 0; margin: 0; font-family: sans-serif; background-color: #f8f8f8; height: calc(100%); display: flex; flex-direction: column; }
+          header { background-color: lightskyblue; padding: 10px 0; }
+          h1 { text-align: center; margin: 0; color: #fafafa; }
+          .content { width: 800px; margin: 20px auto; background-color: white; padding: 20px; flex: 1; overflow-y: auto; }
+        </style>
+        </head>
+        <body>
+        <header><h1>Available Wordpress Installs</h1></header>
+        <div class="content">
+        <ul>
+        <?php
+          foreach (scandir(__DIR__) as \$$folder) {
+            if (preg_match('/^\d+\.\d+\.\d+\$$/', \$$folder) && is_dir(\$$folder)) {
+        ?>
+        <li><a href="<?php echo \$$folder; ?>/"><?php echo \$$folder; ?></a></li>
+        <?php
+            }
+          }
+        ?>
+        </ul>
+        </div>
+        </body>
+        </html>
+        EOF
+        fi
+
         # make sure the files can be edited outside of docker (for easier debugging)
         # TODO: file permissions becoming a pain, shouldn't have to deal with this for dev env. this works for now though.
         find "/var/www/html/$$WORDPRESS_VERSION" -path "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo" -prune -o -exec chown "${UID:-1000}:${GID:-1000}" {} +
         find "/var/www/html/$$WORDPRESS_VERSION" -path "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo" -prune -o -exec chmod 0777 {} +
-        chmod -R 0777 "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo/app/tmp"
+        chmod -R 0777 "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo/app/tmp" "/var/www/html/index.php"
 
         # ordinarily the command is passed to the entrypoint as an argument, but this doesn't seem to work when overriding the entrypoint
         # through docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
         define( 'FS_CHMOD_DIR', ( 0777 & ~ umask() ) );
         define( 'FS_CHMOD_FILE', ( 0644 & ~ umask() ) );
 
+        define( 'MATOMO_ANALYTICS_FILE', __DIR__ . '/wp-content/plugins/matomo/matomo.php' );
+
         $$table_prefix = 'wp_';
 
         /* That's all, stop editing! Happy publishing. */

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # the following environment variables are supported:
 #   - PHP_VERSION (defaults to 8.1, must be a version that has an official docker container available)
 #   - BACKEND ('mariadb' or 'mysql', defaults to 'mariadb')
-#   - WORDPRESS_VERSION (defaults to )
+#   - WORDPRESS_VERSION (defaults to latest (defined below))
 #   - PORT (the port to expose wordpress on, defaults to 3000)
 
 services:
@@ -52,9 +52,13 @@ services:
           echo "wordpress $$WORDPRESS_VERSION already installed."
         fi
 
+        sleep 5 # wait for database
+
         # create database if it does not already exist
-        export WP_DB_NAME="wp_matomo_$$WORDPRESS_VERSION"
-        php -r "\$$pdo = new PDO('mysql:host=$$WP_DB_HOST', '$$WP_DB_USER', '$$WP_DB_PASSWORD'); \$$pdo->exec('CREATE DATABASE IF NOT EXISTS \`$$WP_DB_NAME\`');"
+        export WP_DB_NAME=$$(echo "wp_matomo_$$WORDPRESS_VERSION" | sed 's/\./_/g')
+        php -r "\$$pdo = new PDO('mysql:host=$$WP_DB_HOST', '$$WP_DB_USER', '$$WP_DB_PASSWORD');
+        \$$pdo->exec('CREATE DATABASE IF NOT EXISTS \`$$WP_DB_NAME\`');\
+        \$$pdo->exec('GRANT ALL PRIVILEGES ON $$WP_DB_NAME.* TO \'root\'@\'%\' IDENTIFIED BY \'pass\'');"
 
         # setup wordpress config if not done so
         if [ ! -f "/var/www/html/$$WORDPRESS_VERSION/wp-config.php" ]; then
@@ -99,7 +103,7 @@ services:
         fi
 
         # make sure the files can be edited outside of docker (for easier debugging)
-        chown -R "${UID:-1000}:${GID:-1000}" /var/www/html
+        find "/var/www/html/$$WORDPRESS_VERSION" -path "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo" -prune -o -exec chown "${UID:-1000}:${GID:-1000}" {} +
 
         # ordinarily the command is passed to the entrypoint as an argument, but this doesn't seem to work when overriding the entrypoint
         # through docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
         # TODO: file permissions becoming a pain, shouldn't have to deal with this for dev env. this works for now though.
         find "/var/www/html/$$WORDPRESS_VERSION" -path "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo" -prune -o -exec chown "${UID:-1000}:${GID:-1000}" {} +
         find "/var/www/html/$$WORDPRESS_VERSION" -path "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo" -prune -o -exec chmod 0777 {} +
-        chmod -R 0777 "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo/app/tmp" "/var/www/html/index.php"
+        chmod -R 0777 "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo/app/tmp" "/var/www/html/index.php" "/usr/local/etc/php/conf.d"
 
         # ordinarily the command is passed to the entrypoint as an argument, but this doesn't seem to work when overriding the entrypoint
         # through docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - ./docker/wordpress_php_extensions:/usr/local/lib/php/extensions
       - ./docker/wordpress_php_conf:/usr/local/etc/php/conf.d
       - .:/var/www/html/matomo-for-wordpress
+      - /var/www/html/matomo-for-wordpress/app/tmp
     ports:
       - "${PORT:-3000}:80"
     environment:
@@ -52,7 +53,9 @@ services:
           echo "wordpress $$WORDPRESS_VERSION already installed."
         fi
 
+        echo "waiting for database..."
         sleep 5 # wait for database
+        echo "done."
 
         # create database if it does not already exist
         export WP_DB_NAME=$$(echo "wp_matomo_$$WORDPRESS_VERSION" | sed 's/\./_/g')
@@ -80,7 +83,10 @@ services:
         define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
         define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
         define( 'NONCE_SALT',       'put your unique phrase here' );
-      
+
+        define( 'FS_CHMOD_DIR', ( 0777 & ~ umask() ) );
+        define( 'FS_CHMOD_FILE', ( 0644 & ~ umask() ) );
+
         $$table_prefix = 'wp_';
 
         /* That's all, stop editing! Happy publishing. */
@@ -103,7 +109,10 @@ services:
         fi
 
         # make sure the files can be edited outside of docker (for easier debugging)
+        # TODO: file permissions becoming a pain, shouldn't have to deal with this for dev env. this works for now though.
         find "/var/www/html/$$WORDPRESS_VERSION" -path "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo" -prune -o -exec chown "${UID:-1000}:${GID:-1000}" {} +
+        find "/var/www/html/$$WORDPRESS_VERSION" -path "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo" -prune -o -exec chmod 0777 {} +
+        chmod -R 0777 "/var/www/html/$$WORDPRESS_VERSION/wp-content/plugins/matomo/app/tmp"
 
         # ordinarily the command is passed to the entrypoint as an argument, but this doesn't seem to work when overriding the entrypoint
         # through docker-compose


### PR DESCRIPTION
### Description:

To start the environment, clone the repo and run:

```bash
docker-compose up wordpress; docker-compose stop
```

Everything required for the local environment is specified in the docker-compose.yml file, including bash scripts. This might be a bit unorthodox, but is done to keep from adding clutter to the repository.

The environment can be customized using environment variables specified in a `.env` file (see README for the list of supported env vars).

Fixes WBS-1685

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
