### PR TITLE
allow authenticating tracker via WP application password

### DIFF
--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\WordPress;
 use Piwik\AuthResult;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\SettingsServer;
+use Piwik\Tracker\TrackerConfig;
 use WpMatomo\User;
 
 if (!defined( 'ABSPATH')) {
@@ -30,28 +31,10 @@ class Auth extends \Piwik\Plugins\Login\Auth
         // tracking request authentication. only executes if a WordPress application password
         // is supplied and if a token_auth is supplied (though the token_auth is ignored).
         $isTrackerApiRequest = SettingsServer::isTrackerApiRequest();
-        if ($isTrackerApiRequest
-            && function_exists('wp_validate_application_password')
-        ) {
-            $callback = function () { return true; };
-
-            add_filter('application_password_is_api_request', $callback);
-            try {
-                $loggedInUserId = wp_validate_application_password(false);
-                $isUserLoggedIn = $loggedInUserId !== false;
-            } finally {
-                remove_filter('application_password_is_api_request', $callback);
-            }
-
-            if ($isUserLoggedIn) {
-                $login = User::get_matomo_user_login($loggedInUserId);
-
-                $userModel = new Model();
-                $matomoUser = $userModel->getUser($login);
-                if (!empty($matomoUser)) {
-                    $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
-                    return new AuthResult($code, $login, $this->token_auth);
-                }
+        if ($isTrackerApiRequest) {
+            $result = $this->authTrackerWithAppPassword();
+            if (!empty($result)) {
+                return $result;
             }
         }
 
@@ -68,4 +51,39 @@ class Auth extends \Piwik\Plugins\Login\Auth
         return new AuthResult(AuthResult::FAILURE, $login, $this->token_auth);
     }
 
+    private function authTrackerWithAppPassword()
+    {
+        if (!function_exists('wp_validate_application_password')) {
+            return null;
+        }
+
+        if (TrackerConfig::getConfigValue('allow_wp_app_password_auth') != 1) {
+            return null;
+        }
+
+        $callback = function () { return true; };
+
+        add_filter('application_password_is_api_request', $callback);
+        try {
+            $loggedInUserId = wp_validate_application_password(false);
+            $isUserLoggedIn = $loggedInUserId !== false;
+        } finally {
+            remove_filter('application_password_is_api_request', $callback);
+        }
+
+        if (!$isUserLoggedIn) {
+            return null;
+        }
+
+        $login = User::get_matomo_user_login($loggedInUserId);
+
+        $userModel = new Model();
+        $matomoUser = $userModel->getUser($login);
+        if (empty($matomoUser)) {
+            return null;
+        }
+
+        $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
+        return new AuthResult($code, $login, $this->token_auth);
+    }
 }

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -12,6 +12,7 @@ namespace Piwik\Plugins\WordPress;
 use Piwik\AuthResult;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\SettingsServer;
+use WpMatomo\User;
 
 if (!defined( 'ABSPATH')) {
     exit; // if accessed directly
@@ -43,13 +44,13 @@ class Auth extends \Piwik\Plugins\Login\Auth
             }
 
             if ($isUserLoggedIn) {
-                $user = get_user_by('id', $loggedInUserId);
+                $login = User::get_matomo_user_login($loggedInUserId);
 
                 $userModel = new Model();
-                $matomoUser = $userModel->getUser($user->user_login);
+                $matomoUser = $userModel->getUser($login);
                 if (!empty($matomoUser)) {
                     $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
-                    return new AuthResult($code, $user->user_login, $this->token_auth);
+                    return new AuthResult($code, $login, $this->token_auth);
                 }
             }
         }

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -10,6 +10,8 @@
 namespace Piwik\Plugins\WordPress;
 
 use Piwik\AuthResult;
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\SettingsServer;
 
 if (!defined( 'ABSPATH')) {
     exit; // if accessed directly
@@ -24,7 +26,37 @@ class Auth extends \Piwik\Plugins\Login\Auth
 
     public function authenticate()
     {
-        if (function_exists('is_user_logged_in') && is_user_logged_in()) {
+        // tracking request authentication. only executes if a WordPress application password
+        // is supplied and if a token_auth is supplied (though the token_auth is ignored).
+        $isTrackerApiRequest = SettingsServer::isTrackerApiRequest();
+        if ($isTrackerApiRequest
+            && function_exists('wp_validate_application_password')
+        ) {
+            $callback = function () { return true; };
+
+            add_filter('application_password_is_api_request', $callback);
+            try {
+                $loggedInUserId = wp_validate_application_password(false);
+                $isUserLoggedIn = $loggedInUserId !== false;
+            } finally {
+                remove_filter('application_password_is_api_request', $callback);
+            }
+
+            if ($isUserLoggedIn) {
+                $user = get_user_by('id', $loggedInUserId);
+
+                $userModel = new Model();
+                $matomoUser = $userModel->getUser($user->user_login);
+                if (!empty($matomoUser)) {
+                    $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
+                    return new AuthResult($code, $user->user_login, $this->token_auth);
+                }
+            }
+        }
+
+        // UI request authentication
+        $isUserLoggedIn = function_exists('is_user_logged_in') && is_user_logged_in();
+        if ($isUserLoggedIn) {
 	        if (is_null($this->login) && empty($this->hashedPassword)) {
 	            // api authentication using token
 		        return parent::authenticate();

--- a/tests/phpunit/framework/test-matomo-test-case.php
+++ b/tests/phpunit/framework/test-matomo-test-case.php
@@ -168,10 +168,18 @@ class MatomoAnalytics_TestCase extends MatomoUnit_TestCase {
 	}
 
 	protected function assert_tracking_response( $tracking_response ) {
+		$this->assertEquals( $this->get_expected_tracking_response(), $tracking_response );
+	}
+
+	protected function assert_not_tracking_response( $tracking_response ) {
+		$this->assertNotEquals( $this->get_expected_tracking_response(), $tracking_response );
+	}
+
+	private function get_expected_tracking_response() {
 		$trans_gif_64 = 'R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
 		$expected_response = base64_decode( $trans_gif_64 );
-		$this->assertEquals( $expected_response, $tracking_response );
+		return $expected_response;
 	}
 
 	protected function enable_browser_archiving() {

--- a/tests/phpunit/wpmatomo/test-tracking.php
+++ b/tests/phpunit/wpmatomo/test-tracking.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * @package matomo
+ */
+
+/**
+ * @phpcs:disable WordPress.PHP.IniSet.Risky
+ */
+class TrackingTest extends MatomoAnalytics_TestCase {
+	private $application_password;
+
+	private $user_login;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		$this->user_login = wp_get_current_user()->user_login;
+
+		$this->assertNotEmpty( $this->user_login );
+
+		$sync = new \WpMatomo\User\Sync();
+		$sync->sync_all();
+
+		$user_model = new \Piwik\Plugins\UsersManager\Model();
+		$this->assertNotEmpty( $user_model->getUser( \WpMatomo\User::get_matomo_user_login( $user_id ) ) );
+
+		// add application password
+		// NOTE: we don't skip all the tests here to make sure the auth code
+		// works when application password functions do not exist
+		if ( version_compare( getenv( 'WORDPRESS_VERSION' ), '5.6', '>=' ) ) {
+			add_filter( 'wp_is_application_passwords_available', '__return_true' );
+
+			$request = new WP_REST_Request( 'POST', '/wp/v2/users/me/application-passwords' );
+			$request->set_param( 'name', 'test' );
+			$response = rest_get_server()->dispatch( $request );
+
+			$response_data              = $response->get_data();
+			$this->application_password = $response_data['password'];
+		}
+	}
+
+	public function tearDown(): void {
+		wp_set_current_user( null );
+
+		parent::tearDown();
+	}
+
+	public function test_cdt_requet_fails_when_no_token_auth_and_no_app_pwd() {
+		$date_time_in_past = '2023-02-02 01:00:00';
+
+		$tracker = $this->make_local_tracker( $date_time_in_past );
+		$tracker->setUrl( 'http://test.com/page' );
+
+		$error_log_before = ini_get( 'error_log' );
+		ini_set( 'error_log', 'syslog' );
+		try {
+			self::assert_not_tracking_response( $tracker->doTrackPageView( 'page title' ) );
+		} finally {
+			ini_set( 'error_log', $error_log_before );
+		}
+
+		$visit_date = $this->get_latest_action_date();
+		$this->assertEmpty( $visit_date );
+	}
+
+	public function test_cdt_request_fails_when_token_auth_and_no_app_pwd() {
+		$date_time_in_past = '2023-02-02 01:00:00';
+
+		$tracker = $this->make_local_tracker( $date_time_in_past );
+		$tracker->setTokenAuth( 'testtesttest' );
+		$tracker->setUrl( 'http://test.com/page' );
+
+		$error_log_before = ini_get( 'error_log' );
+		ini_set( 'error_log', 'syslog' );
+		try {
+			self::assert_not_tracking_response( $tracker->doTrackPageView( 'page title' ) );
+		} finally {
+			ini_set( 'error_log', $error_log_before );
+		}
+
+		$visit_date = $this->get_latest_action_date();
+		$this->assertEmpty( $visit_date );
+	}
+
+	public function test_cdt_ignored_when_no_token_auth_and_app_pwd() {
+		$date_time_in_past = '2023-02-02 01:00:00';
+
+		$tracker = $this->make_local_tracker( $date_time_in_past );
+		$tracker->setUrl( 'http://test.com/page' );
+		$tracker->setExtraServerVar( 'PHP_AUTH_USER', $this->user_login );
+		$tracker->setExtraServerVar( 'PHP_AUTH_PW', $this->application_password );
+
+		$error_log_before = ini_get( 'error_log' );
+		ini_set( 'error_log', 'syslog' );
+		try {
+			self::assert_not_tracking_response( $tracker->doTrackPageView( 'page title' ) );
+		} finally {
+			ini_set( 'error_log', $error_log_before );
+		}
+
+		$visit_date = $this->get_latest_action_date();
+		$this->assertEmpty( $visit_date );
+	}
+
+	public function test_cdt_used_when_valid_app_pwd_supplied_with_token_auth() {
+		if ( version_compare( getenv( 'WORDPRESS_VERSION' ), '5.6', '<' ) ) {
+			$this->markTestSkipped( 'WordPress version does not support application passwords.' );
+		}
+
+		$date_time_in_past = '2023-02-02 01:00:00';
+
+		$tracker = $this->make_local_tracker( $date_time_in_past );
+		$tracker->setUrl( 'http://test.com/page' );
+		$tracker->setTokenAuth( 'testtesttest' ); // ignored
+		$tracker->setExtraServerVar( 'PHP_AUTH_USER', $this->user_login );
+		$tracker->setExtraServerVar( 'PHP_AUTH_PW', $this->application_password );
+		self::assert_tracking_response( $tracker->doTrackPageView( 'page title' ) );
+
+		$visit_date = $this->get_latest_action_date();
+		$this->assertEquals( $date_time_in_past, $visit_date );
+	}
+
+	private function get_latest_action_date() {
+		return \Piwik\Db::fetchOne(
+			'SELECT server_time FROM '
+			. \Piwik\Common::prefixTable( 'log_link_visit_action' )
+			. ' ORDER BY idlink_va DESC LIMIT 1'
+		);
+	}
+}


### PR DESCRIPTION
### Description:

Adding primarily for e2e tests so they can track data in the past via `cdt`. It is not expected for users to need this.

During tracking, if a `token_auth` was used and an application password was supplied with the request, attempt to authenticate the tracking request.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
