### PR TITLE
allow disabling async archiving via advanced setting

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -673,6 +673,12 @@ class SystemReport {
 				'comment' => '',
 			];
 
+			$rows[] = [
+				'name'    => 'Async Archiving Disabled in Setting',
+				'value'   => $this->settings->is_async_archiving_disabled_by_option(),
+				'comment' => '',
+			];
+
 			$location_provider = LocationProvider::getCurrentProvider();
 			if ( $location_provider ) {
 				$rows[] = [
@@ -1069,7 +1075,6 @@ class SystemReport {
 			'WP_CRON_LOCK_TIMEOUT',
 			'WP_DISABLE_FATAL_ERROR_HANDLER',
 			'MATOMO_SUPPORT_ASYNC_ARCHIVING',
-			'MATOMO_TRIGGER_BROWSER_ARCHIVING',
 			'MATOMO_ENABLE_TAG_MANAGER',
 			'MATOMO_SUPPRESS_DB_ERRORS',
 			'MATOMO_ENABLE_AUTO_UPGRADE',

--- a/classes/WpMatomo/Admin/views/advanced_settings.php
+++ b/classes/WpMatomo/Admin/views/advanced_settings.php
@@ -75,6 +75,25 @@ if ( $was_updated ) {
 			</tr>
 		<?php } ?>
 		<tr>
+			<th width="20%" scope="row">
+				<label for="matomo[disable_async_archiving]"><?php esc_html_e( 'Enable archiving via HTTP requests', 'matomo' ); ?>:</label>
+			</th>
+			<td>
+				<span style="white-space:nowrap;display: inline-block;">
+					<input type="checkbox" <?php echo ! empty( $matomo_disable_async_archiving ) || empty( $matomo_async_archiving_supported ) ? 'checked="checked" ' : ''; ?> value="1" name="matomo[disable_async_archiving]"
+						   id="matomo[disable_async_archiving]" <?php echo ! empty( $matomo_async_archiving_supported ) ? '' : 'disabled="disabled"'; ?>
+					/>
+				</span>
+			</td>
+			<td width="50%">
+				<?php
+				echo ! empty( $matomo_async_archiving_supported )
+					? esc_html_e( 'If you are experiencing trouble with archiving (as in, report generation), enabling this option may solve the issue.', 'matomo' )
+					: esc_html_e( 'CLI archiving (aka async archiving) is not supported for your server, so archiving via HTTP requests is always enabled.', 'matomo' );
+				?>
+			</td>
+		</tr>
+		<tr>
 			<td colspan="3"><p class="submit"><input name="Submit" type="submit" class="button-primary"
 													 value="<?php esc_attr_e( 'Save Changes', 'matomo' ); ?>"/></p></td>
 		</tr>

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -13,6 +13,7 @@
 
 namespace WpMatomo;
 
+use Piwik\CliMulti\Process;
 use WpMatomo\Admin\CookieConsent;
 use WpMatomo\Admin\TrackingSettings;
 
@@ -33,6 +34,7 @@ class Settings {
 	const DELETE_ALL_DATA_ON_UNINSTALL         = 'delete_all_data_uninstall';
 	const SITE_CURRENCY                        = 'site_currency';
 	const NETWORK_CONFIG_OPTIONS               = 'config_options';
+	const DISABLE_ASYNC_ARCHIVING_OPTION_NAME  = 'matomo_disable_async_archiving';
 
 	public static $is_doing_action_tracking_related = false;
 	/**
@@ -107,6 +109,7 @@ class Settings {
 		'force_protocol'                           => 'disabled',
 		'maxmind_license_key'                      => '',
 		self::SHOW_GET_STARTED_PAGE                => 1,
+		self::DISABLE_ASYNC_ARCHIVING_OPTION_NAME  => false,
 	];
 
 	/**
@@ -485,5 +488,13 @@ class Settings {
 
 	public function set_assume_is_network_enabled_in_tests( $network_enabled = true ) {
 		$this->assume_is_network_enabled_in_tests = $network_enabled;
+	}
+
+	public function is_async_archiving_supported() {
+		return Process::isSupported() && ( ! defined( 'MATOMO_SUPPORT_ASYNC_ARCHIVING' ) || MATOMO_SUPPORT_ASYNC_ARCHIVING );
+	}
+
+	public function is_async_archiving_disabled_by_option() {
+		return (bool) $this->get_global_option( self::DISABLE_ASYNC_ARCHIVING_OPTION_NAME );
 	}
 }

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -173,7 +173,7 @@ class WordPress extends Plugin
 
     private function isAsyncArchivingDisabledBySetting()
     {
-        $settings = new Settings();
+        $settings = \WpMatomo::$settings;
         return $settings->is_async_archiving_disabled_by_option();
     }
 

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -13,6 +13,7 @@ use Exception;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\FrontController;
+use Piwik\Option;
 use Piwik\Piwik;
 use Piwik\Plugin;
 use Piwik\Plugin\Manager;
@@ -21,6 +22,7 @@ use Piwik\Scheduler\Task;
 use Piwik\Url;
 use Piwik\Widget\WidgetsList;
 use WpMatomo\Bootstrap;
+use WpMatomo\Settings;
 
 if (!defined( 'ABSPATH')) {
     exit; // if accessed directly
@@ -158,7 +160,8 @@ class WordPress extends Plugin
             || (defined('WP_DEBUG') && WP_DEBUG)
             || !empty($_SERVER['MATOMO_WP_ROOT_PATH'])
             || !matomo_has_compatible_content_dir()
-	        || (defined( 'MATOMO_SUPPORT_ASYNC_ARCHIVING') && !MATOMO_SUPPORT_ASYNC_ARCHIVING)
+            || (defined( 'MATOMO_SUPPORT_ASYNC_ARCHIVING') && !MATOMO_SUPPORT_ASYNC_ARCHIVING)
+            || $this->isAsyncArchivingDisabledBySetting()
         ) {
             // console wouldn't really work in multi site mode... therefore we prefer to archive in the same request
             // WP_DEBUG also breaks things since it's logging things to stdout and then safe unserialise doesn't work
@@ -166,6 +169,12 @@ class WordPress extends Plugin
             // but not on the CLI
             $supportsAsync = false;
         }
+    }
+
+    private function isAsyncArchivingDisabledBySetting()
+    {
+        $settings = new Settings();
+        return $settings->is_async_archiving_disabled_by_option();
     }
 
     public function onHeader(&$out)


### PR DESCRIPTION
### Description:

![image](https://github.com/matomo-org/matomo-for-wordpress/assets/125140/da03d2b3-389b-4d1e-a0fa-b8adf1f1baab)

Fixes #844 

I've noticed users can have trouble with manually editing wp-config.php, and hosting providers can cater to people who do not have the skills to do or want to do that kind of maintenance. It would be a lot simpler for a user to simply uncheck a setting than edit a file on their server.

Since the main setting that users may have to interact with is `MATOMO_SUPPORT_ASYNC_ARCHIVING`, adding a setting for this seems like a good idea and a quick win.

FAQs may need to be updated after this is released.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
