### PR TITLE
Add system report optional check if bots.yml is accessible

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,15 @@ docker-compose run wp <... rest of command ...>
 
 **Testing on nginx**
 
-To run the local dev environment with nginx instead of apache, run the following command:
+To run the local dev environment with nginx instead of apache, first make sure there is a `127.0.0.1 nginx` entry in your `/etc/hosts` file.
+
+Then run the following command:
 
 ```bash
 docker-compose run nginx fpm; docker-compose stop
 ```
 
-Then visit `http://localhost:3000/`.
+Finally visit `http://nginx:3000/`.
 
 Note: you cannot have both the apache and nginx services running simultaneously as they will try to use the same port.
 
@@ -106,7 +108,6 @@ Enter `pass` for the password.
 (For mysql, replace instances of "mariadb" in the command with "mysql".)
 
 ## Security
-
 Security is a top priority at Matomo. As potential issues are discovered, we validate, patch and release fixes as quickly as we can. We have a security bug bounty program in place that rewards researchers for finding security issues and disclosing them to us.
 
 [Learn more](https://matomo.org/security/) or check out our [HackerOne program](https://hackerone.com/matomo).

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -749,6 +749,28 @@ class SystemReport {
 					'value'   => ! empty( $matomo_url ),
 				];
 			}
+
+			// check that yml files are not accessible
+			$url    = plugins_url( 'app', MATOMO_ANALYTICS_FILE ) . '/vendor/matomo/device-detector/regexes/bots.yml';
+			$result = wp_remote_post(
+				$url,
+				array(
+					'method'    => 'GET',
+					'sslverify' => false,
+					'timeout'   => 2,
+				),
+			);
+			if ( is_array( $result ) ) {
+				$response_code = (int) $result['response']['code'];
+				if ( $response_code >= 200 && $response_code < 300 ) {
+					$rows[] = [
+						'name' => __( 'YML files should not be accessible', 'matomo' ),
+						'value' => 'warning',
+						'comment' => 'The .yml files in the wp-content/plugins/matomo/app/vendor directory are accessible from the internet. This can cause some web security tools to flag your website as suspicious. If you are using Apache, it is probably due to your server configuration disabling the use of .htaccess files. If you are instead using nginx, it is due to your nginx configuration allowing .yml files. You may need to contact your hosting provider to fix this.',
+						'is_warning' => true,
+					];
+				}
+			}
 		}
 
 		$rows[] = [

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -758,15 +758,15 @@ class SystemReport {
 					'method'    => 'GET',
 					'sslverify' => false,
 					'timeout'   => 2,
-				),
+				)
 			);
 			if ( is_array( $result ) ) {
 				$response_code = (int) $result['response']['code'];
 				if ( $response_code >= 200 && $response_code < 300 ) {
 					$rows[] = [
-						'name' => __( 'YML files should not be accessible', 'matomo' ),
-						'value' => 'warning',
-						'comment' => 'The .yml files in the wp-content/plugins/matomo/app/vendor directory are accessible from the internet. This can cause some web security tools to flag your website as suspicious. If you are using Apache, it is probably due to your server configuration disabling the use of .htaccess files. If you are instead using nginx, it is due to your nginx configuration allowing .yml files. You may need to contact your hosting provider to fix this.',
+						'name'       => __( 'YML files should not be accessible', 'matomo' ),
+						'value'      => 'warning',
+						'comment'    => __( 'The .yml files in the wp-content/plugins/matomo/app/vendor directory are accessible from the internet. This can cause some web security tools to flag your website as suspicious. If you are using Apache, it is probably due to your server configuration disabling the use of .htaccess files. If you are instead using nginx, it is due to your nginx configuration allowing .yml files. You may need to contact your hosting provider to fix this.', 'matomo' ),
 						'is_warning' => true,
 					];
 				}

--- a/scripts/local-dev-nginx.conf
+++ b/scripts/local-dev-nginx.conf
@@ -1,5 +1,6 @@
 server {
   listen 80;
+  listen 3000;
   server_name localhost;
   root /var/www/html;
 


### PR DESCRIPTION
### Description:

![image](https://github.com/matomo-org/matomo-for-wordpress/assets/125140/7e797415-c0f1-4b5c-b783-4abffa467807)

Changes:
* If the bots.yml file is accessible via HTTP request display a warning in the system report.
* Fix server side requests and automatic redirects in nginx in the local dev environment.

Fixes MWP-1

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
