### PR TITLE
log an exception during user sync if a user's email already exists in Matomo

### DIFF
--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -326,6 +326,17 @@ class Sync {
 			// note: it's also possible there are multiple users with the same email address,
 			// but this is currently unsupported in matomo so we don't take that into consideration.
 			if ( $user_by_email ) {
+				$this->logger->log_exception(
+					'user_sync',
+					new \Exception(
+						'Syncing user with email identical to a user already synced in Matomo. ' .
+						'This means there are multiple WP users with the same email, which Matomo ' .
+						'does not support, or something has deleted the WP option mapping WP user ' .
+						'to Matomo user. Assuming this is a new user to sync and deleting existing user ' .
+						'preferences and options.'
+					)
+				);
+
 				$user_model->deleteUser( $user_by_email['login'] );
 			}
 


### PR DESCRIPTION
### Description:

To help catch some edge cases.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
