### PR TITLE
check for get_error_message method before using it in AjaxTracker.php

### DIFF
--- a/classes/WpMatomo/AjaxTracker.php
+++ b/classes/WpMatomo/AjaxTracker.php
@@ -87,8 +87,9 @@ class AjaxTracker extends \MatomoTracker {
 
 		$response = wp_remote_request( $url, $args );
 
-		if (is_wp_error($response)) {
-			$this->logger->log_exception('ajax_tracker', new \Exception($response->get_error_message()));
+		if ( is_wp_error($response) ) {
+			$message = method_exists($response, 'get_error_message') ? $response->get_error_message() : print_r($response, true);
+			$this->logger->log_exception('ajax_tracker', new \Exception($message));
 		}
 
 		return $response;


### PR DESCRIPTION
### Description:

Refs #851 

One user's wordpress experienced a fatal error when server side tracking failed:

```
PHP Fatal error:  Uncaught Error: Call to a member function get_error_message() on array in .../wp-content/plugins/matomo/classes/WpMatomo/AjaxTracker.php
```

It seems the response can be a wordpress error but also an array in some cases, though I'm not exactly sure how this situation could occur. Keeping this as a draft until I can confirm it's not due to a different error.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
