### PR TITLE
allow re-running updates from a specific version in troubleshooting page

### DIFF
--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -197,9 +197,28 @@ class SystemReport {
 					$sync->sync_current_site();
 				}
 				if ( ! empty( $_POST[ self::TROUBLESHOOT_RUN_UPDATER ] ) ) {
-					Updater::unlock();
-					$sync = new Updater( $this->settings );
-					$sync->update();
+					$update_from_version = ! empty( $_POST['matomo_troubleshooting_update_from'] )
+						? sanitize_text_field( wp_unslash( $_POST['matomo_troubleshooting_update_from'] ) )
+						: null;
+					$update_from_version = trim( $update_from_version );
+
+					if ( ! empty( $update_from_version )
+						&& ! preg_match( '/^\d+(?:.\d+)*$/', $update_from_version )
+					) {
+						echo '<div class="error"><p>' . esc_html__( 'Matomo Update Error', 'matomo' )
+							. ': unrecognized version string "' . esc_html( $update_from_version )
+							. '", ignoring.</p></div>';
+
+						$update_from_version = '';
+					}
+
+					try {
+						Updater::unlock();
+						$sync = new Updater( $this->settings );
+						$sync->update( $update_from_version );
+					} catch ( \Exception $e ) {
+						echo '<div class="error"><p>' . esc_html__( 'Matomo Update Error', 'matomo' ) . ': ' . esc_html( matomo_anonymize_value( $e->getMessage() . ' =>' . $this->logger->get_readable_trace( $e ) ) ) . '</p></div>';
+					}
 				}
 			}
 			if ( $this->settings->is_network_enabled() ) {

--- a/classes/WpMatomo/Admin/views/systemreport.php
+++ b/classes/WpMatomo/Admin/views/systemreport.php
@@ -216,6 +216,13 @@ if ( ! function_exists( 'matomo_format_value_text' ) ) {
 					   class='button-primary'
 					   title="<?php esc_attr_e( 'Force trigger a Matomo update in case it failed error', 'matomo' ); ?>"
 					   value="<?php esc_html_e( 'Run Updater', 'matomo' ); ?>">
+				<label for="matomo_troubleshooting_update_from">Run updates from version:</label>
+				<input id="matomo_troubleshooting_update_from"
+					   type="text"
+					   name="matomo_troubleshooting_update_from"
+					   title="<?php esc_attr_e( 'Enter a version to re-run updates from, eg, "5.0.0".', 'matomo' ); ?>"
+					   value="">
+				<br/><br/>
 			<?php } ?>
 			<?php if ( $settings->is_network_enabled() ) { ?>
 				<input name="<?php echo esc_attr( SystemReport::TROUBLESHOOT_SYNC_ALL_USERS ); ?>" type="submit"

--- a/tests/e2e/baseline/desktop_firefox/mwp-admin.diagnostics.troubleshooting.png
+++ b/tests/e2e/baseline/desktop_firefox/mwp-admin.diagnostics.troubleshooting.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75c410c5b143026a5f1f4e7476b2a015ff2edbbf820c20139ed5f9223154a47c
-size 206387
+oid sha256:94144ee9c93211e7e5ef441541fd8be10ef6f168a2467cddc8001e8b53c255e5
+size 209405

--- a/tests/e2e/baseline/desktop_firefox/mwp-admin.diagnostics.troubleshooting.trunk.png
+++ b/tests/e2e/baseline/desktop_firefox/mwp-admin.diagnostics.troubleshooting.trunk.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7bf94ede14896ee2de9d707005ab6ee1b0ef159b13c7b5e921430720b9d8e5c
-size 216722
+oid sha256:425143e5bf6ae8fe670cc8af110e340ac641e50bd628c9764291ef6ac1c412e3
+size 219884


### PR DESCRIPTION
### Description:

Users can enter a version to re-run updates from, in case of a failed update.

Also added a catch for updater exceptions so they will be reported as a notice and not simply propagated into a critical error.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
