### PR TITLE
fix: change var notation of plugin_name

### DIFF
--- a/classes/WpMatomo/Admin/AdminSettings.php
+++ b/classes/WpMatomo/Admin/AdminSettings.php
@@ -137,7 +137,7 @@ class AdminSettings {
 				$plugin_display_name = $all_wordpress_plugins[ $plugin_name ]['Name'];
 				$plugin_display_name = preg_replace( '/\s+\(Matomo Plugin\)\s*/', '', $plugin_display_name );
 
-				$tabs[ "plugin-${plugin_name}" ] = [
+				$tabs[ "plugin-{$plugin_name}" ] = [
 					'plugin_name'         => $plugin_name,
 					'plugin_display_name' => $plugin_display_name,
 				];


### PR DESCRIPTION
### Description:
I have changed the deprecated notation `"plugin-${plugin_name}"` to `"plugin-{$plugin_name}"`.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
