### PR TITLE
perform server side tracking if ecommerce events triggered in REST request

### DIFF
--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -77,6 +77,7 @@ class Base {
 
 	protected function should_track_background() {
 		return ( defined( 'DOING_AJAX' ) && DOING_AJAX )
+			   || ( defined( 'REST_REQUEST' ) && REST_REQUEST )
 			   || WpMatomo::$settings->get_global_option( 'track_mode' ) === TrackingSettings::TRACK_MODE_TAGMANAGER;
 	}
 


### PR DESCRIPTION
### Description:

Fixes https://github.com/matomo-org/matomo-for-wordpress/issues/1007

Noticed while writing tests for the ecommerce workflow that if a theme initiates orders via a REST request, rather than an AJAX request that returns HTML, MWP won't do server side tracking. Fixed by looking for the `REST_REQUEST` constant and doing server side tracking if it's present.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
