### PR TITLE
in a multisite WP install, only run geoipdb update when the cron for the main site is run

### DIFF
--- a/classes/WpMatomo/ScheduledTasks.php
+++ b/classes/WpMatomo/ScheduledTasks.php
@@ -228,6 +228,10 @@ class ScheduledTasks {
 	}
 
 	public function update_geo_ip2_db() {
+		if ( is_multisite() && ! is_main_site() ) {
+			return; // only run this task once per entire WP install
+		}
+
 		$this->remove_task_errors( [ 'update_geoip2' ] );
 
 		$this->logger->log( 'Scheduled tasks update geoip database' );

--- a/tests/phpunit/wpmatomo/test-scheduled-tasks.php
+++ b/tests/phpunit/wpmatomo/test-scheduled-tasks.php
@@ -32,8 +32,12 @@ class ScheduledTasksTest extends MatomoAnalytics_TestCase {
 	 */
 	private $settings;
 
+	public $geoip_update_call_count = 0;
+
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->geoip_update_call_count = 0;
 
 		$this->settings = new Settings();
 		$this->tasks    = new ScheduledTasks( $this->settings );
@@ -119,7 +123,7 @@ class ScheduledTasksTest extends MatomoAnalytics_TestCase {
 	}
 
 	/**
-	 * @provideContainerConfig getContainerConfigForGeoIpFail
+	 * @provideContainerConfig get_container_config_for_geoip_fail
 	 */
 	public function test_geoip_update_reschedules_to_tomorrow_on_failure() {
 		// remove event scheduled during install
@@ -147,7 +151,7 @@ class ScheduledTasksTest extends MatomoAnalytics_TestCase {
 	}
 
 	/**
-	 * @provideContainerConfig getContainerConfigForGeoIpFail
+	 * @provideContainerConfig get_container_config_for_geoip_fail
 	 */
 	public function test_geoip_update_does_not_reschedule_if_already_scheduled_within_two_days() {
 		// remove event scheduled during install
@@ -172,13 +176,58 @@ class ScheduledTasksTest extends MatomoAnalytics_TestCase {
 		$this->assertEquals( [ 'update_geoip2' ], array_keys( $task_failures ) );
 	}
 
-	public function getContainerConfigForGeoIpFail() {
+	/**
+	 * @provideContainerConfig get_container_config_for_geoip_no_op
+	 */
+	public function test_geoip_only_runs_on_multisite_if_site_is_not_main_site() {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		$main_site = get_current_blog_id();
+		$this->assertNotEmpty( $main_site );
+
+		$this->tasks->update_geo_ip2_db();
+		$this->assertEquals( 1, $this->geoip_update_call_count );
+
+		$blogid1 = self::factory()->blog->create();
+		switch_to_blog( $blogid1 );
+
+		$this->tasks->update_geo_ip2_db();
+		$this->assertEquals( 1, $this->geoip_update_call_count );
+
+		switch_to_blog( $main_site );
+
+		$this->tasks->update_geo_ip2_db();
+		$this->assertEquals( 2, $this->geoip_update_call_count );
+	}
+
+	public function get_container_config_for_geoip_fail() {
 		return [
 			\Piwik\Plugins\GeoIp2\GeoIP2AutoUpdater::class => function () {
 				// phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
 				return new class extends \Piwik\Plugins\GeoIp2\GeoIP2AutoUpdater {
 					public function update() {
 						throw new \Exception( 'forced error' );
+					}
+				};
+			},
+		];
+	}
+
+	public function get_container_config_for_geoip_no_op() {
+		return [
+			\Piwik\Plugins\GeoIp2\GeoIP2AutoUpdater::class => function () {
+				// phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
+				return new class($this) extends \Piwik\Plugins\GeoIp2\GeoIP2AutoUpdater {
+					private $test;
+
+					public function __construct( ScheduledTasksTest $test ) {
+						$this->test = $test;
+					}
+
+					public function update() {
+						$this->test->geoip_update_call_count += 1;
 					}
 				};
 			},


### PR DESCRIPTION
### Description:

As title.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
