### PR TITLE
handle null values specially in Wordpress::update()

### DIFF
--- a/classes/WpMatomo/Db/WordPress.php
+++ b/classes/WpMatomo/Db/WordPress.php
@@ -479,8 +479,13 @@ class WordPress extends Mysqli {
 		}
 		$fields = implode( ', ', $fields );
 
-		$sql      = "UPDATE `$table` SET $fields " . ( ( $where ) ? " WHERE $where" : '' );
-		$prepared = $wpdb->prepare( $sql, $bind );
+		$sql = "UPDATE `$table` SET $fields " . ( ( $where ) ? " WHERE $where" : '' );
+
+		if ( empty( $bind ) ) {
+			$prepared = $sql;
+		} else {
+			$prepared = $wpdb->prepare( $sql, $bind );
+		}
 
 		$this->before_execute_query( $wpdb, '' );
 

--- a/classes/WpMatomo/Db/WordPress.php
+++ b/classes/WpMatomo/Db/WordPress.php
@@ -468,7 +468,14 @@ class WordPress extends Mysqli {
 
 		$fields = array();
 		foreach ( $bind as $field => $val ) {
-			$fields[] = "`$field` = %s";
+			// wpdb's prepare doesn't seem to handle null values correctly. they are set to `''`
+			// in some cases, so we handle this explicitly here.
+			if ($val === null) {
+				unset($bind[$field]);
+				$fields[] = "`$field` = NULL";
+			} else {
+				$fields[] = "`$field` = %s";
+			}
 		}
 		$fields = implode( ', ', $fields );
 

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -190,7 +190,7 @@ class Sync {
 
 			$site = $sites_manager_model->getSiteFromId( $idsite );
 			if ( ! empty( $site ) ) {
-				// if site doesn't exist for some reason then we have to create it
+				// if site has changed then we have to update it
 				if ( $site['name'] !== $blog_name
 					 || $site['main_url'] !== $blog_url
 				     // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison

--- a/tests/phpunit/wpmatomo/db/test-wordpress.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpress.php
@@ -213,6 +213,64 @@ class DbWordPressTest extends MatomoAnalytics_TestCase {
 		$this->assertEquals( 3, $result );
 	}
 
+	public function test_update_sets_null_values_correctly() {
+		$table = Common::prefixTable( 'logger_message' );
+
+		$this->db->exec( "INSERT INTO $table (tag, timestamp, level, message) VALUES ('tag', CURRENT_TIMESTAMP, 'level', 'message')" );
+
+		$row = $this->db->fetchRow( "SELECT * FROM $table" );
+		$this->assertNotNull( $row['tag'] );
+		$this->assertNotNull( $row['timestamp'] );
+		$this->assertNotNull( $row['level'] );
+		$this->assertNotNull( $row['message'] );
+
+		$this->db->update(
+			$table,
+			[
+				'tag'       => null,
+				'timestamp' => null,
+				'level'     => 'alevel',
+				'message'   => null,
+			],
+			'idlogger_message = ' . (int) $row['idlogger_message']
+		);
+
+		$row = $this->db->fetchRow( "SELECT * FROM $table WHERE idlogger_message = " . (int) $row['idlogger_message'] );
+		$this->assertNull( $row['tag'] );
+		$this->assertNull( $row['timestamp'] );
+		$this->assertEquals( 'alevel', $row['level'] );
+		$this->assertNull( $row['message'] );
+	}
+
+	public function test_update_sets_null_values_correctly_when_all_params_are_null() {
+		$table = Common::prefixTable( 'logger_message' );
+
+		$this->db->exec( "INSERT INTO $table (tag, timestamp, level, message) VALUES ('tag', CURRENT_TIMESTAMP, 'level', 'message')" );
+
+		$row = $this->db->fetchRow( "SELECT * FROM $table" );
+		$this->assertNotNull( $row['tag'] );
+		$this->assertNotNull( $row['timestamp'] );
+		$this->assertNotNull( $row['level'] );
+		$this->assertNotNull( $row['message'] );
+
+		$this->db->update(
+			$table,
+			[
+				'tag'       => null,
+				'timestamp' => null,
+				'level'     => null,
+				'message'   => null,
+			],
+			'idlogger_message = ' . (int) $row['idlogger_message']
+		);
+
+		$row = $this->db->fetchRow( "SELECT * FROM $table WHERE idlogger_message = " . (int) $row['idlogger_message'] );
+		$this->assertNull( $row['tag'] );
+		$this->assertNull( $row['timestamp'] );
+		$this->assertNull( $row['level'] );
+		$this->assertNull( $row['message'] );
+	}
+
 	private function insert_many_values() {
 		$this->insert_access( 'foo', 'view' );
 		$this->insert_access( 'bar', 'write' );


### PR DESCRIPTION
### Description:

The use of `wpdb::prepare()` was resulting in at least one bug where updating a scheduled report with the "All Visits" segment would set the idsegment to `0` instead of `NULL`. (`null` bind values were converted to `''` instead of `NULL` in SQL)

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
