### PR TITLE
try to set zlib.output_compression to avoid showing the technical error to users

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -60,6 +60,7 @@
 		<exclude name="PHPCompatibility.Classes.NewAnonymousClasses.Found"/>
 		<exclude name="PHPCompatibility.InitialValue.NewConstantScalarExpressions.constFound"/>
 		<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch"/>
+		<exclude name="WordPress.PHP.IniSet.Risky"/>
 	</rule>
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -1,5 +1,11 @@
 <?php
 
+// if we're loading Matomo directly, rather than bootstrapping from within WordPress,
+// try to set some INI config values Matomo needs
+if ( ! defined( 'ABSPATH' ) ) {
+	@ini_set( 'zlib.output_compression', false );
+}
+
 // see plugins/WordPress/WordPress.php for more info
 $GLOBALS['MATOMO_WP_ORIGINAL_ERROR_REPORTING'] = error_reporting();
 

--- a/classes/WpMatomo/Admin/SystemReport.php
+++ b/classes/WpMatomo/Admin/SystemReport.php
@@ -1452,6 +1452,9 @@ class SystemReport {
 			'comment' => ! empty( $disabled_functions ) ? $disabled_functions : '',
 		];
 
+		// try to set it before checking, since we try to set it in /app/bootstrap.php
+		@ini_set( 'zlib.output_compression', false );
+
 		$zlib_compression = ini_get( 'zlib.output_compression' );
 		$row              = [
 			'name'  => 'zlib.output_compression is off',


### PR DESCRIPTION
### Description:

Some hosting providers set this setting to 'On', but allow setting it at runtime. In this case, we can just turn it off for Matomo only, and avoid having to show an overly technical error to users right after they install the product.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
