### PR TITLE
throw different exception if token is missing vs token is invalid

### DIFF
--- a/plugins/.editorconfig
+++ b/plugins/.editorconfig
@@ -1,0 +1,2 @@
+[*.php]
+indent_style = space

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -312,20 +312,25 @@ class WordPress extends Plugin
 	        }
         }
 
-	    $requestedModule = !empty($module) ? Common::mb_strtolower($module) : '';
-	    $requestedAction = !empty($action) ? Common::mb_strtolower($action) : '';
+        $requestedModule = !empty($module) ? Common::mb_strtolower($module) : '';
+        $requestedAction = !empty($action) ? Common::mb_strtolower($action) : '';
 
-	    if (!WordPress::$is_archiving
-	        && !Common::isPhpCliMode()
-	        && $requestedModule === 'api'
-	        && (empty($requestedAction) || $requestedAction === 'index')) {
-		    $tokenRequest = Common::getRequestVar('token_auth', false, 'string');
-		    $tokenUser = Piwik::getCurrentUserTokenAuth();
+        if (!WordPress::$is_archiving
+            && !Common::isPhpCliMode()
+            && $requestedModule === 'api'
+            && (empty($requestedAction) || $requestedAction === 'index')
+        ) {
+            $tokenRequest = Common::getRequestVar('token_auth', false, 'string');
+            $tokenUser = Piwik::getCurrentUserTokenAuth();
 
-		    if (!$tokenRequest || $tokenRequest !== $tokenUser) {
-			    throw new Exception(Piwik::translate('General_ExceptionInvalidToken'));
-		    }
-	    }
+            if (!$tokenRequest) {
+                throw new Exception(Piwik::translate('Wordpress_TokenAuthMissing'));
+            }
+
+            if ($tokenRequest !== $tokenUser) {
+                throw new Exception(Piwik::translate('Wordpress_ExceptionInvalidToken'));
+            }
+        }
 
         if ($requestedModule === 'login') {
             if ($action === 'ajaxNoAccess' || $action === 'bruteForceLog') {
@@ -360,7 +365,7 @@ class WordPress extends Plugin
 	            throw new Exception( 'This feature '.$requestedModule. ' / ' .$requestedAction .' is not available' );
             }
         }
-        
+
         if ($requestedModule === 'sitesmanager' && $requestedAction === 'sitewithoutdata') {
             // we don't want the no data message to appear as it contains integration instructions which aren't needed
             // and links to not existing sites

--- a/plugins/WordPress/lang/en.json
+++ b/plugins/WordPress/lang/en.json
@@ -1,0 +1,6 @@
+{
+  "Wordpress": {
+    "TokenAuthMissing": "Missing token_auth in the request.",
+    "ExceptionInvalidToken": "Invalid token_auth in the request."
+  }
+}


### PR DESCRIPTION
### Description:

When debugging the occurrence of token auth issues in API requests for users, it can be helpful to know if the token auth is just missing for the request (say some wordpress security plugin removes it for some reason) or if it's actually invalid.

Also includes a new .editorconfig to change tab type for the Wordpress matomo plugin code which uses spaces.

Refs #820 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
