### PR TITLE
rename WP-Matomo to Connect Matomo

### DIFF
--- a/LEGALNOTICE
+++ b/LEGALNOTICE
@@ -28,8 +28,8 @@ CREDITS
 
 	For detailed contribution history, refer to the source, tickets,
 	patches, and Git revision history, available at
-	https://github.com/matomo-org/wp-matomo/issues
-	https://github.com/matomo-org/wp-matomo
+	https://github.com/matomo-org/matomo-for-wordpress/issues
+	https://github.com/matomo-org/matomo-for-wordpress
 
 
 SEPARATELY LICENSED COMPONENTS AND LIBRARIES
@@ -47,4 +47,3 @@ THIRD-PARTY CONTENT
 	License:  The MIT License (MIT) see node_modules/chart.js/LICENSE.md
 
     For more third party content see the list in `app/LEGALNOTICE`.
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A hassle-free and cost-free web analytics platform for your WordPress which lets you stay in full control with 100% data ownership and user-privacy protection.
 
-This plugin installs a fully functional [Matomo](https://matomo.org) within your WordPress. If you already have a working Matomo (either [On-Premise](https://matomo.org/matomo-on-premise/) or [Matomo Cloud](https://matomo.org/hosting/)), use the [WP-Matomo Integration plugin](https://wordpress.org/plugins/wp-piwik/) instead. If you have a high traffic website, we recommend using On-Premise or the Cloud-hosted solution for better performance.
+This plugin installs a fully functional [Matomo](https://matomo.org) within your WordPress. If you already have a working Matomo (either [On-Premise](https://matomo.org/matomo-on-premise/) or [Matomo Cloud](https://matomo.org/hosting/)), use the [Connect Matomo Integration plugin](https://wordpress.org/plugins/wp-piwik/) instead. If you have a high traffic website, we recommend using On-Premise or the Cloud-hosted solution for better performance.
 
 Learn more about this plugin in the [readme.txt](readme.txt).
 

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -160,7 +160,7 @@ if ( !is_plugin_active('matomo/matomo.php')
 }
 
 if ( $GLOBALS['MATOMO_LOADED_DIRECTLY'] ) {
-	// see https://github.com/matomo-org/wp-matomo/issues/190
+	// see https://github.com/matomo-org/matomo-for-wordpress/issues/190
 	// wp-external-links plugin would register an ob_start(function () {...}) and manipulate any of our API output
 	// and in some cases the output would get completely lost causing blank pages.
 	add_filter('wpel_apply_settings', '__return_false', 99999);

--- a/classes/WpMatomo/API.php
+++ b/classes/WpMatomo/API.php
@@ -208,7 +208,7 @@ class API {
 
 		Bootstrap::do_bootstrap();
 
-		// refs https://github.com/matomo-org/wp-matomo/issues/370 ensuring segment will be used from default request when
+		// refs https://github.com/matomo-org/matomo-for-wordpress/issues/370 ensuring segment will be used from default request when
 		// creating new request object and not the encoded segment
 		if ( isset( $params['segment'] ) ) {
 			if ( isset( $_GET['segment'] ) || isset( $_POST['segment'] ) ) {

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -80,7 +80,7 @@ class SystemReport {
 		'wp-rss-aggregator',
 		// twig conflict
 		'age-verification-for-woocommerce',
-		// see https://github.com/matomo-org/wp-matomo/issues/428
+		// see https://github.com/matomo-org/matomo-for-wordpress/issues/428
 		'minify-html-markup',
 		// see https://wordpress.org/support/topic/graphs-are-not-displayed-in-the-visits-overview-widget/#post-14298068
 		'bigbuy-wc-dropshipping-connector',
@@ -1177,10 +1177,10 @@ class SystemReport {
 
 		if ( is_plugin_active( 'wp-piwik/wp-piwik.php' ) ) {
 			$rows[] = [
-				'name'       => 'WP-Matomo (WP-Piwik) activated',
+				'name'       => 'Connect Matomo (WP-Matomo) activated',
 				'value'      => true,
 				'is_warning' => true,
-				'comment'    => sprintf( esc_html__( 'It is usually not recommended or needed to run Matomo for WordPress and WP-Matomo at the same time. To learn more about the differences between the two plugins view this %s', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/why-are-there-two-different-matomo-for-wordpress-plugins-what-is-the-difference-to-wp-matomo-integration-plugin/', esc_html__( 'URL', 'matomo' ) ) ),
+				'comment'    => sprintf( esc_html__( 'It is usually not recommended or needed to run Matomo for WordPress and Connect Matomo at the same time. To learn more about the differences between the two plugins view this %s', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/why-are-there-two-different-matomo-for-wordpress-plugins-what-is-the-difference-to-wp-matomo-integration-plugin/', esc_html__( 'URL', 'matomo' ) ) ),
 			];
 
 			$mode = get_option( 'wp-piwik_global-piwik_mode' );
@@ -1189,10 +1189,10 @@ class SystemReport {
 			}
 			if ( ! empty( $mode ) ) {
 				$rows[] = [
-					'name'       => 'WP-Matomo mode',
+					'name'       => 'Connect Matomo mode',
 					'value'      => $mode,
 					'is_warning' => 'php' === $mode || 'PHP' === $mode,
-					'comment'    => esc_html__( 'WP-Matomo is configured in "PHP mode". This is known to cause issues with Matomo for WordPress. We recommend you either deactivate WP-Matomo or you go "Settings => WP-Matomo" and change the "Matomo Mode" in the "Connect to Matomo" section to "Self-hosted HTTP API".', 'matomo' ),
+					'comment'    => esc_html__( 'Connect Matomo is configured in "PHP mode". This is known to cause issues with Matomo for WordPress. We recommend you either deactivate Connect Matomo or you go "Settings => Connect Matomo" and change the "Matomo Mode" in the "Connect to Matomo" section to "Self-hosted HTTP API".', 'matomo' ),
 				];
 			}
 		}

--- a/classes/WpMatomo/Admin/views/info_bug_report.php
+++ b/classes/WpMatomo/Admin/views/info_bug_report.php
@@ -20,9 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 		'</a>',
 		'<a target="_blank" rel="noreferrer noopener" href="https://developer.matomo.org/guides/core-team-workflow#submitting-a-feature-request">',
 		'</a>',
-		'<a target="_blank" rel="noreferrer noopener" href="https://github.com/matomo-org/wp-matomo/issues">',
+		'<a target="_blank" rel="noreferrer noopener" href="https://github.com/matomo-org/matomo-for-wordpress/issues">',
 		'</a>',
-		'<a target="_blank" rel="noreferrer noopener" href="https://github.com/matomo-org/wp-matomo/issues/new">',
+		'<a target="_blank" rel="noreferrer noopener" href="https://github.com/matomo-org/matomo-for-wordpress/issues/new">',
 		'</a>'
 	);
 	?>

--- a/classes/WpMatomo/Admin/views/info_high_traffic.php
+++ b/classes/WpMatomo/Admin/views/info_high_traffic.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		On-Premise</a>
 	separately (it's free as well) in combination with the <a href="https://wordpress.org/plugins/wp-piwik/"
 															  target="_blank"
-															  rel="noreferrer noopener">WP-Matomo</a> WordPress
+															  rel="noreferrer noopener">Connect Matomo</a> WordPress
 	plugin.
 	It's free to install and has the same requirements as WordPress.
 	Your Matomo will then run a lot faster and it allows you to put your Matomo installation on a separate server if

--- a/classes/WpMatomo/Admin/views/info_multisite.php
+++ b/classes/WpMatomo/Admin/views/info_multisite.php
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php
 		echo sprintf(
 			esc_html__(
-				'If you are managing quite a few sites or have quite a bit of traffic then we recommend installing %1$sMatomo On-Premise%2$s separately outside WordPress (it\'s free as well) and use it in combination with the %3$sWP-Matomo%4$s WordPress plugin.
+				'If you are managing quite a few sites or have quite a bit of traffic then we recommend installing %1$sMatomo On-Premise%2$s separately outside WordPress (it\'s free as well) and use it in combination with the %3$sConnect Matomo%4$s WordPress plugin.
         Your Matomo will then run a lot faster, you can put Matomo on a separate server if needed, and it allows you to make use of additional features such as %5$sRoll-Up Reporting%6$s.',
 				'matomo'
 			),

--- a/classes/WpMatomo/Compatibility.php
+++ b/classes/WpMatomo/Compatibility.php
@@ -19,7 +19,7 @@ class Compatibility {
 	}
 
 	/**
-	 * refs https://github.com/matomo-org/wp-matomo/issues/131
+	 * refs https://github.com/matomo-org/matomo-for-wordpress/issues/131
 	 * When user disables feature "Disable PHP in plugins" in system tweaks
 	 * then the Matomo backend doesn't work
 	 */

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -100,7 +100,7 @@ class Sync {
 
 		$current_user = wp_get_current_user();
 		if ( ! empty( $current_user ) && ! empty( $current_user->user_login ) ) {
-			// refs https://github.com/matomo-org/wp-matomo/issues/365
+			// refs https://github.com/matomo-org/matomo-for-wordpress/issues/365
 			// some other plugins may under circumstances overwrite the get_users query and not return all users
 			// as a result we would delete some users in the matomo users table. this way we make sure at least the current
 			// user will be added and not deleted even if the list of users is not complete

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -289,7 +289,7 @@ class WordPress extends Plugin
     public function onGenerateReportEnd()
     {
     	if (Request::isCurrentApiRequestTheRootApiRequest() && !headers_sent()) {
-    		// fix https://github.com/matomo-org/wp-matomo/issues/98
+    		// fix https://github.com/matomo-org/matomo-for-wordpress/issues/98
 		    // When some plugin does an ob_start before the API is being executed then the following happens:
 		    // * PDF is generated and sent
 		    // * We send the application/pdf content-type header

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Matomo is the #1 Google Analytics alternative that gives you full control over y
 
 == Description ==
 
-Already Matomo On-Premise or Matomo Cloud user? You need to use the [WP-Matomo plugin](https://wordpress.org/plugins/wp-piwik/) instead of this plugin.
+Already Matomo On-Premise or Matomo Cloud user? You need to use the [Connect Matomo plugin](https://wordpress.org/plugins/wp-piwik/) instead of this plugin.
 
 For all you WordPress website owners wanting an easier way to get customer insights to grow your business, you can now get the solution the professionals use, for free!
 
@@ -91,7 +91,7 @@ Running Matomo Analytics on your server can use significant resources. Whenever 
 
 * The minimum PHP memory limit is 128Mb, but we recommend to use a higher limit (memory_limit = 256M).
 * PHP 7.2 at minimum is required.
-* If you have high traffic website, or manage a lot of websites with WordPress MultiSite, we recommend installing [Matomo On-Premise](https://matomo.org/docs/installation/) or signup to [Matomo Cloud](https://matomo.org/hosting/) and install the [WP-Matomo plugin](https://wordpress.org/plugins/wp-piwik/) instead.
+* If you have high traffic website, or manage a lot of websites with WordPress MultiSite, we recommend installing [Matomo On-Premise](https://matomo.org/docs/installation/) or signup to [Matomo Cloud](https://matomo.org/hosting/) and install the [Connect Matomo plugin](https://wordpress.org/plugins/wp-piwik/) instead.
 * Needing to know more before you install? Have a [read through the most popular FAQs to ensure you’re making the right choice for you](https://matomo.org/faq/wordpress/what-are-the-requirements-for-matomo-for-wordpress/).
 
 Over 1 million websites in over 190 countries are using Matomo already. Join the revolution too! Install Matomo on your Wordpress website completely free and take back full control of your data!
@@ -175,7 +175,7 @@ Needing to know more? [Click here to view all of our FAQs on our website](https:
 == Credits ==
 
 * The entire Matomo team and everyone who contributed
-* Andr&eacute; Br&auml;kling who is the Author of the [WP-Matomo plugin](https://github.com/braekling/WP-Matomo)
+* Andr&eacute; Br&auml;kling who is the Author of the [Connect Matomo plugin](https://github.com/braekling/WP-Matomo)
 
 == Screenshots ==
 
@@ -193,4 +193,4 @@ Needing to know more? [Click here to view all of our FAQs on our website](https:
 
 == Changelog ==
 
-[See changelog for all versions](https://github.com/matomo-org/wp-matomo/blob/develop/CHANGELOG.md).
+[See changelog for all versions](https://github.com/matomo-org/matomo-for-wordpress/blob/develop/CHANGELOG.md).

--- a/tests/phpunit/wpmatomo/test-optout.php
+++ b/tests/phpunit/wpmatomo/test-optout.php
@@ -34,7 +34,7 @@ class OptOutTest extends MatomoAnalytics_TestCase {
 	}
 
 	public function test_optOutJs_exists() {
-		// see https://github.com/matomo-org/wp-matomo/issues/46
+		// see https://github.com/matomo-org/matomo-for-wordpress/issues/46
 		$this->assertFileExists( plugin_dir_path( MATOMO_ANALYTICS_FILE ) . 'app/plugins/CoreAdminHome/javascripts/optOut.js' );
 	}
 


### PR DESCRIPTION
### Description:

Fixes #891 

Also includes renaming the wp-matomo repo in URLs to matomo-for-wordpress, since those were found by my grep as well.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
