### PR TITLE
Do not load plugins whose core version req is incompatible with the current Matomo.

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -250,6 +250,9 @@ $GLOBALS['MATOMO_MODIFY_CONFIG_SETTINGS'] = function ($settings) {
 			}
 		}
 	}
+	if (!empty($GLOBALS['MATOMO_MARKETPLACE_PLUGINS'])) {
+		matomo_filter_incompatible_plugins($plugins['Plugins']);
+	}
 	$settings['Plugins'] = $plugins;
 	return $settings;
 };

--- a/classes/WpMatomo/Bootstrap.php
+++ b/classes/WpMatomo/Bootstrap.php
@@ -55,7 +55,7 @@ class Bootstrap {
 		self::$assume_not_bootstrapped   = false; // we need to unset it again to prevent recursion
 
 		if ( ! self::$are_incompatible_plugins_filtered ) {
-			$this->filter_incompatible_plugins();
+			matomo_filter_incompatible_plugins( $GLOBALS['MATOMO_PLUGINS_ENABLED'] );
 
 			self::$are_incompatible_plugins_filtered = true;
 		}
@@ -116,32 +116,5 @@ class Bootstrap {
 	public static function do_bootstrap() {
 		$bootstrap = new Bootstrap();
 		$bootstrap->bootstrap();
-	}
-
-	/**
-	 * TODO: test
-	 * public for tests
-	 *
-	 * @return void
-	 */
-	public function filter_incompatible_plugins() {
-		if ( empty( $GLOBALS['MATOMO_MARKETPLACE_PLUGINS'] ) ) {
-			return;
-		}
-
-		$incompatible_plugins = [];
-		foreach ( $GLOBALS['MATOMO_MARKETPLACE_PLUGINS'] as $wp_plugin_file ) {
-			if ( matomo_is_plugin_compatible( $wp_plugin_file ) ) {
-				continue;
-			}
-
-			$plugin_name            = basename( dirname( $wp_plugin_file ) );
-			$incompatible_plugins[] = $plugin_name;
-		}
-
-		$GLOBALS['MATOMO_PLUGINS_ENABLED'] = array_diff(
-			$GLOBALS['MATOMO_PLUGINS_ENABLED'],
-			$incompatible_plugins
-		);
 	}
 }

--- a/matomo.php
+++ b/matomo.php
@@ -209,8 +209,8 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 		// assume the plugin is not compatible in case the below code fails.
 		// this way, the following request will work rather than trigger the same
 		// error.
-		$two_months = 60 * 60 * 24 * 60;
-		set_transient( $cache_key, 0, $two_months );
+		$one_day = 24 * 60 * 60;
+		set_transient( $cache_key, 0, $one_day );
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$plugin_manifest = file_get_contents( $plugin_manifest_path );
@@ -233,6 +233,7 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 		$is_compatible = empty( $missing_dependencies );
 		$cache_value   = (int) $is_compatible;
 
+		$two_months = 60 * 60 * 24 * 60;
 		set_transient( $cache_key, $cache_value, $two_months );
 	}
 

