### PR TITLE
add notification if ninja firewall plugin is detected

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1689,14 +1689,19 @@ class SystemReport {
 			];
 		}
 
-		$active_plugins = $this->get_actives_plugins();
+		$active_plugins_with_version = $this->get_actives_plugins();
 
-		if ( ! empty( $active_plugins ) && is_array( $active_plugins ) ) {
+		if ( ! empty( $active_plugins_with_version ) && is_array( $active_plugins_with_version ) ) {
 			$rows[] = [
 				'name'    => 'Active Plugins',
-				'value'   => count( $active_plugins ),
-				'comment' => implode( ' ', $active_plugins ),
+				'value'   => count( $active_plugins_with_version ),
+				'comment' => implode( ' ', $active_plugins_with_version ),
 			];
+
+			$active_plugins = array_map(function ( $plugin_with_version ) {
+				$parts = explode( ':', $plugin_with_version );
+				return $parts[0];
+			}, $active_plugins_with_version);
 
 			$used_not_compatible = array_intersect( $active_plugins, $this->not_compatible_plugins );
 			if ( in_array( 'wp-rocket', $used_not_compatible, true ) ) {
@@ -1734,6 +1739,17 @@ class SystemReport {
 						'is_error'   => $is_error,
 					];
 				}
+			}
+
+			if ( in_array( 'ninjafirewall', $active_plugins, true ) ) {
+				$warning = <<<EOF
+<div class="notice notice-warning">
+	<p><strong>We noticed you are using Matomo with Ninja Firewall.</strong> This can result in Matomo cache file changes showing up in Ninja Firewall which likely undesired.
+	<a href="https://matomo.org/faq/wordpress/how-do-i-prevent-matomo-cache-file-changes-to-show-up-in-ninja-firewall/" rel="noreferrer noopener" target="_blank">Read our FAQ to learn how to prevent these entries.</a>
+	</p>
+</div>
+EOF;
+				echo $warning;
 			}
 		}
 

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1698,10 +1698,13 @@ class SystemReport {
 				'comment' => implode( ' ', $active_plugins_with_version ),
 			];
 
-			$active_plugins = array_map(function ( $plugin_with_version ) {
-				$parts = explode( ':', $plugin_with_version );
-				return $parts[0];
-			}, $active_plugins_with_version);
+			$active_plugins = array_map(
+				function ( $plugin_with_version ) {
+					$parts = explode( ':', $plugin_with_version );
+					return $parts[0];
+				},
+				$active_plugins_with_version
+			);
 
 			$used_not_compatible = array_intersect( $active_plugins, $this->not_compatible_plugins );
 			if ( in_array( 'wp-rocket', $used_not_compatible, true ) ) {
@@ -1742,14 +1745,11 @@ class SystemReport {
 			}
 
 			if ( in_array( 'ninjafirewall', $active_plugins, true ) ) {
-				$warning = <<<EOF
-<div class="notice notice-warning">
-	<p><strong>We noticed you are using Matomo with Ninja Firewall.</strong> This can result in Matomo cache file changes showing up in Ninja Firewall which likely undesired.
-	<a href="https://matomo.org/faq/wordpress/how-do-i-prevent-matomo-cache-file-changes-to-show-up-in-ninja-firewall/" rel="noreferrer noopener" target="_blank">Read our FAQ to learn how to prevent these entries.</a>
+				echo '<div class="notice notice-warning">
+	<p><strong>' . esc_html__( 'We noticed you are using Matomo with Ninja Firewall.', 'matomo' ) . '</strong> ' . esc_html__( 'This can result in Matomo cache file changes showing up in Ninja Firewall which likely undesired.', 'matomo' ) . '
+	<a href="https://matomo.org/faq/wordpress/how-do-i-prevent-matomo-cache-file-changes-to-show-up-in-ninja-firewall/" rel="noreferrer noopener" target="_blank">' . esc_html__( 'Read our FAQ to learn how to prevent these entries.', 'matomo' ) . '</a>
 	</p>
-</div>
-EOF;
-				echo $warning;
+</div>';
 			}
 		}
 


### PR DESCRIPTION
### Description:

Fixes #281 

Also fixes regression in incompatible plugin detection. Previously I changed the $active_plugins array to have plugin names and versions, but later in the code the system report checks if plugins are in that array by name alone.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
