### PR TITLE
Add ability to download and install plugins to local dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,13 @@ as you are using this local dev environment, you should not delete this folder.
 You can customize your local environment by setting environment variables in a `.env` file. Currently, the following
 variables are supported:
 
-- `PHP_VERSION` - (defaults to 8.1, must be a version that has an official docker container available)
-- `BACKEND` - ('mariadb' or 'mysql', defaults to 'mariadb')
-- `WORDPRESS_VERSION` - (defaults to 6.3.1)
-- `PORT` - (the port to expose wordpress on, defaults to 3000)
+- `PHP_VERSION` - defaults to 8.1, must be a version that has an official docker container available
+- `BACKEND` - 'mariadb' or 'mysql', defaults to 'mariadb'
+- `WORDPRESS_VERSION` - defaults to 6.3.1
+- `PORT` - the port to expose wordpress on, defaults to 3000
+- `WP_PLUGINS` - a list of plugin/version pairs like "my-plugin my-other-plugin:1.2.3". for each item, wp-cli will attempt to download and activate the plugin.
+  This is the same format as the Active Plugins entry in the System Report, so you could copy that value to this environment variable to quickly (or more quickly)
+  replicate a user's setup.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ variables are supported:
 - `BACKEND` - 'mariadb' or 'mysql', defaults to 'mariadb'
 - `WORDPRESS_VERSION` - defaults to 6.3.1
 - `PORT` - the port to expose wordpress on, defaults to 3000
-- `WP_PLUGINS` - a list of plugin/version pairs like "my-plugin my-other-plugin:1.2.3". for each item, wp-cli will attempt to download and activate the plugin.
+- `WP_PLUGINS` - a list of plugin/version pairs like "my-plugin my-other-plugin:1.2.3". For each item, wp-cli will attempt to download and activate the plugin.
   This is the same format as the Active Plugins entry in the System Report, so you could copy that value to this environment variable to quickly (or more quickly)
   replicate a user's setup.
 

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1636,11 +1636,9 @@ class SystemReport {
 			$plugins        = get_plugins();
 			$active_plugins = array_map(
 				function ( $active_plugin ) use ( $plugins ) {
-					$plugin_version = isset($plugins[$active_plugin]['Version']) ? $plugins[$active_plugin]['Version'] : null;
-					$result_suffix = $plugin_version ? (':' . $plugin_version) : '';
-
+					$plugin_version = isset( $plugins[ $active_plugin ]['Version'] ) ? $plugins[ $active_plugin ]['Version'] : null;
+					$result_suffix  = $plugin_version ? ( ':' . $plugin_version ) : '';
 					$parts          = explode( '/', trim( $active_plugin ) );
-
 					return trim( $parts[0] ) . $result_suffix;
 				},
 				$active_plugins

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1633,11 +1633,15 @@ class SystemReport {
 	private function get_actives_plugins() {
 		$active_plugins = get_option( 'active_plugins', [] );
 		if ( ! empty( $active_plugins ) && is_array( $active_plugins ) ) {
+			$plugins        = get_plugins();
 			$active_plugins = array_map(
-				function ( $active_plugin ) {
-					$parts = explode( '/', trim( $active_plugin ) );
+				function ( $active_plugin ) use ( $plugins ) {
+					$plugin_version = isset($plugins[$active_plugin]['Version']) ? $plugins[$active_plugin]['Version'] : null;
+					$result_suffix = $plugin_version ? (':' . $plugin_version) : '';
 
-					return trim( $parts[0] );
+					$parts          = explode( '/', trim( $active_plugin ) );
+
+					return trim( $parts[0] ) . $result_suffix;
 				},
 				$active_plugins
 			);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         set -e
 
         cd /var/www/html
-        
+
         LATEST_WORDPRESS_VERSION=6.3.1 # can't use the github API, too easy to get rate limited
 
         # install PHP extensions needed
@@ -142,6 +142,31 @@ services:
         </html>
         EOF
         fi
+
+        # download WP_PLUGINS plugins if not present
+        if [ ! -f "/var/www/html/wp-cli.phar" ]; then
+          curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o /var/www/html/wp-cli.phar
+        fi
+        chmod +x /var/www/html/wp-cli.phar
+
+        for PLUGIN_VERSION in $WP_PLUGINS
+        do
+          PLUGIN_VERSION_ARRAY=($${PLUGIN_VERSION//:/ })
+          PLUGIN=$${PLUGIN_VERSION_ARRAY[0]}
+          VERSION=$${PLUGIN_VERSION_ARRAY[1]}
+
+          if [ "$$PLUGIN" = "matomo" ]; then
+            echo "skipping matomo plugin install"
+            continue
+          fi
+
+          if [[ ! -z "$$VERSION" ]]; then
+            VERSION_ARGUMENT="--version=$$VERSION"
+          fi
+
+          echo "installing plugin $$PLUGIN $$VERSION_ARGUMENT"
+          /var/www/html/wp-cli.phar --allow-root --path=/var/www/html/$$WORDPRESS_VERSION plugin install --activate $$VERSION_ARGUMENT $$PLUGIN || true
+        done
 
         # make sure the files can be edited outside of docker (for easier debugging)
         # TODO: file permissions becoming a pain, shouldn't have to deal with this for dev env. this works for now though.


### PR DESCRIPTION
### Description:

Changes:
* In local dev docker-compose.yml install wp-cli if not present.
* In local dev docker-compose.yml, if WP_PLUGINS environment variable is set to a list of slug/plugin pairs like "my-plugin my-other-plugin:1.2.3", it will use wp-cli to download and activate the plugins. If the plugin cannot be found, it keeps going.
* In the System Report modify the active plugins entry to include versions of each plugin. So you should be able to copy that value, say from a user created issue, and paste it in a .env file and have the system download the plugins.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
