### PR TITLE
if cookies are disabled, ensure disableCookies is called before ecommerce tracking calls 

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -235,13 +235,13 @@ class WpMatomo {
 			&& ! $tracking_code->is_hidden_user() ) {
 			$tracker = new AjaxTracker( self::$settings );
 
-			$woocommerce = new Woocommerce( $tracker );
+			$woocommerce = new Woocommerce( $tracker, self::$settings );
 			$woocommerce->register_hooks();
 
-			$easy_digital_downloads = new EasyDigitalDownloads( $tracker );
+			$easy_digital_downloads = new EasyDigitalDownloads( $tracker, self::$settings );
 			$easy_digital_downloads->register_hooks();
 
-			$member_press = new MemberPress( $tracker );
+			$member_press = new MemberPress( $tracker, self::$settings );
 			$member_press->register_hooks();
 
 			do_action( 'matomo_ecommerce_init', $tracker );

--- a/classes/WpMatomo/AjaxTracker.php
+++ b/classes/WpMatomo/AjaxTracker.php
@@ -48,6 +48,8 @@ class AjaxTracker extends \MatomoTracker {
 		if ( ! $settings->get_global_option( 'disable_cookies' ) ) {
 			$cookie_domain = $settings->get_tracking_cookie_domain();
 			$this->enableCookies( $cookie_domain );
+		} else {
+			$this->disableCookieSupport();
 		}
 
 		if ( $this->loadVisitorIdCookie() ) {

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -86,7 +86,14 @@ class Base {
 			$this->ajax_tracker_calls[] = $params;
 		}
 
-		return sprintf( 'window._paq = window._paq || []; window._paq.push(%s);', wp_json_encode( $params ) );
+		$args = [];
+		if ( WpMatomo::$settings->get_global_option( 'disable_cookies' ) ) {
+			$args[] = wp_json_encode( [ 'disableCookies' ] );
+		}
+		$args[] = wp_json_encode( $params );
+		$args   = implode( ',', $args );
+
+		return sprintf( 'window._paq = window._paq || []; window._paq.push(%s);', $args );
 	}
 
 	protected function wrap_script( $script ) {

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -49,7 +49,7 @@ class Base {
 
 	private $ajax_tracker_calls = [];
 
-	public function __construct( AjaxTracker $tracker, Settings $settings = null ) {
+	public function __construct( AjaxTracker $tracker, Settings $settings ) {
 		$this->logger   = new Logger();
 		$this->tracker  = $tracker;
 		$this->settings = $settings;

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -42,11 +42,17 @@ class Base {
 	 */
 	protected $cart_update_queue = '';
 
+	/**
+	 * @var Settings
+	 */
+	protected $settings;
+
 	private $ajax_tracker_calls = [];
 
-	public function __construct( AjaxTracker $tracker ) {
-		$this->logger  = new Logger();
-		$this->tracker = $tracker;
+	public function __construct( AjaxTracker $tracker, Settings $settings = null ) {
+		$this->logger   = new Logger();
+		$this->tracker  = $tracker;
+		$this->settings = $settings;
 
 		// by using prefix we make sure it will be removed on unistall and make sure it's clear it belongs to us
 		$this->key_order_tracked = Settings::OPTION_PREFIX . $this->key_order_tracked;
@@ -78,7 +84,7 @@ class Base {
 	protected function should_track_background() {
 		return ( defined( 'DOING_AJAX' ) && DOING_AJAX )
 			   || ( defined( 'REST_REQUEST' ) && REST_REQUEST )
-			   || WpMatomo::$settings->get_global_option( 'track_mode' ) === TrackingSettings::TRACK_MODE_TAGMANAGER;
+			   || $this->settings->get_global_option( 'track_mode' ) === TrackingSettings::TRACK_MODE_TAGMANAGER;
 	}
 
 	protected function make_matomo_js_tracker_call( $params ) {
@@ -86,14 +92,13 @@ class Base {
 			$this->ajax_tracker_calls[] = $params;
 		}
 
-		$args = [];
-		if ( WpMatomo::$settings->get_global_option( 'disable_cookies' ) ) {
-			$args[] = wp_json_encode( [ 'disableCookies' ] );
+		$code = 'window._paq = window._paq || [];';
+		if ( $this->settings->get_global_option( 'disable_cookies' ) ) {
+			$code .= ' ' . WpMatomo\TrackingCode\TrackingCodeGenerator::get_disable_cookies_partial();
 		}
-		$args[] = wp_json_encode( $params );
-		$args   = implode( ',', $args );
+		$code .= sprintf( ' window._paq.push(%s);', wp_json_encode( $params ) );
 
-		return sprintf( 'window._paq = window._paq || []; window._paq.push(%s);', $args );
+		return $code;
 	}
 
 	protected function wrap_script( $script ) {

--- a/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
+++ b/classes/WpMatomo/TrackingCode/TrackingCodeGenerator.php
@@ -45,6 +45,16 @@ class TrackingCodeGenerator {
 		$this->logger   = new Logger();
 	}
 
+	public static function get_disable_cookies_partial() {
+		// if ecommerce tracking is enabled, disableCookies can be added to _paq multiple times
+		// (since ecommerce tracking methods can be called before the main tracking JS in some situations).
+		// piwik.js complains if the initial _paq array has more than one of the same method, so
+		// we only add it if it's not there to begin with.
+		return 'if (!window._paq.find || !window._paq.find(function (m) { return m[0] === "disableCookies"; })) {
+	window._paq.push(["disableCookies"]);
+}';
+	}
+
 	public function register_hooks() {
 		add_action( 'matomo_site_synced', [ $this, 'update_tracking_code' ], $prio = 10, $args = 0 );
 		add_action( 'matomo_tracking_settings_changed', [ $this, 'update_tracking_code' ], $prio = 10, $args = 0 );
@@ -238,7 +248,7 @@ g.type=\'text/javascript\'; g.async=true; g.src="' . $container_url . '"; s.pare
 			$options[] = "_paq.push(['setLinkClasses', " . wp_json_encode( $this->settings->get_global_option( 'set_link_classes' ) ) . ']);';
 		}
 		if ( $this->settings->get_global_option( 'disable_cookies' ) ) {
-			$options[] = "_paq.push(['disableCookies']);";
+			$options[] = self::get_disable_cookies_partial();
 		}
 		if ( $this->settings->get_global_option( 'track_crossdomain_linking' ) ) {
 			$options[] = "_paq.push(['enableCrossDomainLinking']);";

--- a/scripts/local-dev-entrypoint.sh
+++ b/scripts/local-dev-entrypoint.sh
@@ -262,6 +262,8 @@ fi
 if [ ! -d "/var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo-marketplace-for-wordpress" ]; then
   echo "installing matomo marketplace"
   /var/www/html/wp-cli.phar --allow-root --path=/var/www/html/$WORDPRESS_FOLDER plugin install --activate https://builds.matomo.org/matomo-marketplace-for-wordpress-latest.zip
+else
+  /var/www/html/wp-cli.phar --allow-root --path=/var/www/html/$WORDPRESS_FOLDER plugin activate matomo-marketplace-for-wordpress
 fi
 
 # other plugins used during tests

--- a/tests/phpunit/wpmatomo/ecommerce/test-base.php
+++ b/tests/phpunit/wpmatomo/ecommerce/test-base.php
@@ -22,7 +22,7 @@ class BaseTest extends MatomoAnalytics_TestCase {
 		/*
 		 * use a custom object which provide public methods of the Base class
 		 */
-		$this->base = new MatomoTestEcommerce( new AjaxTracker( $this->settings ) );
+		$this->base = new MatomoTestEcommerce( new AjaxTracker( $this->settings ), $this->settings );
 	}
 
 	public function test_wrap_script_on_set_ecommerce_view() {
@@ -51,6 +51,40 @@ class BaseTest extends MatomoAnalytics_TestCase {
 		$this->assertSame(
 			'<script ' . $this->get_type_attribute() . ">\n$cdata_start" .
 			'window._paq = window._paq || []; window._paq.push(["setEcommerceView","sku","product-title",[],50]);' . PHP_EOL .
+			"$cdata_end</script>" . PHP_EOL,
+			$this->base->wrap_script( $this->base->make_matomo_js_tracker_call( $params ) )
+		);
+	}
+
+	public function test_wrap_script_on_set_ecommerce_view_if_cookies_disabled() {
+		$this->settings->apply_tracking_related_changes(
+			array(
+				'track_mode'      => TrackingSettings::TRACK_MODE_DEFAULT,
+				'track_ecommerce' => true,
+				'disable_cookies' => true,
+			)
+		);
+
+		$params = array(
+			'setEcommerceView',
+			'sku',
+			'product-title',
+			array(),
+			50,
+		);
+
+		$cdata_start = "/* <![CDATA[ */\n";
+		$cdata_end   = "/* ]]> */\n";
+		if ( getenv( 'WORDPRESS_VERSION' ) && ( getenv( 'WORDPRESS_VERSION' ) !== 'latest' && version_compare( getenv( 'WORDPRESS_VERSION' ), '6.4', '<' ) ) ) {
+			$cdata_start = '';
+			$cdata_end   = '';
+		}
+
+		$this->assertSame(
+			'<script ' . $this->get_type_attribute() . ">\n$cdata_start" .
+			'window._paq = window._paq || []; if (!window._paq.find || !window._paq.find(function (m) { return m[0] === "disableCookies"; })) {
+	window._paq.push(["disableCookies"]);
+} window._paq.push(["setEcommerceView","sku","product-title",[],50]);' . PHP_EOL .
 			"$cdata_end</script>" . PHP_EOL,
 			$this->base->wrap_script( $this->base->make_matomo_js_tracker_call( $params ) )
 		);

--- a/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
+++ b/tests/phpunit/wpmatomo/trackingcode/test-trackingcodegenerator.php
@@ -93,7 +93,9 @@ g.type=\'text/javascript\'; g.async=true; g.src="\/\/example.org\/wp-content\/pl
 			'<!-- Matomo --><script ' . $this->get_type_attribute() . '>' . "\n$cdata_start" . 'var _paq = window._paq = window._paq || [];
 _paq.push([\'addDownloadExtensions\', "zip|waf"]);
 _paq.push([\'setLinkClasses\', "clickme|foo"]);
-_paq.push([\'disableCookies\']);
+if (!window._paq.find || !window._paq.find(function (m) { return m[0] === "disableCookies"; })) {
+	window._paq.push(["disableCookies"]);
+}
 _paq.push([\'enableCrossDomainLinking\']);
 _paq.push(["setCookieDomain", "*.example.org"]);
 _paq.push([\'trackAllContentImpressions\']);_paq.push([\'trackPageView\']);_paq.push([\'enableLinkTracking\']);_paq.push([\'alwaysUseSendBeacon\']);_paq.push([\'setTrackerUrl\', "\/\/example.org\/index.php?rest_route=\/matomo\/v1\/hit\/"]);_paq.push([\'setSiteId\', \'21\']);var d=document, g=d.createElement(\'script\'), s=d.getElementsByTagName(\'script\')[0];


### PR DESCRIPTION
### Description:

Fixes #1077 

Make sure `"disableCookies"` is called before ecommerce tracking functions, since in some setups, ecommerce tracking functions can be called before the main tracking code is executed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
