### PR TITLE
if available, use is_created_via() to tell if an order is from the wp admin back office

### DIFF
--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -397,7 +397,7 @@ class Woocommerce extends Base {
 		return method_exists( $order, 'is_created_via' ) ? $order->is_created_via( 'admin' ) : is_admin();
 	}
 
-  protected function has_order_been_tracked_already( $order_id ) {
+	protected function has_order_been_tracked_already( $order_id ) {
 		throw new \Exception( 'has_order_been_tracked_already() should not be used in Woocommerce, use wc_get_order()->get_meta() instead' );
 	}
 

--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -189,6 +189,11 @@ class Woocommerce extends Base {
 		if ( ! $order ) {
 			return;
 		}
+
+		if ( $this->isOrderFromBackOffice( $order ) ) {
+			return;
+		}
+
 		$order_id_to_track = $order_id;
 		if ( method_exists( $order, 'get_order_number' ) ) {
 			$order_id_to_track = $order->get_order_number();
@@ -374,5 +379,15 @@ class Woocommerce extends Base {
 		// we're not using wc_enqueue_js eg to prevent sometimes this code from being minified on some JS minifier plugins
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $this->wrap_script( $this->make_matomo_js_tracker_call( $params ) );
+	}
+
+	/**
+	 * @param \WC_Order|\WC_Order_Refund $order
+	 * @return bool
+	 */
+	private function isOrderFromBackOffice( $order ) {
+		// for recent versions of woocommerce (4.0+) use is_created_via(), otherwise default to is_admin() (which will provide false positives
+		// when using a theme that uses admin-ajax.php to add orders)
+		return method_exists( $order, 'is_created_via' ) ? $order->is_created_via( 'admin' ) : is_admin();
 	}
 }


### PR DESCRIPTION
### Description:

Fixes #914 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
