### PR TITLE
correctly compute tag manager web dir when matomo is installed as a symlink

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -44,13 +44,13 @@ return array(
 		return rtrim('/'. $paths->get_relative_dir_to_matomo($paths->get_upload_base_dir().'/'), '/');
 	},
 	'TagManagerContainerWebDir' => function () {
-		if (defined('MATOMO_TAG_MANAGER_STORAGE_DIR')) {
-			return MATOMO_TAG_MANAGER_STORAGE_DIR;
+		if (defined('MATOMO_TAG_MANAGER_WEB_DIR')) {
+			return MATOMO_TAG_MANAGER_WEB_DIR;
 		}
 
 		// the location where we store the generated javascript or json container files
 		$paths = new \WpMatomo\Paths();
-		return rtrim('/'. $paths->get_relative_dir_to_matomo($paths->get_upload_base_dir().'/'), '/');
+		return rtrim('/'. matomo_rel_path($paths->get_upload_base_dir() . '/', WP_PLUGIN_DIR . '/matomo/app'), '/');
 	},
 	'Piwik\Plugins\Login\PasswordVerifier' => DI\autowire('Piwik\Plugins\WordPress\WpPasswordVerifier'),
 	'Piwik\Session\SessionAuth' => DI\autowire('Piwik\Plugins\WordPress\SessionAuth'),


### PR DESCRIPTION
### Description:

Extracted from #1013 

Changes:

* The tag manager web dir should not get the relative path to the actual, `realpath`-d matomo location, but matomo for WordPress plugin folder.
* Use a separate override const for the web dir, since it does not need to be the same as the storage dir.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
