### PR TITLE
fix JSON double encode in WP matomo API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 == Changelog ===
 
+= 5.0.0 =
+* Fix double encoded JSON response from REST API when `format=json` is used with Matomo API requests. If you rely on using the Matomo API through WordPress REST requests, you may need to adjust your code that processes API responses.
+
 = 4.15.3 =
 * Compatibility with WooCommerce's HPOS feature
 * Avoid executing System Report on every Matomo for WordPress admin page view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 == Changelog ===
 
 = 5.0.0 =
-* Fix double encoded JSON response from REST API when `format=json` is used with Matomo API requests. If you rely on using the Matomo API through WordPress REST requests, you may need to adjust your code that processes API responses.
+* Fix double encoded JSON response from REST API when `format=json` is used in Matomo API requests. If you use the Matomo API through WordPress REST requests, you may need to adjust your code that processes API responses.
 
 = 4.15.3 =
 * Compatibility with WooCommerce's HPOS feature

--- a/classes/WpMatomo/API.php
+++ b/classes/WpMatomo/API.php
@@ -219,16 +219,15 @@ class API {
 			}
 		}
 
+		if ( isset( $params['format'] ) && 'json' === $params['format'] ) {
+			// WordPress always JSON encodes the result of REST API methods, so sending format=json to Matomo
+			// results in double JSON encoding the result. so if format=json is detected, we override the format
+			// to 'original', to ensure it's only JSON encoded once.
+			$params['format'] = 'original';
+		}
+
 		try {
 			$result = Request::processRequest( $api_method, $params );
-
-			if ( isset( $params['format'] ) && 'json' === $params['format'] ) {
-				// WordPress always JSON encodes the result of REST API methods, so sending format=json to Matomo
-				// results in double JSON encoding the result. so we decode it here to avoid this.
-				// NOTE: if the array/php API renderer was still around in core, we could use that, but it was
-				// deprecated a while ago.
-				$result = json_decode( $result, true );
-			}
 		} catch ( Exception $e ) {
 			$code = 'matomo_error';
 			if ( $e->getCode() ) {

--- a/classes/WpMatomo/API.php
+++ b/classes/WpMatomo/API.php
@@ -221,6 +221,14 @@ class API {
 
 		try {
 			$result = Request::processRequest( $api_method, $params );
+
+			if ( isset( $params['format'] ) && 'json' === $params['format'] ) {
+				// WordPress always JSON encodes the result of REST API methods, so sending format=json to Matomo
+				// results in double JSON encoding the result. so we decode it here to avoid this.
+				// NOTE: if the array/php API renderer was still around in core, we could use that, but it was
+				// deprecated a while ago.
+				$result = json_decode( $result, true );
+			}
 		} catch ( Exception $e ) {
 			$code = 'matomo_error';
 			if ( $e->getCode() ) {

--- a/tests/phpunit/wpmatomo/test-api.php
+++ b/tests/phpunit/wpmatomo/test-api.php
@@ -46,11 +46,22 @@ class ApiTest extends MatomoAnalytics_TestCase {
 	public function test_dispatch_matomo_api_with_json_response() {
 		$this->create_set_super_admin();
 
-		$request  = new WP_REST_Request( 'GET', '/' . API::VERSION . '/api/matomo_version?format=json' );
+		$request = new WP_REST_Request( 'GET', '/' . API::VERSION . '/api/matomo_version' );
+		$request->set_param( 'format', 'json' );
+
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertStringStartsWith( '4.', $response->get_data() );
 		// check that the string is not serialized json
 		$this->assertNull( json_decode( $response->get_data() ) );
+	}
+
+	public function test_dispatch_matomo_api_with_json_response_when_datatable() {
+		$this->create_set_super_admin();
+
+		$request = new WP_REST_Request( 'GET', '/' . API::VERSION . '/api/widget_metadata' );
+		$request->set_param( 'format', 'json' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertIsArray( $response->get_data() );
 	}
 
 	public function test_dispatch_matomo_api_when_not_authenticated() {

--- a/tests/phpunit/wpmatomo/test-api.php
+++ b/tests/phpunit/wpmatomo/test-api.php
@@ -43,6 +43,16 @@ class ApiTest extends MatomoAnalytics_TestCase {
 		$this->assertTrue( strlen( $response->get_data() ) < 15 );
 	}
 
+	public function test_dispatch_matomo_api_with_json_response() {
+		$this->create_set_super_admin();
+
+		$request  = new WP_REST_Request( 'GET', '/' . API::VERSION . '/api/matomo_version?format=json' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertStringStartsWith( '4.', $response->get_data() );
+		// check that the string is not serialized json
+		$this->assertNull( json_decode( $response->get_data() ) );
+	}
+
 	public function test_dispatch_matomo_api_when_not_authenticated() {
 		$request  = new WP_REST_Request( 'GET', '/' . API::VERSION . '/api/matomo_version' );
 		$response = rest_get_server()->dispatch( $request );


### PR DESCRIPTION
### Description:

WordPress always json encode's the response after dispatching a REST request. So when `format=json` is used, the JSON returned by Matomo is encoded again.

Fixed by forcing format=original if `format=json` is used.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
