### PR TITLE
workaround Fluent SMTP bug

### DIFF
--- a/classes/WpMatomo/Email.php
+++ b/classes/WpMatomo/Email.php
@@ -97,9 +97,11 @@ class Email {
 			$header          = 'X-Matomo: ' . $random_id;
 			$executed_action = false;
 
+			$fluent_smtp_workaround = new WpMatomo\Workarounds\FluentSmtp();
+
 			add_action(
 				'phpmailer_init',
-				function ( &$phpmailer ) use ( $attachments, $subject, $random_id, &$executed_action ) {
+				function ( &$phpmailer ) use ( $attachments, $subject, $random_id, &$executed_action, $fluent_smtp_workaround ) {
 					/** @var PHPMailer $phpmailer */
 					if ( $executed_action ) {
 						return; // already done, do not execute another time
@@ -136,7 +138,7 @@ class Email {
 						}
 					}
 
-					$phpmailer = WpMatomo\Workarounds\FluentSmtp::make_php_mailer_proxy( $phpmailer );
+					$phpmailer = $fluent_smtp_workaround->make_php_mailer_proxy( $phpmailer );
 				}
 			);
 		}
@@ -146,7 +148,7 @@ class Email {
 		remove_action( 'wp_mail_failed', [ $this, 'on_error' ] );
 		remove_filter( 'wp_mail_content_type', [ $this, 'set_content_type' ] );
 
-		WpMatomo\Workarounds\FluentSmtp::unset_phpmailer();
+		$fluent_smtp_workaround->reset_phpmailer();
 
 		if ( ! $success ) {
 			$message = 'Error unknown.';

--- a/classes/WpMatomo/Email.php
+++ b/classes/WpMatomo/Email.php
@@ -136,7 +136,7 @@ class Email {
 						}
 					}
 
-                    $phpmailer = WpMatomo\Workarounds\FluentSmtp::make_php_mailer_proxy($phpmailer);
+					$phpmailer = WpMatomo\Workarounds\FluentSmtp::make_php_mailer_proxy( $phpmailer );
 				}
 			);
 		}
