### PR TITLE
ensure REST API correctly json_encodes Matomo API DataTable responses

### DIFF
--- a/classes/WpMatomo/API.php
+++ b/classes/WpMatomo/API.php
@@ -11,6 +11,7 @@ namespace WpMatomo;
 
 use Exception;
 use Piwik\API\Request;
+use Piwik\API\ResponseBuilder;
 use Piwik\Common;
 use WP_Error;
 use WP_REST_Request;
@@ -220,15 +221,28 @@ class API {
 			}
 		}
 
-		if ( isset( $params['format'] ) && 'json' === $params['format'] ) {
-			// WordPress always JSON encodes the result of REST API methods, so sending format=json to Matomo
-			// results in double JSON encoding the result. so if format=json is detected, we override the format
-			// to 'original', to ensure it's only JSON encoded once.
-			$params['format'] = 'original';
-		}
+		$output_format    = empty( $params['format'] ) ? 'json' : $params['format'];
+		$params['format'] = 'original';
 
 		try {
 			$result = Request::processRequest( $api_method, $params );
+
+			$response_builder = new ResponseBuilder( $output_format, $params );
+			$response_builder->disableDataTablePostProcessor(); // done within Request, we don't need to use it again
+
+			$result = $response_builder->getResponse( $result );
+
+			if ( 'json' === $output_format ) {
+				// WordPress always JSON encodes the result of REST API methods, so sending format=json to Matomo
+				// results in double JSON encoding the result. so if format=json is detected, we have to parse the
+				// the JSON before handing it over to WordPress.
+				$result = json_decode( $result, true );
+
+				// scalar values are returned as is currently
+				if ( array_key_exists( 'value', $result ) && count( $result ) === 1 ) {
+					$result = $result['value'];
+				}
+			}
 		} catch ( Exception $e ) {
 			$code = 'matomo_error';
 			if ( $e->getCode() ) {

--- a/tests/phpunit/wpmatomo/test-api.php
+++ b/tests/phpunit/wpmatomo/test-api.php
@@ -55,13 +55,31 @@ class ApiTest extends MatomoAnalytics_TestCase {
 		$this->assertNull( json_decode( $response->get_data() ) );
 	}
 
-	public function test_dispatch_matomo_api_with_json_response_when_datatable() {
+	public function test_dispatch_matomo_api_with_json_response_when_array() {
 		$this->create_set_super_admin();
 
 		$request = new WP_REST_Request( 'GET', '/' . API::VERSION . '/api/widget_metadata' );
 		$request->set_param( 'format', 'json' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertIsArray( $response->get_data() );
+	}
+
+	public function test_dispatch_matomo_api_response_when_datatable() {
+		$this->create_set_super_admin();
+
+		$tracker = $this->make_local_tracker( null );
+		$tracker->setUrl( 'http://whatever.com/a/page' );
+		$this->assert_tracking_response( $tracker->doTrackPageView( 'a page view' ) );
+
+		$request = new WP_REST_Request( 'GET', '/' . API::VERSION . '/live/last_visits_details' );
+		$request->set_param( 'format', 'json' );
+		$request->set_param( 'period', 'month' );
+		$request->set_param( 'date', 'today' );
+		$request->set_param( 'idSite', '1' );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertIsArray( $response->get_data() );
+		$this->assertCount( 1, $response->get_data() );
 	}
 
 	public function test_dispatch_matomo_api_when_not_authenticated() {


### PR DESCRIPTION
### Description:

Extracted from #1004 

DataTable instances are not currently output correctly via the WordPress REST API. Since the MWP internally uses `format=original` when passing requests to the Matomo API, the response will be a DataTable instance. WordPress will try to json_encode() these instances, but they are not JsonSerializable.

This issue is solved by invoking another ResponseBuilder with the actual appropriate output format, after invoking the Matomo API. Then, if `format=json` is used, decoding the result to avoid WordPress double encoding it.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
