### PR TITLE
allow users to override charset/collation used for Matomo tables via two new consts

### DIFF
--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -353,8 +353,15 @@ class Installer {
 			}
 		}
 
-		$charset   = $wpdb->charset ? $wpdb->charset : 'utf8';
+		$charset = $wpdb->charset ? $wpdb->charset : 'utf8';
+		if ( defined( 'MATOMO_DB_CHARSET' ) && MATOMO_DB_CHARSET ) {
+			$charset = MATOMO_DB_CHARSET;
+		}
+
 		$collation = $wpdb->collate ? $wpdb->collate : 'utf8mb4_general_ci';
+		if ( defined( 'MATOMO_DB_COLLATE' ) && MATOMO_DB_COLLATE ) {
+			$collation = MATOMO_DB_COLLATE;
+		}
 
 		$database = [
 			'host'          => $host,

--- a/matomo.php
+++ b/matomo.php
@@ -7,7 +7,7 @@
  * Version: 5.1.5
  * Domain Path: /languages
  * WC requires at least: 2.4.0
- * WC tested up to: 9.3.3
+ * WC tested up to: 9.4.1
  *
  * Matomo - free/libre analytics platform
  *

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: matomoteam
 Tags: matomo,analytics,statistics,stats,ecommerce
 Requires at least: 4.8
-Tested up to: 6.6.2
+Tested up to: 6.7.0
 Stable tag: 5.1.5
 Requires PHP: 7.2.5
 License: GPLv3 or later

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -3,7 +3,7 @@
  * @package matomo
  */
 
-use \WpMatomo\Capabilities;
+require_once __DIR__ . '/fixture/test-wordpress-fixture.php';
 
 /**
  * phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery

--- a/tests/phpunit/framework/test-matomo-test-case.php
+++ b/tests/phpunit/framework/test-matomo-test-case.php
@@ -27,6 +27,8 @@ use WpMatomo\Settings;
 use WpMatomo\Uninstaller;
 use WpMatomo\User;
 
+require_once __DIR__ . '/fixture/test-matomo-fixture.php';
+
 /**
  * Piwik constants
  * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals

--- a/tests/phpunit/wpmatomo/test-install.php
+++ b/tests/phpunit/wpmatomo/test-install.php
@@ -161,4 +161,24 @@ class InstallTest extends MatomoAnalytics_TestCase {
 		$this->assertCount( 1, $all_sites );
 	}
 
+	/**
+	 * @preserveGlobalState disabled
+	 * @runInSeparateProcess
+	 */
+	public function test_get_db_infos_respects_charset_overrides() {
+		global $wpdb;
+
+		$db_config = Installer::get_db_infos();
+
+		$this->assertEquals( $wpdb->charset ? $wpdb->charset : 'utf8', $db_config['charset'] );
+		$this->assertEquals( $wpdb->collate ? $wpdb->collate : 'utf8mb4_general_ci', $db_config['collation'] );
+
+		define( 'MATOMO_DB_CHARSET', 'dummycharset' );
+		define( 'MATOMO_DB_COLLATE', 'dummycollate' );
+
+		$db_config = Installer::get_db_infos();
+
+		$this->assertEquals( 'dummycharset', $db_config['charset'] );
+		$this->assertEquals( 'dummycollate', $db_config['collation'] );
+	}
 }

--- a/tests/phpunit/wpmatomo/test-release.php
+++ b/tests/phpunit/wpmatomo/test-release.php
@@ -273,7 +273,7 @@ class ReleaseTest extends MatomoAnalytics_TestCase {
 
 		$tested_up_to_version = $matches[1];
 
-		$this->assertTrue( version_compare( $latest_version, $tested_up_to_version, '==' ) );
+		$this->assertTrue( $this->compare_version( $latest_version, $tested_up_to_version ), "Tested up to version ($tested_up_to_version) does not match ($latest_version)." );
 	}
 
 	public function test_woocommerce_tested_up_to_is_latest() {
@@ -294,7 +294,7 @@ class ReleaseTest extends MatomoAnalytics_TestCase {
 
 		$tested_up_to_version = $matches[1];
 
-		$this->assertTrue( version_compare( $latest_version, $tested_up_to_version, '==' ) );
+		$this->assertTrue( $this->compare_version( $latest_version, $tested_up_to_version ), "Tested up to version ($tested_up_to_version) does not match latest version ($latest_version)." );
 	}
 
 	private function get_zip_file_contents( $path_to_zip ) {
@@ -328,5 +328,12 @@ class ReleaseTest extends MatomoAnalytics_TestCase {
 		exec( $command, $output, $return_code );
 		$output = implode( '\n', $output );
 		return [ $return_code, $output ];
+	}
+
+	private function compare_version( $latest_version, $tested_up_to_version ) {
+		$latest_version       = rtrim( $latest_version, '.0' );
+		$tested_up_to_version = rtrim( $tested_up_to_version, '.0' );
+
+		return version_compare( $latest_version, $tested_up_to_version, '==' );
 	}
 }

--- a/tests/phpunit/wpmatomo/test-release.php
+++ b/tests/phpunit/wpmatomo/test-release.php
@@ -273,7 +273,7 @@ class ReleaseTest extends MatomoAnalytics_TestCase {
 
 		$tested_up_to_version = $matches[1];
 
-		$this->assertEquals( $latest_version, $tested_up_to_version );
+		$this->assertTrue( version_compare( $latest_version, $tested_up_to_version, '==' ) );
 	}
 
 	public function test_woocommerce_tested_up_to_is_latest() {
@@ -294,7 +294,7 @@ class ReleaseTest extends MatomoAnalytics_TestCase {
 
 		$tested_up_to_version = $matches[1];
 
-		$this->assertEquals( $latest_version, $tested_up_to_version );
+		$this->assertTrue( version_compare( $latest_version, $tested_up_to_version, '==' ) );
 	}
 
 	private function get_zip_file_contents( $path_to_zip ) {


### PR DESCRIPTION
### Description:

See https://wordpress.org/support/topic/error-creating-archive-table/ for the use case.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
