### PR TITLE
add CoreAdminHome.runCronArchiving to WP REST API for tests

### DIFF
--- a/classes/WpMatomo/API.php
+++ b/classes/WpMatomo/API.php
@@ -53,6 +53,7 @@ class API {
 		$this->register_route( 'Annotations', 'getAll' );
 		$this->register_route( 'CoreAdminHome', 'invalidateArchivedReports' );
 		$this->register_route( 'CoreAdminHome', 'runScheduledTasks' );
+		$this->register_route( 'CoreAdminHome', 'runCronArchiving' );
 		$this->register_route( 'Dashboard', 'getDashboards' );
 		$this->register_route( 'ImageGraph', 'get' );
 		$this->register_route( 'VisitsSummary', 'getVisits' );

--- a/config/config.php
+++ b/config/config.php
@@ -30,6 +30,10 @@ return array(
 	// we want to avoid the regular monolog logger as it could interfere with other plugins maybe. for now lets use a
 	// custom logger
 	'Psr\Log\LoggerInterface' => DI\get('\Piwik\Plugins\WordPress\Logger'),
+	// following two entries used by CoreAdminHome.runCronArchiving
+	'log.short.format' => '%level% %tag%[%datetime%] %message%',
+	'Piwik\Plugins\Monolog\Formatter\LineMessageFormatter' => DI\create('Piwik\Plugins\Monolog\Formatter\LineMessageFormatter')
+		->constructor(DI\get('log.short.format')),
 	'TagManagerContainerStorageDir' => function () {
 		if (defined('MATOMO_TAG_MANAGER_STORAGE_DIR')) {
 			return MATOMO_TAG_MANAGER_STORAGE_DIR;

--- a/plugins/WordPress/Logger.php
+++ b/plugins/WordPress/Logger.php
@@ -9,6 +9,7 @@
 
 namespace Piwik\Plugins\WordPress;
 
+use Monolog\Handler\HandlerInterface;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Piwik\Common;
 use Piwik\Config;
@@ -32,16 +33,16 @@ if (!defined( 'ABSPATH')) {
 
 class Logger extends AbstractLogger implements LoggerInterface
 {
-	const DEBUG = 100;
-	const INFO = 200;
-	const NOTICE = 250;
-	const WARNING = 300;
-	const ERROR = 400;
-	const CRITICAL = 500;
-	const ALERT = 550;
-	const EMERGENCY = 600;
+    const DEBUG = 100;
+    const INFO = 200;
+    const NOTICE = 250;
+    const WARNING = 300;
+    const ERROR = 400;
+    const CRITICAL = 500;
+    const ALERT = 550;
+    const EMERGENCY = 600;
 
-	private $levels = array(
+    private $levels = array(
         self::DEBUG     => 'DEBUG',
         self::INFO      => 'INFO',
         self::NOTICE    => 'NOTICE',
@@ -52,170 +53,185 @@ class Logger extends AbstractLogger implements LoggerInterface
         self::EMERGENCY => 'EMERGENCY',
     );
 
-	private $writers = array();
+    private $writers = array();
 
-	private $is_tracker = false;
+    private $is_tracker = false;
 
-	private $level = self::WARNING;
+    private $level = self::WARNING;
 
-	/**
-	 * @var \WpMatomo\Logger
-	 */
-	private $logger;
+    /**
+     * @var \WpMatomo\Logger
+     */
+    private $logger;
 
-	public function __construct() {
-		$this->logger = new \WpMatomo\Logger();
-		$logConfig = Config::getInstance()->log;
+    /**
+     * @var HandlerInterface[]
+     */
+    private $handlers = [];
 
-		if (!empty($logConfig['log_writers'])) {
-			$this->writers = $logConfig['log_writers'];
-		}
+    public function __construct() {
+        $this->logger = new \WpMatomo\Logger();
+        $logConfig = Config::getInstance()->log;
 
-		$this->is_tracker = SettingsServer::isTrackerApiRequest();
+        if (!empty($logConfig['log_writers'])) {
+            $this->writers = $logConfig['log_writers'];
+        }
 
-		$level = null;
-		if (!empty($logConfig['log_level'])) {
-			$level = strtoupper($logConfig['log_level']);
+        $this->is_tracker = SettingsServer::isTrackerApiRequest();
 
-			if (defined('Piwik\Log::'.strtoupper($level))) {
-				$this->level = Log::getMonologLevel(constant('Piwik\Log::'.strtoupper($level)));
-			}
-		}
-	}
+        $level = null;
+        if (!empty($logConfig['log_level'])) {
+            $level = strtoupper($logConfig['log_level']);
 
-	private function make_numeric_level($level)
-	{
-		if (is_string($level) && defined(__CLASS__.'::'.strtoupper($level))) {
-			return constant(__CLASS__.'::'.strtoupper($level));
-		}
+            if (defined('Piwik\Log::'.strtoupper($level))) {
+                $this->level = Log::getMonologLevel(constant('Piwik\Log::'.strtoupper($level)));
+            }
+        }
+    }
 
-		return $level;
-	}
+    public function pushHandler(HandlerInterface $handler)
+    {
+        $this->handlers[] = $handler;
+    }
 
-	public function emergency($message, array $context = [])
-	{
-		$this->log(self::EMERGENCY, $message, $context);
-	}
+    private function make_numeric_level($level)
+    {
+        if (is_string($level) && defined(__CLASS__.'::'.strtoupper($level))) {
+            return constant(__CLASS__.'::'.strtoupper($level));
+        }
 
-	public function alert($message, array $context = [])
-	{
-		$this->log(self::ALERT, $message, $context);
-	}
+        return $level;
+    }
 
-	public function critical($message, array $context = array())
-	{
-		$this->log(self::CRITICAL, $message, $context);
-	}
+    public function emergency($message, array $context = [])
+    {
+        $this->log(self::EMERGENCY, $message, $context);
+    }
 
-	public function error($message, array $context = [])
-	{
-		$this->log(self::ERROR, $message, $context);
-	}
+    public function alert($message, array $context = [])
+    {
+        $this->log(self::ALERT, $message, $context);
+    }
 
-	public function warning($message, array $context = [])
-	{
-		$this->log(self::WARNING, $message, $context);
-	}
+    public function critical($message, array $context = array())
+    {
+        $this->log(self::CRITICAL, $message, $context);
+    }
 
-	public function debug($message, array $context = [])
-	{
-		$this->log(self::DEBUG, $message, $context);
-	}
+    public function error($message, array $context = [])
+    {
+        $this->log(self::ERROR, $message, $context);
+    }
 
-	public function notice($message, array $context = [])
-	{
-		$this->log(self::NOTICE, $message, $context);
-	}
+    public function warning($message, array $context = [])
+    {
+        $this->log(self::WARNING, $message, $context);
+    }
 
-	public function info($message, array $context = [])
-	{
-		$this->log(self::INFO, $message, $context);
-	}
+    public function debug($message, array $context = [])
+    {
+        $this->log(self::DEBUG, $message, $context);
+    }
 
-	/**
-	 * Logs with an arbitrary level.
-	 *
-	 * @param mixed $level
-	 * @param string $message
-	 * @param array $context
-	 *
-	 * @return void
-	 */
-	public function log( $level, $message, array $context = array() ) {
+    public function notice($message, array $context = [])
+    {
+        $this->log(self::NOTICE, $message, $context);
+    }
 
-		$is_tracker_debug = $this->is_tracker && ((!empty($GLOBALS['PIWIK_TRACKER_DEBUG']) && $GLOBALS['PIWIK_TRACKER_DEBUG'] === true) || StaticContainer::get("ini.Tracker.debug"));
+    public function info($message, array $context = [])
+    {
+        $this->log(self::INFO, $message, $context);
+    }
 
-		if ( !$is_tracker_debug && (!defined( 'WP_DEBUG' ) || WP_DEBUG !== true )) {
-			return;
-		}
 
-		$level = $this->make_numeric_level($level);
+    /**
+     * Logs with an arbitrary level.
+     *
+     * @param mixed $level
+     * @param string $message
+     * @param array $context
+     *
+     * @return void
+     */
+    public function log( $level, $message, array $context = array() ) {
 
-		if ($is_tracker_debug) {
-			$this->level = self::DEBUG;
-		}
+        $is_tracker_debug = $this->is_tracker && ((!empty($GLOBALS['PIWIK_TRACKER_DEBUG']) && $GLOBALS['PIWIK_TRACKER_DEBUG'] === true) || StaticContainer::get("ini.Tracker.debug"));
 
-		if ($level < $this->level) {
-			return;
-		}
+        if ( !$is_tracker_debug && (!defined( 'WP_DEBUG' ) || WP_DEBUG !== true )) {
+            return;
+        }
 
-		$title = '';
-		if ($this->levels[$level]) {
-			$title = $this->levels[$level] . ': ';
-		}
+        $level = $this->make_numeric_level($level);
 
-		$record = array('message' => $message, 'context' => $context);
-		$processors = [
-			new SprintfProcessor(),
-			new ClassNameProcessor(),
-			new RequestIdProcessor(),
-			new ExceptionToTextProcessor(),
-			new PsrLogMessageProcessor(),
-			new TokenProcessor()
-		];
-		foreach ($processors as $processor) {
-			$record = call_user_func($processor, $record);
-		}
-		$message = $record['message'];
+        if ($is_tracker_debug) {
+            $this->level = self::DEBUG;
+        }
 
-		if (!Common::isPhpCliMode()
-		    && !Bootstrap::was_bootstrapped_by_wordpress() // we don't want to show log messages while being in wordpress
-		    && in_array('screen', $this->writers)
-		    && !empty($message)) {
-			if ($this->is_tracker) {
-				if ($is_tracker_debug) {
-					echo time() . ': ' . $message . "\n";
-				}
-			} else {
+        if ($level < $this->level) {
+            return;
+        }
 
-				switch ($level) {
-					case Logger::EMERGENCY:
-					case Logger::ALERT:
-					case Logger::CRITICAL:
-					case Logger::ERROR:
-						$contextNotification = Notification::CONTEXT_ERROR;
-						break;
-					case Logger::WARNING:
-						$contextNotification = Notification::CONTEXT_WARNING;
-						break;
-					default:
-						$contextNotification = Notification::CONTEXT_INFO;
-						break;
-				}
-				$message = $title . htmlentities($message, ENT_COMPAT | ENT_HTML401, 'UTF-8');
+        $title = '';
+        if ($this->levels[$level]) {
+            $title = $this->levels[$level] . ': ';
+        }
 
-				$notification = new Notification($message);
-				$notification->context = $contextNotification;
-				$notification->flags = 0;
-				try {
-					Manager::notify(Common::getRandomString(), $notification);
-				} catch (\Zend_Session_Exception $e) {
-					// Can happen if this handler is enabled in CLI
-					// Silently ignore the error.
-				}
-			}
-		}
+        $record = array('message' => $message, 'context' => $context);
+        $processors = [
+            new SprintfProcessor(),
+            new ClassNameProcessor(),
+            new RequestIdProcessor(),
+            new ExceptionToTextProcessor(),
+            new PsrLogMessageProcessor(),
+            new TokenProcessor()
+        ];
+        foreach ($processors as $processor) {
+            $record = call_user_func($processor, $record);
+        }
+        $message = $record['message'];
 
-		$this->logger->log($message);
-	}
+        if (!Common::isPhpCliMode()
+            && !Bootstrap::was_bootstrapped_by_wordpress() // we don't want to show log messages while being in wordpress
+            && in_array('screen', $this->writers)
+            && !empty($message)) {
+            if ($this->is_tracker) {
+                if ($is_tracker_debug) {
+                    echo time() . ': ' . $message . "\n";
+                }
+            } else {
+
+                switch ($level) {
+                    case Logger::EMERGENCY:
+                    case Logger::ALERT:
+                    case Logger::CRITICAL:
+                    case Logger::ERROR:
+                        $contextNotification = Notification::CONTEXT_ERROR;
+                        break;
+                    case Logger::WARNING:
+                        $contextNotification = Notification::CONTEXT_WARNING;
+                        break;
+                    default:
+                        $contextNotification = Notification::CONTEXT_INFO;
+                        break;
+                }
+                $message = $title . htmlentities($message, ENT_COMPAT | ENT_HTML401, 'UTF-8');
+
+                $notification = new Notification($message);
+                $notification->context = $contextNotification;
+                $notification->flags = 0;
+                try {
+                    Manager::notify(Common::getRandomString(), $notification);
+                } catch (\Zend_Session_Exception $e) {
+                    // Can happen if this handler is enabled in CLI
+                    // Silently ignore the error.
+                }
+            }
+        }
+
+        $this->logger->log($message);
+
+        foreach ($this->handlers as $handler) {
+            $handler->handle($record);
+        }
+    }
 }


### PR DESCRIPTION
### Description:

Makes the CoreAdminHome.runCronArchiving method accessible through the WP REST API. This is primarily for e2e tests to be able to programmatically launch archiving. It is not expected that users will actively use this, as there's a far more convenient way of doing it in the UI.

Note: due to [this flush() call](https://github.com/matomo-org/matomo/blob/5.x-dev/core/CronArchive.php#L386), the API method will end up triggering an error when WordPress tries to send headers, since `flush()` makes it impossible to send new headers. Otherwise it works.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
