### PR TITLE
keep manifest.json file in CoreHome/javascripts folder in the generated archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -165,7 +165,7 @@ jest.config.js export-ignore
 /app/plugins/Tour/javascripts export-ignore
 /app/plugins/ExamplePlugin/javascripts export-ignore
 /app/plugins/Transitions/javascripts export-ignore
-/app/plugins/CoreHome/javascripts export-ignore
+/app/plugins/CoreHome/javascripts/*.js export-ignore
 /app/plugins/CoreHome/angularjs export-ignore
 /app/plugins/Insights/javascripts export-ignore
 /app/plugins/PagePerformance/javascripts export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -271,13 +271,13 @@ jobs:
           RELEASE_ZIP: ${{ github.workspace }}/matomo.zip
           TEST_SHOP_LICENSE: ${{ secrets.TEST_SHOP_LICENSE }}
       - name: Archive test artifacts (actual)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: actual-screenshots-${{ matrix.php-versions }}-${{ matrix.wp-versions }}
           path: tests/e2e/actual
       - name: Archive test artifacts (diffs)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: diff-screenshots-${{ matrix.php-versions }}-${{ matrix.wp-versions }}


### PR DESCRIPTION
### Description:

It can be requested via a `<link>` in matomo HTML, so keep it.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