--- a/matomo.php
+++ b/matomo.php
@@ -188,6 +188,8 @@ function matomo_rel_path( $to_dir, $from_dir ) {
 }
 
 function matomo_is_plugin_compatible( $wp_plugin_file ) {
+	require_once __DIR__ . '/app/core/Version.php';
+
 	$plugin_manifest_path = dirname( $wp_plugin_file ) . '/plugin.json';
 	if ( ! is_file( $plugin_manifest_path )
 		|| ! is_readable( $plugin_manifest_path )
@@ -195,7 +197,12 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 		return false;
 	}
 
-	$cache_key   = 'matomo_plugin_compatible_' . basename( $wp_plugin_file ) . '_' . filemtime( $plugin_manifest_path );
+	$modified_time = filemtime( $plugin_manifest_path );
+	if ( false === $modified_time ) {
+		return false;
+	}
+
+	$cache_key   = 'matomo_plugin_compatible_' . basename( $wp_plugin_file ) . '_' . \Piwik\Version::VERSION . '_' . $modified_time;
 	$cache_value = get_transient( $cache_key );
 
 	if ( false === $cache_value ) {
@@ -220,7 +227,8 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 		$is_compatible = empty( $missing_dependencies );
 		$cache_value   = (int) $is_compatible;
 
-		set_transient( $cache_key, $cache_value );
+		$two_months = 60 * 60 * 24 * 60;
+		set_transient( $cache_key, $cache_value, $two_months );
 	}
 
 	return 1 === (int) $cache_value;

--- a/matomo.php
+++ b/matomo.php
@@ -250,10 +250,6 @@ function matomo_add_plugin( $plugins_directory, $wp_plugin_file, $is_marketplace
 	}
 
 	if ( $is_marketplace_plugin && dirname( $wp_plugin_file ) === $plugins_directory ) {
-		if ( ! matomo_is_plugin_compatible( $wp_plugin_file ) ) {
-			return;
-		}
-
 		$GLOBALS['MATOMO_MARKETPLACE_PLUGINS'][] = $wp_plugin_file;
 	}
 

--- a/matomo.php
+++ b/matomo.php
@@ -197,6 +197,8 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 		return false;
 	}
 
