### PR TITLE
compatibility with WooCommerce's HPOS feature

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -248,8 +248,7 @@ class WpMatomo {
 		}
 	}
 
-	private function declare_woocommerce_hpos_compatible()
-	{
+	private function declare_woocommerce_hpos_compatible() {
 		add_action(
 			'before_woocommerce_init',
 			function() {

--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -44,6 +44,8 @@ class WpMatomo {
 	public static $settings;
 
 	public function __construct() {
+		$this->declare_woocommerce_hpos_compatible();
+
 		if ( ! $this->check_compatibility() ) {
 			return;
 		}
@@ -244,5 +246,17 @@ class WpMatomo {
 
 			do_action( 'matomo_ecommerce_init', $tracker );
 		}
+	}
+
+	private function declare_woocommerce_hpos_compatible()
+	{
+		add_action(
+			'before_woocommerce_init',
+			function() {
+				if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+					\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'matomo/matomo.php', true );
+				}
+			},
+		);
 	}
 }

--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -256,7 +256,7 @@ class WpMatomo {
 				if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 					\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', 'matomo/matomo.php', true );
 				}
-			},
+			}
 		);
 	}
 }

--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -242,9 +242,12 @@ class Woocommerce extends Base {
 
 		$this->logger->log( sprintf( 'Tracked ecommerce order %s with number %s', $order_id, $order_id_to_track ) );
 
-		$this->save_order_metadata( $order, [
-			$this->key_order_tracked => 1,
-		] );
+		$this->save_order_metadata(
+			$order,
+			[
+				$this->key_order_tracked => 1,
+			]
+		);
 
 		return $this->wrap_script( $tracking_code );
 	}
@@ -390,7 +393,7 @@ class Woocommerce extends Base {
 
 	/**
 	 * @param \WC_Order $order
-	 * @param $name
+	 * @param string    $name
 	 * @return mixed
 	 */
 	private function get_order_meta( $order, $name ) {
@@ -404,12 +407,11 @@ class Woocommerce extends Base {
 
 	/**
 	 * @param \WC_Order $order
-	 * @param array $metadata
+	 * @param array     $metadata
 	 * @return void
 	 */
-	private function save_order_metadata( $order, $metadata )
-	{
-		foreach ($metadata as $name => $value) {
+	private function save_order_metadata( $order, $metadata ) {
+		foreach ( $metadata as $name => $value ) {
 			if ( method_exists( $order, 'update_meta_data' ) ) {
 				$order->update_meta_data( $name, $value );
 			} else {

--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -182,6 +182,7 @@ class Woocommerce extends Base {
 			return;
 		}
 
+		// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 		if ( $order->get_meta( $this->key_order_tracked ) == 1 ) {
 			$this->logger->log( sprintf( 'Ignoring already tracked order %d', $order_id ) );
 
@@ -379,10 +380,10 @@ class Woocommerce extends Base {
 	}
 
 	protected function has_order_been_tracked_already( $order_id ) {
-		throw new \Exception('has_order_been_tracked_already() should not be used in Woocommerce, use wc_get_order()->get_meta() instead');
+		throw new \Exception( 'has_order_been_tracked_already() should not be used in Woocommerce, use wc_get_order()->get_meta() instead' );
 	}
 
 	protected function set_order_been_tracked( $order_id ) {
-		throw new \Exception('set_order_been_tracked() should not be used in Woocommerce, use wc_get_order()->update_meta_data() instead');
+		throw new \Exception( 'set_order_been_tracked() should not be used in Woocommerce, use wc_get_order()->update_meta_data() instead' );
 	}
 }


### PR DESCRIPTION
### Description:

Fixes #899 

Changes:
* switch to using WooCommerce methods to get/set order metadata
* mark plugin as compatible with the HPOS feature

Did some light testing locally and orders were tracked successfully.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
