### PR TITLE
correctly initialize trusted_hosts iwhen wordpress is on a non-80 port

### DIFF
--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -260,13 +260,20 @@ class Installer {
 		$this->logger->log( 'Matomo is now creating the config' );
 		$home_url = home_url();
 		$domain   = wp_parse_url( $home_url, PHP_URL_HOST );
-		$domain   = $domain ? $home_url : $domain;
-		$general  = [
+		if ( $domain ) {
+			$port = wp_parse_url( $home_url, PHP_URL_PORT );
+			if ( $port ) {
+				$domain .= ':' . $port;
+			}
+		} else {
+			$domain = $home_url;
+		}
+		$general = [
 			'trusted_hosts' => [ $domain ],
 			'salt'          => Common::generateUniqId(),
 		];
-		$config   = Config::getInstance();
-		$path     = $config->getLocalPath();
+		$config  = Config::getInstance();
+		$path    = $config->getLocalPath();
 		if ( ! is_dir( dirname( $path ) ) ) {
 			wp_mkdir_p( dirname( $path ) );
 		}


### PR DESCRIPTION
### Description:

As title. Extracted from #975 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
