### PR TITLE
rewrite PHP CLI version check to check that it matches the web PHP version

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -268,4 +268,13 @@ class WpMatomo {
 			}
 		);
 	}
+
+	public static function is_async_archiving_manually_disabled() {
+		return ( defined( 'MATOMO_SUPPORT_ASYNC_ARCHIVING' ) && ! MATOMO_SUPPORT_ASYNC_ARCHIVING )
+			|| self::is_async_archiving_disabled_by_setting();
+	}
+
+	private static function is_async_archiving_disabled_by_setting() {
+		return self::$settings->is_async_archiving_disabled_by_option();
+	}
 }

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -401,7 +401,7 @@ class SystemReport {
 				}
 
 				$comment = sprintf(
-					esc_html__( 'The detected PHP cli version does not match the PHP web version. To avoid archiving errors, %1$senable archiving via HTTP requests%2$s, or %3$smanually set the path to your PHP CLI executable%4$s to the one for PHP version %5$s.', 'matomo' ),
+					esc_html__( 'The detected PHP CLI version does not match the PHP web version. To avoid archiving errors, %1$senable archiving via HTTP requests%2$s, or %3$smanually set the path to your PHP CLI executable%4$s to the one for PHP version %5$s.', 'matomo' ),
 					'<a href="' . $advanced_settings_url . '">',
 					'</a>',
 					'<a href="https://matomo.org/faq/how-to-solve-the-error-message-your-php-cli-version-is-not-compatible-with-the-matomo-requirements/" target="_blank" rel="noreferrer noopener">',
@@ -410,7 +410,7 @@ class SystemReport {
 				);
 			}
 			$rows[] = [
-				'name'       => esc_html__( 'PHP cli Version', 'matomo' ),
+				'name'       => esc_html__( 'PHP CLI Version', 'matomo' ),
 				'value'      => $phpcli_version,
 				'comment'    => $comment,
 				'is_warning' => $is_warning,

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -387,21 +387,29 @@ class SystemReport {
 
 		if ( $this->shell_exec_available ) {
 			$phpcli_version = $this->get_phpcli_output( '-r "echo phpversion();"' );
-            // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			global $piwik_minimumPHPVersion;
+
+			$is_warning = false;
+			$comment    = '';
+
+			$advanced_settings_url = home_url( '/wp-admin/admin.php?page=matomo-settings&tab=advanced#matomo[disable_async_archiving]' );
+
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			if ( version_compare( $phpcli_version, $piwik_minimumPHPVersion ) <= 0 ) {
-				$is_error = true;
-				$comment  = sprintf( esc_html__( 'Your PHP cli version is not compatible with the %s. Please upgrade your PHP cli version, otherwise, you might have some archiving errors', 'matomo' ), sprintf( '<a href="%s" target="_blank">%s</a>', 'https://matomo.org/faq/on-premise/matomo-requirements/', esc_html__( 'Matomo requirements', 'matomo' ) ) );
-			} else {
-				$is_error = false;
-				$comment  = '';
+			if ( version_compare( $phpcli_version, PHP_VERSION ) < 0 ) {
+				$is_warning = true;
+				$comment    = sprintf(
+					esc_html__( 'The detected PHP cli version does not match the PHP web version. To avoid archiving errors, %1$senable archiving via HTTP requests%2$s, or %3$smanually set the path to your PHP CLI executable%4$s to the one for PHP version %5$s.', 'matomo' ),
+					'<a href="' . $advanced_settings_url . '">',
+					'</a>',
+					'<a href="https://matomo.org/faq/how-to-solve-the-error-message-your-php-cli-version-is-not-compatible-with-the-matomo-requirements/" target="_blank" rel="noreferrer noopener">',
+					'</a>',
+					PHP_VERSION
+				);
 			}
 			$rows[] = [
-				'name'     => esc_html__( 'PHP cli Version', 'matomo' ),
-				'value'    => $phpcli_version,
-				'comment'  => $comment,
-				'is_error' => $is_error,
+				'name'       => esc_html__( 'PHP cli Version', 'matomo' ),
+				'value'      => $phpcli_version,
+				'comment'    => $comment,
+				'is_warning' => $is_warning,
 			];
 
 			$is_error = false;

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -24,6 +24,7 @@ use Piwik\Plugins\Diagnostics\Diagnostic\DiagnosticResult;
 use Piwik\Plugins\Diagnostics\DiagnosticService;
 use Piwik\Plugins\SitesManager\Model;
 use Piwik\Plugins\UserCountry\LocationProvider;
+use Piwik\Plugins\WordPress\WordPress;
 use Piwik\SettingsPiwik;
 use Piwik\Tracker\Failures;
 use Piwik\Version;
@@ -395,8 +396,11 @@ class SystemReport {
 
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 			if ( version_compare( $phpcli_version, PHP_VERSION ) < 0 ) {
-				$is_warning = true;
-				$comment    = sprintf(
+				if ( ! \WpMatomo::is_async_archiving_manually_disabled() ) {
+					$is_warning = true;
+				}
+
+				$comment = sprintf(
 					esc_html__( 'The detected PHP cli version does not match the PHP web version. To avoid archiving errors, %1$senable archiving via HTTP requests%2$s, or %3$smanually set the path to your PHP CLI executable%4$s to the one for PHP version %5$s.', 'matomo' ),
 					'<a href="' . $advanced_settings_url . '">',
 					'</a>',

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -23,6 +23,7 @@ use Piwik\Scheduler\Task;
 use Piwik\Url;
 use Piwik\Version;
 use Piwik\Widget\WidgetsList;
+use WpMatomo;
 use WpMatomo\Bootstrap;
 use WpMatomo\Settings;
 use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
@@ -202,8 +203,7 @@ class WordPress extends Plugin
         if (is_multisite()
             || !empty($_SERVER['MATOMO_WP_ROOT_PATH'])
             || !matomo_has_compatible_content_dir()
-            || (defined( 'MATOMO_SUPPORT_ASYNC_ARCHIVING') && !MATOMO_SUPPORT_ASYNC_ARCHIVING)
-            || $this->isAsyncArchivingDisabledBySetting()
+            || WpMatomo::is_async_archiving_manually_disabled()
         ) {
             // console wouldn't really work in multi site mode... therefore we prefer to archive in the same request
             // WP_DEBUG also breaks things since it's logging things to stdout and then safe unserialise doesn't work
@@ -211,12 +211,6 @@ class WordPress extends Plugin
             // but not on the CLI
             $supportsAsync = false;
         }
-    }
-
-    private function isAsyncArchivingDisabledBySetting()
-    {
-        $settings = \WpMatomo::$settings;
-        return $settings->is_async_archiving_disabled_by_option();
     }
 
     public function onHeader(&$out)

--- a/scripts/local-dev-entrypoint.sh
+++ b/scripts/local-dev-entrypoint.sh
@@ -323,7 +323,10 @@ if [[ "$WOOCOMMERCE" == "1" ]]; then
 
     # install oceanwp
     echo "installing oceanwp..."
-    /var/www/html/wp-cli.phar --path=/var/www/html/$WORDPRESS_FOLDER --allow-root theme install oceanwp --activate
+    if php -r 'exit(version_compare(PHP_VERSION, "7.3", "<") ? 0 : 1);'; then
+      OCEANWP_VERSION="--version=3.5.5"
+    fi
+    /var/www/html/wp-cli.phar --path=/var/www/html/$WORDPRESS_FOLDER --allow-root theme install oceanwp --activate $OCEANWP_VERSION
 
     # add 5 test products
     IMAGE_ID=$( /var/www/html/wp-cli.phar --path=/var/www/html/$WORDPRESS_FOLDER --allow-root --user=$WP_ADMIN_USER media import "/var/www/html/matomo-for-wordpress/tests/resources/products/ceiling_fan.jpg" | grep -o 'attachment ID [0-9][0-9]*' | awk '{print $3}' )
@@ -429,7 +432,7 @@ fi
 # make sure the files can be edited outside of docker (for easier debugging)
 # TODO: file permissions becoming a pain, shouldn't have to deal with this for dev env. this works for now though.
 touch /var/www/html/$WORDPRESS_FOLDER/debug.log /var/www/html/matomo.wpload_dir.php
-mkdir -p /var/www/html/$WORDPRESS_FOLDER/wp-content/uploads/matomo /var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo/app/tmp
+mkdir -p /var/www/html/$WORDPRESS_FOLDER/wp-content/uploads/matomo/tmp/cache/tracker /var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo/app/tmp
 chown -R "${FIlE_OWNER_USERID:-1000}:${GID:-1000}" /var/www/html/$WORDPRESS_FOLDER/wp-content/uploads
 find "/var/www/html/$WORDPRESS_FOLDER" -path "/var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo" -prune -o -exec chown "${FIlE_OWNER_USERID:-1000}:${GID:-1000}" {} +
 find "/var/www/html/$WORDPRESS_FOLDER" -path "/var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo" -prune -o -exec chmod 0777 {} +

--- a/tests/e2e/pageobjects/tag-manager/container-tags.page.ts
+++ b/tests/e2e/pageobjects/tag-manager/container-tags.page.ts
@@ -26,7 +26,7 @@ class ContainerTagsPage extends TagManagerPage {
       $('td.lastUpdated').each((i, e) => $(e).html('REMOVED'));
     });
 
-    await browser.pause(1000);
+    await browser.pause(2000);
 
     return result;
   }

--- a/tests/e2e/pageobjects/tag-manager/container-triggers.page.ts
+++ b/tests/e2e/pageobjects/tag-manager/container-triggers.page.ts
@@ -24,7 +24,7 @@ class ContainerTriggersPage extends TagManagerPage {
       $('td.lastUpdated').each((i, e) => $(e).html('REMOVED'));
     });
 
-    await browser.pause(1000);
+    await browser.pause(2000);
 
     return result;
   }

--- a/tests/phpunit/wpmatomo/wpstatistics/test-import.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/test-import.php
@@ -197,7 +197,7 @@ class ImportTest extends MatomoAnalytics_TestCase {
 			return;
 		}
 
-		$possible_values = [ 156, 81, 77 ];
+		$possible_values = [ 156, 81, 77, 91 ];
 
 		$report = $this->fetch_report( 'Actions', 'getPageUrls' );
 		$this->assertContains( $report['reportData']->getRowsCount(), $possible_values );


### PR DESCRIPTION
### Description:

Fixes #1098 
Fixes #875 

Changes:
* Instead of checking that the PHP CLI version is greater than the minimum PHP version supported by Matomo, check that it matches the web PHP version. (It is possible for the incorrect PHP executable to be above the minimum supported PHP version, and still cause problems, since MWP will end up loading other WordPress plugins.)
* Do not report this as an error, but a warning, as it's not always a problem, and we don't want spurious support requests.
* Add a link to the 'Enable archiving via HTTP requests' setting for quick fixes.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
