### PR TITLE
Avoid incidental execution of system report unless it has not been executed in a week

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -284,13 +284,13 @@ class SystemReport {
 	}
 
 	public function errors_present() {
-		$secondsInADay = 86400;
+		$secondsInAWeek = 86400 * 7;
 
 		$cache_key   = 'matomo_system_report_has_errors';
 		$cache_value = get_option( $cache_key );
 
 		if ( empty( $cache_value['last_updated'] )
-			|| $cache_value['last_updated'] + $secondsInADay < time()
+			|| $cache_value['last_updated'] + $secondsInAWeek < time()
 			|| ! isset( $cache_value['errors_found'] )
 		) {
 			// pre-record that there were no errors found. in case the system report fails to execute, this will

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -122,7 +122,7 @@ class SystemReport {
 	 */
 	public $db_settings;
 	/**
-	 * @var string the php binary used by Matomo
+	 * @var string the php binary used by Matomo (use get_php_binary() to access)
 	 */
 	private $binary;
 
@@ -133,11 +133,6 @@ class SystemReport {
 		$this->logger               = new Logger();
 		$this->db_settings          = new \WpMatomo\Db\Settings();
 		$this->shell_exec_available = function_exists( 'shell_exec' );
-		if ( ! WpMatomo::is_safe_mode() ) {
-			Bootstrap::do_bootstrap();
-			$cli_php      = new CliPhp();
-			$this->binary = $cli_php->findPhpBinary();
-		}
 	}
 
 	public function get_not_compatible_plugins() {
@@ -289,6 +284,8 @@ class SystemReport {
 	}
 
 	public function errors_present() {
+		// TODO: cache this (use Matomo cache)
+
 		$matomo_tables = $this->get_error_tables();
 
 		$matomo_tables = apply_filters( 'matomo_systemreport_tables', $matomo_tables );
@@ -442,9 +439,9 @@ class SystemReport {
 
 	private function get_phpcli_output( $phpcli_params ) {
 		$output = '';
-		if ( $this->shell_exec_available && $this->binary ) {
+		if ( $this->shell_exec_available && $this->get_php_cli_binary() ) {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec
-			$output = trim( '' . @shell_exec( $this->binary . ' ' . $phpcli_params ) );
+			$output = trim( '' . @shell_exec( $this->get_php_cli_binary() . ' ' . $phpcli_params ) );
 		}
 
 		return $output;
@@ -1295,10 +1292,10 @@ class SystemReport {
 			'value' => $this->initial_error_reporting . ' After bootstrap: ' . @error_reporting(),
 		];
 
-		if ( ! empty( $this->binary ) ) {
+		if ( ! empty( $this->get_php_cli_binary() ) ) {
 			$rows[] = [
 				'name'  => 'PHP Found Binary',
-				'value' => $this->binary,
+				'value' => $this->get_php_cli_binary(),
 			];
 		}
 		$rows[] = [
@@ -1928,5 +1925,15 @@ class SystemReport {
 		}
 
 		return $content;
+	}
+
+	private function get_php_cli_binary() {
+		if ( ! $this->binary && ! WpMatomo::is_safe_mode() ) {
+			Bootstrap::do_bootstrap();
+			$cli_php      = new CliPhp();
+			$this->binary = $cli_php->findPhpBinary();
+		}
+
+		return $this->binary;
 	}
 }

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -284,18 +284,21 @@ class SystemReport {
 	}
 
 	public function errors_present() {
-		$secondsInAWeek = 86400 * 7;
+		$seconds_in_a_week = 86400 * 7;
 
 		$cache_key   = 'matomo_system_report_has_errors';
 		$cache_value = get_option( $cache_key );
 
 		if ( empty( $cache_value['last_updated'] )
-			|| $cache_value['last_updated'] + $secondsInAWeek < time()
+			|| $cache_value['last_updated'] + $seconds_in_a_week < time()
 			|| ! isset( $cache_value['errors_found'] )
 		) {
 			// pre-record that there were no errors found. in case the system report fails to execute, this will
 			// allow the rest of Matomo for WordPress to continue to still be usable.
-			$cache_value = [ 'last_updated' => time(), 'errors_found' => 0 ];
+			$cache_value = [
+				'last_updated' => time(),
+				'errors_found' => 0,
+			];
 			update_option( $cache_key, $cache_value );
 
 			$errors_found  = false;
@@ -312,11 +315,14 @@ class SystemReport {
 				}
 			}
 
-			$cache_value = [ 'last_updated' => time(), 'errors_found' => (int) $errors_found ];
+			$cache_value = [
+				'last_updated' => time(),
+				'errors_found' => (int) $errors_found,
+			];
 			update_option( $cache_key, $cache_value );
 		}
 
-		return $cache_value['errors_found'] == 1;
+		return 1 === $cache_value['errors_found'];
 	}
 
 	public function show() {

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -287,7 +287,7 @@ class SystemReport {
 		$cache_key   = 'matomo_system_report_has_errors';
 		$cache_value = get_transient( $cache_key );
 
-		if ( $cache_value === false ) {
+		if ( false === $cache_value ) {
 			// pre-record that there were no errors found. in case the system report fails to execute, this will
 			// allow the rest of Matomo for WordPress to continue to still be usable.
 			set_transient( $cache_key, 0, WEEK_IN_SECONDS );

--- a/classes/WpMatomo/ErrorNotice.php
+++ b/classes/WpMatomo/ErrorNotice.php
@@ -31,10 +31,12 @@ class ErrorNotice {
 		if ( isset( $_GET['page'] ) && substr( sanitize_text_field( wp_unslash( $_GET['page'] ) ), 0, 7 ) === 'matomo-' ) {
 			$system_report = new \WpMatomo\Admin\SystemReport( $this->settings );
 			if ( ! get_user_meta( get_current_user_id(), self::OPTION_NAME_SYSTEM_REPORT_ERRORS_DISMISSED ) && $system_report->errors_present() ) {
-				echo '<div class="notice notice-warning is-dismissible" id="matomo-systemreporterrors">
-					<p>' . esc_html__( 'There are some errors in the', 'matomo' ) .
-					' <a href="' . esc_url( admin_url( 'admin.php?page=matomo-systemreport' ) ) . '">' . esc_html__( 'Matomo Diagnostics System report', 'matomo' ) . '</a> ' .
-					esc_html__( 'that may prevent the plugin for working normally.', 'matomo' ) . '</p></div>';
+				$message    = 'There are some errors in the %sMatomo Diagnostics System report%s that may prevent the plugin for working normally.';
+				$link_start = '<a href="' . esc_url( admin_url( 'admin.php?page=matomo-systemreport' ) ) . '">';
+				$link_end   = '</a>';
+
+				echo '<div class="notice notice-warning is-dismissible" id="matomo-systemreporterrors"><p>'
+					. sprintf( esc_html__( $message, 'matomo' ), $link_start, $link_end ) . '</p></div>';
 			}
 		}
 	}

--- a/classes/WpMatomo/ErrorNotice.php
+++ b/classes/WpMatomo/ErrorNotice.php
@@ -31,12 +31,13 @@ class ErrorNotice {
 		if ( isset( $_GET['page'] ) && substr( sanitize_text_field( wp_unslash( $_GET['page'] ) ), 0, 7 ) === 'matomo-' ) {
 			$system_report = new \WpMatomo\Admin\SystemReport( $this->settings );
 			if ( ! get_user_meta( get_current_user_id(), self::OPTION_NAME_SYSTEM_REPORT_ERRORS_DISMISSED ) && $system_report->errors_present() ) {
-				$message    = 'There are some errors in the %sMatomo Diagnostics System report%s that may prevent the plugin for working normally.';
-				$link_start = '<a href="' . esc_url( admin_url( 'admin.php?page=matomo-systemreport' ) ) . '">';
-				$link_end   = '</a>';
-
 				echo '<div class="notice notice-warning is-dismissible" id="matomo-systemreporterrors"><p>'
-					. sprintf( esc_html__( $message, 'matomo' ), $link_start, $link_end ) . '</p></div>';
+					. sprintf(
+						esc_html__( 'There are some errors in the %1$sMatomo Diagnostics System report%2$s that may prevent the plugin for working normally.', 'matomo' ),
+						'<a href="' . esc_url( admin_url( 'admin.php?page=matomo-systemreport' ) ) . '">',
+						'</a>'
+					)
+					. '</p></div>';
 			}
 		}
 	}


### PR DESCRIPTION
### Description:

Fixes #893

Changes:
* Look for PHP binary in system report only on demand.
* Cache whether errors exist in the system report for use with the admin menu item and notification. Before starting this check, assume there are no errors, so if the system report fails, Matomo for WordPress will still be accessible.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
