### PR TITLE
allow bots when doing server side tracking, in case the server is seen as a bot by Matomo

### DIFF
--- a/classes/WpMatomo/AjaxTracker.php
+++ b/classes/WpMatomo/AjaxTracker.php
@@ -85,7 +85,7 @@ class AjaxTracker extends \MatomoTracker {
 		// 1) Not send any response no matter what happens
 		// 2) Never exit at any point
 
-		$response = wp_remote_request( $url, $args );
+		$response = wp_remote_request( $url . '&bots=1', $args );
 
 		if (is_wp_error($response)) {
 			$this->logger->log_exception('ajax_tracker', new \Exception($response->get_error_message()));


### PR DESCRIPTION
### Description:

As title.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
