### PR TITLE
on order status change from pending to processing, try to track an order

### DIFF
--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -457,8 +457,4 @@ class Woocommerce extends Base {
 			$order->save();
 		}
 	}
-
-	private function get_order_id( $order ) {
-		return method_exists( $order, 'get_id' ) ? $order->get_id() : $order->id;
-	}
 }

--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -33,6 +33,7 @@ class Woocommerce extends Base {
 		add_action( 'woocommerce_cart_item_restored', [ $this, 'on_cart_updated_safe' ], 99999, 0 );
 		add_action( 'woocommerce_cart_item_set_quantity', [ $this, 'on_cart_updated_safe' ], 99999, 0 );
 		add_action( 'woocommerce_thankyou', [ $this, 'anonymise_orderid_in_url' ], 1, 1 );
+		add_action( 'woocommerce_order_status_changed', [ $this, 'on_order_status_change' ], 10, 3 );
 
 		if ( ! $this->should_track_background() ) {
 			// prevent possibly executing same event twice where eg first a PHP Matomo tracker request is created
@@ -52,6 +53,24 @@ class Woocommerce extends Base {
 
 		add_action( 'woocommerce_applied_coupon', [ $this, 'on_coupon_updated_safe' ], 99999, 0 );
 		add_action( 'woocommerce_removed_coupon', [ $this, 'on_coupon_updated_safe' ], 99999, 0 );
+	}
+
+	public function on_order_status_change( $order_id, $old_status, $new_status ) {
+		$order = wc_get_order( $order_id );
+		if ( empty( $order ) ) {
+			return;
+		}
+
+		if ( $this->isOrderFromBackOffice( $order ) ) {
+			return;
+		}
+
+		if ( 'pending' === $old_status && 'processing' === $new_status ) {
+			$this->logger->log( sprintf( 'Order ID = %s status changed from pending to processing, attempting to track it', $order_id ) );
+
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $this->on_order( $order_id );
+		}
 	}
 
 	public function anonymise_orderid_in_url( $order_id ) {
@@ -437,5 +456,9 @@ class Woocommerce extends Base {
 		if ( method_exists( $order, 'save' ) ) {
 			$order->save();
 		}
+	}
+
+	private function get_order_id( $order ) {
+		return method_exists( $order, 'get_id' ) ? $order->get_id() : $order->id;
 	}
 }


### PR DESCRIPTION
### Description:

Refs #202

Given the recent change that more precisely checks if an order was created via the WP admin, this change might be able to fix issue 202.

Changes:
* When the status of an order changes from pending to processing, and wasn't created through the WP admin interface, try to track the order as complete.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
