### PR TITLE
register woocommerce hooks, even if in admin page for plugins that do ajax through admin-ajax.php

### DIFF
--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -24,10 +24,6 @@ class Woocommerce extends Base {
 	private $order_status_ignore = MATOMO_WOOCOMMERCE_IGNORED_ORDER_STATUS;
 
 	public function register_hooks() {
-		if ( is_admin() ) {
-			return;
-		}
-
 		parent::register_hooks();
 
 		add_action( 'wp_head', [ $this, 'maybe_track_order_complete' ], 99999 );
@@ -63,10 +59,10 @@ class Woocommerce extends Base {
 			$order_id = (int) $order_id;
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo "<script>(function () {
-	if (location.href) { 
+	if (location.href) {
 		window._paq = window._paq || [];
 	    var url = location.href;
-		if (url.indexOf('?') > 0) { 
+		if (url.indexOf('?') > 0) {
 		    url = url.substr(0, url.indexOf('?')); // remove order key
 		}
 		window._paq.push(['setCustomUrl', url.replace('$order_id', 'orderid_anonymised')]);


### PR DESCRIPTION
### Description:

Refs #851 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
