### PR TITLE
delete any pre-existing matomo user by email before syncing

### DIFF
--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -307,6 +307,17 @@ class Sync {
 		if ( $matomo_user_login ) {
 			$user_in_matomo = $user_model->getUser( $matomo_user_login );
 		} else {
+			$user_by_email = $user_model->getUserByEmail( $wp_user->user_email );
+
+			// the user was deleted without matomo being notified. delete user so we can recreate it
+			// below.
+			//
+			// note: it's also possible there are multiple users with the same email address,
+			// but this is currently unsupported in matomo so we don't take that into consideration.
+			if ( $user_by_email ) {
+				$user_model->deleteUser( $user_by_email['login'] );
+			}
+
 			// wp usernames may include whitespace etc
 			$login = preg_replace( '/[^A-Za-zÄäÖöÜüß0-9_.@+-]+/D', '_', $login );
 			$login = substr( $login, 0, self::MAX_USER_NAME_LENGTH );


### PR DESCRIPTION
### Description:

If a wordpress user was deleted manually or without going through wordpress, the syncing process to Matomo will not occur. If a new user is then created with the same email there will be a conflict when Matomo tries to create the user again. This PR fixes this case by checking if the email already exists for a user and deleting it if so.

Fixes #802

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