+	clearstatcache( false, $plugin_manifest_path );
+
 	$modified_time = filemtime( $plugin_manifest_path );
 	if ( false === $modified_time ) {
 		return false;
@@ -204,15 +206,12 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 
 	$cache_key   = 'matomo_plugin_compatible_' . basename( $wp_plugin_file ) . '_' . \Piwik\Version::VERSION . '_' . $modified_time;
 	$cache_value = get_transient( $cache_key );
-
 	if ( false === $cache_value ) {
 		// assume the plugin is not compatible in case the below code fails.
 		// this way, the following request will work rather than trigger the same
 		// error.
 		$one_day = 24 * 60 * 60;
 		set_transient( $cache_key, 0, $one_day );
-
-		clearstatcache( false, $plugin_manifest_path );
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$plugin_manifest = file_get_contents( $plugin_manifest_path );

--- a/matomo.php
+++ b/matomo.php
@@ -206,6 +206,11 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 	$cache_value = get_transient( $cache_key );
 
 	if ( false === $cache_value ) {
+		// assume it's not in case the following code fails.
+		// this way, the following request will work.
+		$two_months = 60 * 60 * 24 * 60;
+		set_transient( $cache_key, 0, $two_months );
+
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$plugin_manifest = file_get_contents( $plugin_manifest_path );
 		$plugin_manifest = json_decode( $plugin_manifest, true );
@@ -227,7 +232,6 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 		$is_compatible = empty( $missing_dependencies );
 		$cache_value   = (int) $is_compatible;
 
-		$two_months = 60 * 60 * 24 * 60;
 		set_transient( $cache_key, $cache_value, $two_months );
 	}
 

--- a/matomo.php
+++ b/matomo.php
@@ -256,7 +256,7 @@ function matomo_filter_incompatible_plugins( &$plugin_list ) {
 		$incompatible_plugins[] = $plugin_name;
 	}
 
-	$plugin_list = array_diff( $plugin_list, $incompatible_plugins );
+	$plugin_list = array_values( array_diff( $plugin_list, $incompatible_plugins ) );
 }
 
 function matomo_add_plugin( $plugins_directory, $wp_plugin_file, $is_marketplace_plugin = false ) {

--- a/matomo.php
+++ b/matomo.php
@@ -189,7 +189,9 @@ function matomo_rel_path( $to_dir, $from_dir ) {
 
 function matomo_is_plugin_compatible( $wp_plugin_file ) {
 	$plugin_manifest_path = dirname( $wp_plugin_file ) . '/plugin.json';
-	if ( ! is_file( $plugin_manifest_path ) ) {
+	if ( ! is_file( $plugin_manifest_path )
+		|| ! is_readable( $plugin_manifest_path )
+	) {
 		return false;
 	}
 

--- a/matomo.php
+++ b/matomo.php
@@ -191,13 +191,13 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 	require_once __DIR__ . '/app/core/Version.php';
 
 	$plugin_manifest_path = dirname( $wp_plugin_file ) . '/plugin.json';
+	clearstatcache( false, $plugin_manifest_path );
+
 	if ( ! is_file( $plugin_manifest_path )
 		|| ! is_readable( $plugin_manifest_path )
 	) {
 		return false;
 	}
-
-	clearstatcache( false, $plugin_manifest_path );
 
 	$modified_time = filemtime( $plugin_manifest_path );
 	if ( false === $modified_time ) {
@@ -208,7 +208,7 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 	$cache_value = get_transient( $cache_key );
 	if ( false === $cache_value ) {
 		// assume the plugin is not compatible in case the below code fails.
-		// this way, the following request will work rather than trigger the same
+		// this way, the next request will work rather than trigger the same
 		// error.
 		$one_day = 24 * 60 * 60;
 		set_transient( $cache_key, 0, $one_day );

--- a/matomo.php
+++ b/matomo.php
@@ -206,8 +206,9 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 	$cache_value = get_transient( $cache_key );
 
 	if ( false === $cache_value ) {
-		// assume it's not in case the following code fails.
-		// this way, the following request will work.
+		// assume the plugin is not compatible in case the below code fails.
+		// this way, the following request will work rather than trigger the same
+		// error.
 		$two_months = 60 * 60 * 24 * 60;
 		set_transient( $cache_key, 0, $two_months );
 

--- a/matomo.php
+++ b/matomo.php
@@ -203,7 +203,7 @@ function matomo_is_plugin_compatible( $wp_plugin_file ) {
 		if ( empty( $plugin_manifest['require']['matomo'] )
 			&& empty( $plugin_manifest['require']['piwik'] )
 		) {
-			return null;
+			return false;
 		}
 
 		$core_requirement = isset( $plugin_manifest['require']['matomo'] )

--- a/tests/phpunit/wpmatomo/test-matomo.php
+++ b/tests/phpunit/wpmatomo/test-matomo.php
@@ -166,7 +166,6 @@ class MatomoTest extends MatomoUnit_TestCase {
 		$this->assertFalse( $actual );
 
 		sleep( 1 ); // so file modified time increases
-		clearstatcache( false, $this->get_test_plugin_manifest_path() );
 
 		$plugin_json_contents = [
 			'require' => [ 'matomo' => $compatible_constraint ],

--- a/tests/phpunit/wpmatomo/test-matomo.php
+++ b/tests/phpunit/wpmatomo/test-matomo.php
@@ -6,6 +6,14 @@
  */
 class MatomoTest extends MatomoUnit_TestCase {
 
+	public function tear_down() {
+		if ( is_file( $this->get_test_plugin_manifest_path() ) ) {
+			unlink( $this->get_test_plugin_manifest_path() );
+		}
+
+		parent::tear_down();
+	}
+
 	public function test_matomo_has_compatible_content_dir() {
 		$this->assertTrue( matomo_has_compatible_content_dir() );
 	}
@@ -26,5 +34,125 @@ class MatomoTest extends MatomoUnit_TestCase {
 			[ '/var/www/html/wordpress', '/var/www/matomo/for/wordpress', '../../../html/wordpress' ],
 			[ '/var/www/matomo/for/wordpress', '/var/www/html/wordpress', '../../matomo/for/wordpress' ],
 		];
+	}
+
+	/**
+	 * @dataProvider get_test_data_for_matomo_is_plugin_compatible
+	 */
+	public function test_matomo_is_plugin_compatible( $plugin_json_contents, $expected ) {
+		if ( null !== $plugin_json_contents ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
+			file_put_contents( $this->get_test_plugin_manifest_path(), wp_json_encode( $plugin_json_contents ) );
+		}
+
+		$actual = matomo_is_plugin_compatible( __DIR__ . '/PluginFile.php' );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function get_test_data_for_matomo_is_plugin_compatible() {
+		require_once __DIR__ . '/../../../app/core/Version.php';
+
+		$current_major_version = \Piwik\Version::MAJOR_VERSION;
+
+		// >=5.0.0-b4,<6.0.0-b1
+		$not_compatible_constraint = '>=' . ( $current_major_version - 1 ) . '.0.0-b1,<' . $current_major_version . '.0.0-b1';
+		$compatible_constraint     = '>=' . $current_major_version . '.0.0-b1,<' . ( $current_major_version + 1 ) . '.0.0-b1';
+
+		$incomplete_constraint_compatible   = '>=' . $current_major_version . '.0.0-b1';
+		$incomplete_constraint_incompatible = '<' . ( $current_major_version - 1 ) . '.5.0';
+
+		return [
+			// no plugin.json
+			[
+				null,
+				false,
+			],
+
+			// normal plugin.json, not compatible
+			[
+				[
+					'require' => [ 'matomo' => $not_compatible_constraint ],
+				],
+				false,
+			],
+
+			// normal plugin.json, compatible
+			[
+				[
+					'require' => [ 'matomo' => $compatible_constraint ],
+				],
+				true,
+			],
+
+			// plugin.json w/ non-core requirements, not compatible
+			[
+				[
+					'require' => [
+						'matomo'        => $compatible_constraint,
+						'AnotherPlugin' => 'ignored',
+					],
+				],
+				true,
+			],
+			[
+				[
+					'require' => [
+						'piwik'         => $compatible_constraint,
+						'AnotherPlugin' => 'ignored',
+					],
+				],
+				true,
+			],
+
+			// plugin.json w/ non-core requirements, compatible
+			[
+				[
+					'require' => [
+						'matomo'        => $not_compatible_constraint,
+						'AnotherPlugin' => 'ignored',
+					],
+				],
+				false,
+			],
+			[
+				[
+					'require' => [
+						'piwik'         => $not_compatible_constraint,
+						'AnotherPlugin' => 'ignored',
+					],
+				],
+				false,
+			],
+
+			// plugin.json w/ missing values
+			[
+				[
+					'require' => [],
+				],
+				false,
+			],
+			[
+				[],
+				false,
+			],
+
+			// plugin.json w/ incomplete constraints
+			[
+				[
+					'require' => [ 'matomo' => $incomplete_constraint_compatible ],
+				],
+				true,
+			],
+			[
+				[
+					'require' => [ 'matomo' => $incomplete_constraint_incompatible ],
+				],
+				false,
+			],
+		];
+	}
+
+	private function get_test_plugin_manifest_path() {
+		return __DIR__ . '/plugin.json';
 	}
 }

--- a/tests/phpunit/wpmatomo/test-matomo.php
+++ b/tests/phpunit/wpmatomo/test-matomo.php
@@ -49,11 +49,6 @@ class MatomoTest extends MatomoUnit_TestCase {
 		$this->mk_temp_dir();
 
 		if ( null !== $plugin_json_contents ) {
-			clearstatcache();
-			if ( ! is_dir( dirname( $this->get_test_plugin_manifest_path() ) ) ) {
-				throw new \Exception("temp dir does not exist?");
-			}
-
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
 			file_put_contents( $this->get_test_plugin_manifest_path(), wp_json_encode( $plugin_json_contents ) );
 		}


### PR DESCRIPTION
### Description:

In Matomo core this is done within the Plugin\Manager, but in Matomo for WordPress we have to do this a bit earlier, since third party plugins are managed by WordPress. An error in incompatibility there can take down the WP back office.

Note: we should ideally also let users know in the WP back office that these plugins need to be updated, but that change is not as urgent.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
