### PR TITLE
fix General_Confirm shown in some cases when showing the password confirmation modal

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@
 .github export-ignore
 .gitignore export-ignore
 .gitattributes export-ignore
+.gitmodules export-ignore
 .travis.yml export-ignore
 package-lock.json export-ignore
 bower.json export-ignore
@@ -47,6 +48,7 @@ docker-compose.yml export-ignore
 tsconfig.json export-ignore
 tsconfig.spec.json export-ignore
 wdio.conf.ts export-ignore
+wdio.conf.tracking.ts export-ignore
 vue.config.js export-ignore
 .env.default export-ignore
 .env export-ignore

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -136,6 +136,7 @@ class WordPress extends Plugin
         $translationKeys[] = 'WordPress_Example';
         $translationKeys[] = 'WordPress_SaveChanges';
         $translationKeys[] = 'WordPress_NoMeasurableSettingsAvailable';
+        $translationKeys[] = 'General_Confirm'; // this is not loaded client side by default for some reason
 	}
 
     public function modifyTourChallenges(&$challenges)


### PR DESCRIPTION
### Description:

As title.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
