### PR TITLE
matomo's override of error_reporting config can reveal errors in other WP plugins

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,5 +1,8 @@
 <?php
 
+// see plugins/WordPress/WordPress.php for more info
+$GLOBALS['MATOMO_WP_ORIGINAL_ERROR_REPORTING'] = error_reporting();
+
 $GLOBALS['CONFIG_INI_PATH_RESOLVER'] = function () {
 	if ( defined( 'ABSPATH' )
 	     && defined( 'MATOMO_CONFIG_PATH' ) ) {

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -28,6 +28,14 @@ if (!defined( 'ABSPATH')) {
     exit; // if accessed directly
 }
 
+// undo the error_reporting(E_ALL) in app/core/bootstrap.php
+// since we're not running Matomo in isolation, we don't want to
+// override the user's configured error_reporting value, which
+// may be set to hide errors from other WordPress plugins
+if (isset($GLOBALS['MATOMO_WP_ORIGINAL_ERROR_REPORTING'])) {
+    error_reporting($GLOBALS['MATOMO_WP_ORIGINAL_ERROR_REPORTING']);
+}
+
 class WordPress extends Plugin
 {
 	public static $is_archiving = false;


### PR DESCRIPTION
### Description:

Extracted from #1004 

Matomo forces an error_reporting value of E_ALL here: https://github.com/matomo-org/matomo/blob/5.x-dev/core/bootstrap.php#L17

This is fine for the core product, since it is expected that users will run it in isolation, not alongside any other products. However, this assumption does not apply to Matomo for WordPress. MWP is run within WordPress alongside any number of other WordPress plugins of varying quality.

This other code can create warnings and notices that Matomo cannot prevent, and forcing an error_reporting value of E_ALL can cause problems for users throughout WordPress.

So instead of forcing this value, reset the value to it's original value obtained from the server's php.ini.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
