### PR TITLE
only show system report users to matomo superusers

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -264,12 +264,12 @@ class SystemReport {
 
 	public function errors_present() {
 		$cache_key   = 'matomo_system_report_has_errors';
-		$cache_value = get_transient( $cache_key );
+		$cache_value = get_site_transient( $cache_key );
 
 		if ( false === $cache_value ) {
 			// pre-record that there were no errors found. in case the system report fails to execute, this will
 			// allow the rest of Matomo for WordPress to continue to still be usable.
-			set_transient( $cache_key, 0, WEEK_IN_SECONDS );
+			set_site_transient( $cache_key, 0, WEEK_IN_SECONDS );
 
 			$matomo_tables = $this->get_error_tables();
 
@@ -284,7 +284,7 @@ class SystemReport {
 				}
 			}
 
-			set_transient( $cache_key, (int) $cache_value, WEEK_IN_SECONDS );
+			set_site_transient( $cache_key, (int) $cache_value, WEEK_IN_SECONDS );
 		}
 
 		return 1 === (int) $cache_value;

--- a/classes/WpMatomo/ErrorNotice.php
+++ b/classes/WpMatomo/ErrorNotice.php
@@ -28,7 +28,11 @@ class ErrorNotice {
 	}
 
 	public function check_errors() {
-		if ( isset( $_GET['page'] ) && substr( sanitize_text_field( wp_unslash( $_GET['page'] ) ), 0, 7 ) === 'matomo-' ) {
+		$is_matomo_super_user = current_user_can( Capabilities::KEY_SUPERUSER );
+		if ( isset( $_GET['page'] )
+			&& substr( sanitize_text_field( wp_unslash( $_GET['page'] ) ), 0, 7 ) === 'matomo-'
+			&& $is_matomo_super_user
+		) {
 			$system_report = new \WpMatomo\Admin\SystemReport( $this->settings );
 			if ( ! get_user_meta( get_current_user_id(), self::OPTION_NAME_SYSTEM_REPORT_ERRORS_DISMISSED ) && $system_report->errors_present() ) {
 				echo '<div class="notice notice-warning is-dismissible" id="matomo-systemreporterrors"><p>'

--- a/classes/WpMatomo/ScheduledTasks.php
+++ b/classes/WpMatomo/ScheduledTasks.php
@@ -221,7 +221,6 @@ class ScheduledTasks {
 		return true;
 	}
 
-	// TODO: more logging
 	public function update_geo_ip2_db() {
 		$this->remove_task_errors( [ 'update_geoip2' ] );
 

--- a/classes/WpMatomo/ScheduledTasks.php
+++ b/classes/WpMatomo/ScheduledTasks.php
@@ -221,6 +221,7 @@ class ScheduledTasks {
 		return true;
 	}
 
+	// TODO: more logging
 	public function update_geo_ip2_db() {
 		$this->remove_task_errors( [ 'update_geoip2' ] );
 


### PR DESCRIPTION
### Description:

As title.

Also use a site transient instead of a transient to store whether there were errors detected or not.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
