### PR TITLE
remove plugins no longer incompatible with matomo from list in system report

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -71,35 +71,7 @@ class SystemReport {
 	const TROUBLESHOOT_RUN_UPDATER        = 'matomo_troubleshooting_action_run_updater';
 
 	private $not_compatible_plugins = [
-		'background-manager',
-		// Uses an old version of Twig and plugin is no longer maintained.
-		'all-in-one-event-calendar',
-		// Uses an old version of Twig
-		'tweet-old-post-pro',
-		// uses a newer version of monolog
-		'wp-rss-aggregator',
-		// twig conflict
-		'age-verification-for-woocommerce',
-		// see https://github.com/matomo-org/matomo-for-wordpress/issues/428
 		'minify-html-markup',
-		// see https://wordpress.org/support/topic/graphs-are-not-displayed-in-the-visits-overview-widget/#post-14298068
-		'bigbuy-wc-dropshipping-connector',
-		// see https://wordpress.org/support/topic/20-total-errors-during-this-script-execution/
-		'google-listings-and-ads',
-		// see https://wordpress.org/support/topic/20-total-errors-during-this-script-execution/
-		'post-smtp',
-		// see https://wordpress.org/support/topic/activation-of-another-plugin-breaks-matomo/#post-15045079
-		'adshares',
-		// see https://github.com/matomo-org/matomo-for-wordpress/issues/618
-		'bluehost-wordpress-plugin',
-		// see https://wordpress.org/support/topic/archive-error-with-wp-rocket/
-		'wp-rocket',
-		// see https://github.com/matomo-org/matomo-for-wordpress/issues/697
-		'backwpup',
-		// see https://github.com/matomo-org/matomo-for-wordpress/issues/710
-		'fs-poster',
-		// see https://github.com/matomo-org/matomo-for-wordpress/issues/790
-		'advanced-gutenberg',
 	];
 
 	private $valid_tabs = [ 'troubleshooting' ];
@@ -1856,39 +1828,15 @@ class SystemReport {
 			);
 
 			$used_not_compatible = array_intersect( $active_plugins, $this->not_compatible_plugins );
-			if ( in_array( 'wp-rocket', $used_not_compatible, true ) ) {
-				if ( defined( 'WP_ROCKET_VERSION' ) && ( version_compare( WP_ROCKET_VERSION, '3.11.5' ) <= 0 ) ) {
-					unset( $used_not_compatible[ array_search( 'wp-rocket', $used_not_compatible, true ) ] );
-				}
-			}
-
 			if ( ! empty( $used_not_compatible ) ) {
 				$additional_comment = '';
-				if ( in_array( 'tweet-old-post-pro', $used_not_compatible, true ) ) {
-					$additional_comment .= '<br><br>' . esc_html__( 'A workaround for Revive Old Posts Pro may be to add the following line to your "wp-config.php"', 'matomo' ) . '<br><code>define( \'MATOMO_SUPPORT_ASYNC_ARCHIVING\', false );</code>.';
-				}
-				if ( in_array( 'post-smtp', $used_not_compatible, true ) ) {
-					$additional_comment .= '<br><br>' . esc_html__( 'The PDF report files from the email reports will be missing when the PostSMTP mode is selected but it works when the PHPMailer mode is selected.', 'matomo' );
-				}
-				if ( in_array( 'wp-rocket', $used_not_compatible, true ) ) {
-					$additional_comment .= '<br><br>' . sprintf( esc_html__( 'WP-Rocket is incompatible from version 3.12. Until fixes, please reinstall version 3.11.5 if you have a newer version. For more information please visit %s', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://github.com/matomo-org/matomo-for-wordpress/wiki/Downgrade-wp-rocket-to-a-version-compatible-with-the-Matomo-plugin', esc_html__( 'How to downgrade Wp-rocket to be compatible with Matomo', 'matomo' ) ) );
-				}
-				$is_warning = false;
-				$is_error   = false;
 				if ( count( $used_not_compatible ) ) {
-					$is_warning = true;
-					$is_error   = false;
-					if ( in_array( 'cookiebot', $used_not_compatible, true ) ) {
-						$is_warning = false;
-						$is_error   = true;
-					}
-
 					$rows[] = [
 						'name'       => __( 'Not compatible plugins', 'matomo' ),
 						'value'      => count( $used_not_compatible ),
 						'comment'    => implode( ', ', $used_not_compatible ) . '<br><br>' . sprintf( esc_html__( 'Matomo may work fine when using these plugins but there may be some issues. For more information %1$sSee %2$s', 'matomo' ), '<br/>', sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/wordpress/which-plugins-is-matomo-for-wordpress-known-to-be-not-compatible-with/', esc_html__( 'this FAQ', 'matomo' ) ) ) . $additional_comment,
-						'is_warning' => $is_warning,
-						'is_error'   => $is_error,
+						'is_warning' => true,
+						'is_error'   => false,
 					];
 				}
 			}

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1271,7 +1271,7 @@ class SystemReport {
 					array(
 						'method'    => 'GET',
 						'sslverify' => false,
-						'timeout'   => 3,
+						'timeout'   => defined( 'MATOMO_LOCAL_ENVIRONMENT' ) && MATOMO_LOCAL_ENVIRONMENT ? 5 : 2,
 					)
 				);
 				if ( is_array( $result ) ) {

--- a/tests/e2e/baseline/desktop_firefox/mwp-admin.diagnostics.system-report.8.1.trunk.png
+++ b/tests/e2e/baseline/desktop_firefox/mwp-admin.diagnostics.system-report.8.1.trunk.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fc5449044ff124aacc8e7910765540b7e42ba1fcb421b6d2db2ec045998df082
-size 720661
+oid sha256:d0f0dd5fb3c62d453174b8a38582a8d86be5b75dbb541fcddfcd7db4cfb1ee0d
+size 712092

--- a/tests/e2e/baseline/desktop_firefox/mwp-admin.settings.tracking.8.1.trunk.png
+++ b/tests/e2e/baseline/desktop_firefox/mwp-admin.settings.tracking.8.1.trunk.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e67a05a2707995f838dc23b9157a3dc223483eb7ad94036c0d1338a49faf8aad
-size 323260
+oid sha256:e6f3d91e3c2150f15fcc8d5f73ab3add7075db17794fb8a79d5d9912cf86e240
+size 324107

--- a/tests/e2e/pageobjects/matomo-reporting/behaviour/transitions.page.ts
+++ b/tests/e2e/pageobjects/matomo-reporting/behaviour/transitions.page.ts
@@ -6,16 +6,18 @@
  *
  */
 
-import { $ } from '@wdio/globals';
+import { $, browser } from '@wdio/globals';
 import MatomoReportingPage from '../../matomo-reporting.page.js';
 
 class TransitionsPage extends MatomoReportingPage {
   async open() {
     const result = await super.open('General_Actions.Transitions_Transitions');
 
+    await browser.pause(500);
     await browser.waitUntil(
       async () => !(await $('#transitions_inline_loading').isDisplayed()),
     );
+    await browser.pause(500);
 
     return result;
   }

--- a/tests/e2e/pageobjects/tag-manager/container-tags.page.ts
+++ b/tests/e2e/pageobjects/tag-manager/container-tags.page.ts
@@ -24,6 +24,8 @@ class ContainerTagsPage extends TagManagerPage {
       $('td.lastUpdated').each((i, e) => $(e).html('REMOVED'));
     });
 
+    await browser.pause(1000);
+
     return result;
   }
 }


### PR DESCRIPTION
### Description:

Using these plugins with Matomo for WordPress 5 should no longer result in a critical error.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
