### PR TITLE
allow bash-ing into the wordpress container in the local dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Enter `pass` for the password.
 
 (For mysql, replace instances of "mariadb" in the command with "mysql".)
 
+**Starting a shell in the container**
+
+```bash
+npm run compose -- run wordpress bash
+```
+
 #### Updating the Matomo core version
 
 Matomo for WordPress embeds the self-hosted Matomo in the `app/` subdirectory. To update the version that is used,

--- a/scripts/local-dev-entrypoint.sh
+++ b/scripts/local-dev-entrypoint.sh
@@ -29,6 +29,11 @@ echo
 
 echo "<?php # /var/www/html/$WORDPRESS_FOLDER/wp-load.php" > /var/www/html/matomo.wpload_dir.php || true
 
+if [[ "$1" = "bash" ]]; then
+  "$@"
+  exit $?
+fi
+
 if [[ "$EXECUTE_WP_CLI" = "1" ]]; then
   /var/www/html/wp-cli.phar --path=/var/www/html/$WORDPRESS_FOLDER "$@"
   exit $?


### PR DESCRIPTION
### Description:

As title.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