@@ -146,7 +146,7 @@ class Email {
 		remove_action( 'wp_mail_failed', [ $this, 'on_error' ] );
 		remove_filter( 'wp_mail_content_type', [ $this, 'set_content_type' ] );
 
-        WpMatomo\Workarounds\FluentSmtp::unset_phpmailer();
+		WpMatomo\Workarounds\FluentSmtp::unset_phpmailer();
 
 		if ( ! $success ) {
 			$message = 'Error unknown.';

--- a/classes/WpMatomo/Email.php
+++ b/classes/WpMatomo/Email.php
@@ -99,7 +99,7 @@ class Email {
 
 			add_action(
 				'phpmailer_init',
-				function ( $phpmailer ) use ( $attachments, $subject, $random_id, &$executed_action ) {
+				function ( &$phpmailer ) use ( $attachments, $subject, $random_id, &$executed_action ) {
 					/** @var PHPMailer $phpmailer */
 					if ( $executed_action ) {
 						return; // already done, do not execute another time
@@ -135,6 +135,8 @@ class Email {
 							);
 						}
 					}
+
+                    $phpmailer = WpMatomo\Workarounds\FluentSmtp::make_php_mailer_proxy($phpmailer);
 				}
 			);
 		}
@@ -143,6 +145,8 @@ class Email {
 
 		remove_action( 'wp_mail_failed', [ $this, 'on_error' ] );
 		remove_filter( 'wp_mail_content_type', [ $this, 'set_content_type' ] );
+
+        WpMatomo\Workarounds\FluentSmtp::unset_phpmailer();
 
 		if ( ! $success ) {
 			$message = 'Error unknown.';

--- a/classes/WpMatomo/Workarounds/FluentSmtp.php
+++ b/classes/WpMatomo/Workarounds/FluentSmtp.php
@@ -33,7 +33,7 @@ class FluentSmtp {
 		}
 
 		$this->was_phpmailer_replaced = true;
-		$this->original_phpmailer = $phpmailer;
+		$this->original_phpmailer     = $phpmailer;
 
 		return new PHPMailerProxy( $phpmailer );
 	}

--- a/classes/WpMatomo/Workarounds/FluentSmtp.php
+++ b/classes/WpMatomo/Workarounds/FluentSmtp.php
@@ -33,6 +33,7 @@ class FluentSmtp {
 		}
 
 		$this->was_phpmailer_replaced = true;
+		$this->original_phpmailer = $phpmailer;
 
 		return new PHPMailerProxy( $phpmailer );
 	}

--- a/classes/WpMatomo/Workarounds/FluentSmtp.php
+++ b/classes/WpMatomo/Workarounds/FluentSmtp.php
@@ -9,59 +9,40 @@
 
 namespace WpMatomo\Workarounds;
 
+use WpMatomo\Workarounds\FluentSmtp\PHPMailerProxy;
+
 /**
- * Workarounds for bugs in the Fluent SMTP wordpress plugin.
+ * Workarounds for bugs in the Fluent SMTP WordPress plugin.
  */
-class FluentSmtp
-{
-    /**
-     * Worksaround this bug in Fluent SMTP: https://github.com/WPManageNinja/fluent-smtp/issues/180
-     * by creating a proxy to the global PHPMailer object that disables the addAttachment() method.
-     *
-     * Should be used in a phpmailer_init action after manually adding attachments to the original
-     * PHPMailer instance.
-     */
-    public static function make_php_mailer_proxy( $phpmailer ) {
-        if ( ! is_plugin_active( 'fluent-smtp/fluent-smtp.php' ) ) {
-            return $phpmailer;
-        }
+class FluentSmtp {
+	/**
+	 * Worksaround this bug in Fluent SMTP: https://github.com/WPManageNinja/fluent-smtp/issues/180
+	 * by creating a proxy to the global PHPMailer object that disables the addAttachment() method.
+	 *
+	 * Should be used in a phpmailer_init action after manually adding attachments to the original
+	 * PHPMailer instance.
+	 */
+	public static function make_php_mailer_proxy( $phpmailer ) {
+		if ( ! is_plugin_active( 'fluent-smtp/fluent-smtp.php' ) ) {
+			return $phpmailer;
+		}
 
-        return new class( $phpmailer ) {
-            private $wrapped;
+		return new PHPMailerProxy( $phpmailer );
+	}
 
-            public function __construct( $phpmailer ) {
-                $this->wrapped = $phpmailer;
-            }
+	/**
+	 * FluentSMTP will check if the global phpmailer object's class is actually PHPMailer, and if not, abort
+	 * so we need to make sure it doesn't see our wrapped proxy again.
+	 */
+	public static function unset_phpmailer() {
+		global $phpmailer;
 
-            public function __get( $name )
-            {
-                return $this->wrapped->$name;
-            }
+		if ( ! is_plugin_active( 'fluent-smtp/fluent-smtp.php' ) ) {
+			return;
+		}
 
-            public function __set( $name, $value )
-            {
-                $this->wrapped->$name = $value;
-            }
-
-            public function __call( $name , $arguments ) {
-                if ( $name == 'addAttachment' ) {
-                    return;
-                }
-
-                return call_user_func_array([$this->wrapped, $name], $arguments);
-            }
-        };
-    }
-
-    // fluent smtp will check if the global phpmailer object's class is actually PHPMailer, and if not, abort
-    // so we need to make sure it doesn't see our wrapped proxy again.
-    public static function unset_phpmailer() {
-        global $phpmailer;
-
-        if ( ! is_plugin_active( 'fluent-smtp/fluent-smtp.php' ) ) {
-            return;
-        }
-
-        $phpmailer = null;
-    }
+		// @codingStandardsIgnoreStart
+		$phpmailer = null;
+		// @codingStandardsIgnoreEnd
+	}
 }

--- a/classes/WpMatomo/Workarounds/FluentSmtp.php
+++ b/classes/WpMatomo/Workarounds/FluentSmtp.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+namespace WpMatomo\Workarounds;
+
+/**
+ * Workarounds for bugs in the Fluent SMTP wordpress plugin.
+ */
+class FluentSmtp
+{
+    /**
+     * Worksaround this bug in Fluent SMTP: https://github.com/WPManageNinja/fluent-smtp/issues/180
+     * by creating a proxy to the global PHPMailer object that disables the addAttachment() method.
+     *
+     * Should be used in a phpmailer_init action after manually adding attachments to the original
+     * PHPMailer instance.
+     */
+    public static function make_php_mailer_proxy( $phpmailer ) {
+        if ( ! is_plugin_active( 'fluent-smtp/fluent-smtp.php' ) ) {
+            return $phpmailer;
+        }
+
+        return new class( $phpmailer ) {
+            private $wrapped;
+
+            public function __construct( $phpmailer ) {
+                $this->wrapped = $phpmailer;
+            }
+
+            public function __get( $name )
+            {
+                return $this->wrapped->$name;
+            }
+
+            public function __set( $name, $value )
+            {
+                $this->wrapped->$name = $value;
+            }
+
+            public function __call( $name , $arguments ) {
+                if ( $name == 'addAttachment' ) {
+                    return;
+                }
+
+                return call_user_func_array([$this->wrapped, $name], $arguments);
+            }
+        };
+    }
+
+    // fluent smtp will check if the global phpmailer object's class is actually PHPMailer, and if not, abort
+    // so we need to make sure it doesn't see our wrapped proxy again.
+    public static function unset_phpmailer() {
+        global $phpmailer;
+
+        if ( ! is_plugin_active( 'fluent-smtp/fluent-smtp.php' ) ) {
+            return;
+        }
+
+        $phpmailer = null;
+    }
+}

--- a/classes/WpMatomo/Workarounds/FluentSmtp/PHPMailerProxy.php
+++ b/classes/WpMatomo/Workarounds/FluentSmtp/PHPMailerProxy.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+namespace WpMatomo\Workarounds\FluentSmtp;
+
+class PHPMailerProxy {
+	private $wrapped;
+
+	public function __construct( $phpmailer ) {
+		$this->wrapped = $phpmailer;
+	}
+
+	// @codingStandardsIgnoreStart
+
+	public function __get( $name )
+	{
+		return $this->wrapped->$name;
+	}
+
+	public function __set( $name, $value )
+	{
+		$this->wrapped->$name = $value;
+	}
+
+	public function __call( $name , $arguments ) {
+		if ( $name == 'addAttachment' ) {
+			return;
+		}
+
+		return call_user_func_array([$this->wrapped, $name], $arguments);
+	}
+
+	// @codingStandardsIgnoreEnd
+}


### PR DESCRIPTION
### Description:

FluentSMTP has a bug where it will try to add attachments already added to a PHPMailer instance again. For some types of attachments this just fails, and for others I'm guessing it will duplicate the attachment. This PR works around that issue by creating a proxy to the PHPMailer instance that disables the addAttachment method FluentSMTP uses.

The workaround is kept in a new class in a Workarounds namespace to keep it separate from Matomo for Wordpress code and is only used if the FluentSMTP plugin is active.

To test whether it works:
- download and setup FluentSMTP using the SMTP handler (using mailtrap.io as an smtp server)
- create a PDF report in Matomo
- click the send report now button

Refs https://github.com/WPManageNinja/fluent-smtp/issues/180
Fixes #674 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
