### PR TITLE
Add wp service to docker-compose so devs can run wp-cli in local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ variables are supported:
   This is the same format as the Active Plugins entry in the System Report, so you could copy that value to this environment variable to quickly (or more quickly)
   replicate a user's setup.
 
+**Running wp-cli**
+
+Make sure the wordpress service is running in one terminal, then in another terminal run:
+
+```bash
+docker-compose run wp <... rest of command ...>
+```
+
 **Accessing MariaDB/MySQL**
 
 First ensure the database you want to inspect (mariadb or mysql) is the one that's currently being used by your local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
     ports:
       - "${PORT:-3000}:80"
     environment:
-      WP_DB_USER: root
-      WP_DB_PASSWORD: pass
       WP_DB_HOST: "${BACKEND:-mariadb}"
     entrypoint:
       - bash
@@ -58,8 +56,8 @@ services:
         echo "done."
 
         # create database if it does not already exist
-        export WP_DB_NAME=$$(echo "wp_matomo_$$WORDPRESS_VERSION" | sed 's/\./_/g')
-        php -r "\$$pdo = new PDO('mysql:host=$$WP_DB_HOST', '$$WP_DB_USER', '$$WP_DB_PASSWORD');
+        WP_DB_NAME=$$(echo "wp_matomo_$$WORDPRESS_VERSION" | sed 's/\./_/g')
+        php -r "\$$pdo = new PDO('mysql:host=$$WP_DB_HOST', 'root', 'pass');
         \$$pdo->exec('CREATE DATABASE IF NOT EXISTS \`$$WP_DB_NAME\`');\
         \$$pdo->exec('GRANT ALL PRIVILEGES ON $$WP_DB_NAME.* TO \'root\'@\'%\' IDENTIFIED BY \'pass\'');"
 
@@ -67,14 +65,14 @@ services:
         if [ ! -f "/var/www/html/$$WORDPRESS_VERSION/wp-config.php" ]; then
           cat > "/var/www/html/$$WORDPRESS_VERSION/wp-config.php" <<EOF
         <?php
-        define('DB_NAME', getenv('WP_DB_NAME'));
-        define('DB_USER', getenv('WP_DB_USER'));
-        define('DB_PASSWORD', getenv('WP_DB_PASSWORD'));
+        define('DB_NAME', '$$WP_DB_NAME');
+        define('DB_USER', 'root');
+        define('DB_PASSWORD', 'pass');
         define('DB_HOST', getenv('WP_DB_HOST'));
         define('DB_CHARSET', 'utf8');
         define('DB_COLLATE', '');
-        define( 'WP_DEBUG', (bool)getenv('WP_DEBUG') );
-      
+        define( 'WP_DEBUG', false );
+
         define( 'AUTH_KEY',         'put your unique phrase here' );
         define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
         define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
@@ -93,12 +91,12 @@ services:
         \$$table_prefix = 'wp_';
 
         /* That's all, stop editing! Happy publishing. */
-        
+
         /** Absolute path to the WordPress directory. */
         if ( ! defined( 'ABSPATH' ) ) {
           define( 'ABSPATH', __DIR__ . '/' );
         }
-        
+
         /** Sets up WordPress vars and included files. */
         require_once ABSPATH . 'wp-settings.php';
         EOF
@@ -182,6 +180,23 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
+  wp:
+    image: "php:${PHP_VERSION:-8.1}-apache"
+    volumes:
+      - ./docker/wordpress:/var/www/html
+      - "./docker/php-${PHP_VERSION:-8.1}/php:/usr/src/php"
+      - "./docker/php-${PHP_VERSION:-8.1}/extensions:/usr/local/lib/php/extensions"
+      - "./docker/php-${PHP_VERSION:-8.1}/conf:/usr/local/etc/php/conf.d"
+      - .:/var/www/html/matomo-for-wordpress
+      - /var/www/html/matomo-for-wordpress/app/tmp
+    ports:
+      - "${PORT:-3000}:80"
+    environment:
+      WP_DB_HOST: "${BACKEND:-mariadb}"
+    user: "${UID:-1000}:${GID:-1000}"
+    entrypoint: "/var/www/html/wp-cli.phar --path=/var/www/html/${WORDPRESS_VERSION:-6.3.1}"
+    depends_on:
+      - "${BACKEND:-mariadb}"
   mariadb:
     image: mariadb
     environment:


### PR DESCRIPTION
### Description:

As title.

Also hardcodes credentials for the docker database since they can't actually change.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
