### PR TITLE
show ninja firewall warning as a row in the system report

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1825,11 +1825,12 @@ class SystemReport {
 			}
 
 			if ( in_array( 'ninjafirewall', $active_plugins, true ) ) {
-				echo '<div class="notice notice-warning">
-	<p><strong>' . esc_html__( 'We noticed you are using Matomo with Ninja Firewall.', 'matomo' ) . '</strong> ' . esc_html__( 'This can result in Matomo cache file changes showing up in Ninja Firewall which likely undesired.', 'matomo' ) . '
-	<a href="https://matomo.org/faq/wordpress/how-do-i-prevent-matomo-cache-file-changes-to-show-up-in-ninja-firewall/" rel="noreferrer noopener" target="_blank">' . esc_html__( 'Read our FAQ to learn how to prevent these entries.', 'matomo' ) . '</a>
-	</p>
-</div>';
+				$rows[] = [
+					'name'    => 'Ninja Firewall',
+					'value'   => '',
+					'comment' => esc_html__( 'We noticed you are using Matomo with Ninja Firewall. This can result in Matomo cache file changes showing up in Ninja Firewall which likely undesired.', 'matomo' ) . '
+	<a href="https://matomo.org/faq/wordpress/how-do-i-prevent-matomo-cache-file-changes-to-show-up-in-ninja-firewall/" rel="noreferrer noopener" target="_blank">' . esc_html__( 'Read our FAQ to learn how to prevent these entries.', 'matomo' ) . '</a>',
+				];
 			}
 		}
 

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1757,11 +1757,17 @@ class SystemReport {
 
 		$plugins = get_plugins();
 
-		foreach ( $plugins as $plugin ) {
+		foreach ( $plugins as $plugin_file => $plugin ) {
 			$comment = '';
 			if ( ! empty( $plugin['Network'] ) ) {
 				$comment = esc_html__( 'Network enabled', 'matomo' );
 			}
+
+			if ( strpos( $plugin_file, 'ninjafirewall/' ) === 0 ) {
+				$comment .= '<br/><br/>' . esc_html__( 'We noticed you are using Matomo with Ninja Firewall. This can result in Matomo cache file changes showing up in Ninja Firewall which likely undesired.', 'matomo' ) . '
+	<a href="https://matomo.org/faq/wordpress/how-do-i-prevent-matomo-cache-file-changes-to-show-up-in-ninja-firewall/" rel="noreferrer noopener" target="_blank">' . esc_html__( 'Read our FAQ to learn how to prevent these entries.', 'matomo' ) . '</a>';
+			}
+
 			$rows[] = [
 				'name'    => $plugin['Name'],
 				'value'   => $plugin['Version'],
@@ -1822,15 +1828,6 @@ class SystemReport {
 						'is_error'   => $is_error,
 					];
 				}
-			}
-
-			if ( in_array( 'ninjafirewall', $active_plugins, true ) ) {
-				$rows[] = [
-					'name'    => 'Ninja Firewall',
-					'value'   => '',
-					'comment' => esc_html__( 'We noticed you are using Matomo with Ninja Firewall. This can result in Matomo cache file changes showing up in Ninja Firewall which likely undesired.', 'matomo' ) . '
-	<a href="https://matomo.org/faq/wordpress/how-do-i-prevent-matomo-cache-file-changes-to-show-up-in-ninja-firewall/" rel="noreferrer noopener" target="_blank">' . esc_html__( 'Read our FAQ to learn how to prevent these entries.', 'matomo' ) . '</a>',
-				];
 			}
 		}
 


### PR DESCRIPTION
### Description:

Since the system report is executed on every admin page view currently, the notification will be displayed on every page load. Which may annoy some users.

![image](https://github.com/matomo-org/matomo-for-wordpress/assets/125140/3a986944-ffea-4834-97aa-9a0c77e72819)

Fixes #926 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
