### PR TITLE
make sure matomo base URL ends with '/' when executing scheduled tasks

### DIFF
--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -198,6 +198,7 @@ class Installer {
 
 		$matomo_url  = SettingsPiwik::getPiwikUrl();
 		$plugins_url = plugins_url( 'app', MATOMO_ANALYTICS_FILE );
+		$plugins_url = rtrim( $plugins_url, '/' ) . '/';
 		// need to make sure to update plugins url if it changes eg if installed somewhere else or domain changes
 
 		if ( $matomo_url

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - .:/var/www/html/matomo-for-wordpress
       - ./scripts/local-dev-entrypoint.sh:/usr/src/entrypoint.sh
       - ./docker/wp-cli:/.wp-cli
-      - ./docker/php-custom.ini:/usr/local/etc/php/conf.d/php-custom.ini
+      - ./scripts/local-php-custom.ini:/usr/local/etc/php/conf.d/php-custom.ini
       - ./scripts/local-gitconfig:/root/.gitconfig
     ports:
       - "$PORT:$PORT"
@@ -58,7 +58,7 @@ services:
       - .:/var/www/html/matomo-for-wordpress
       - ./scripts/local-dev-entrypoint.sh:/usr/src/entrypoint.sh
       - ./docker/wp-cli:/.wp-cli
-      - ./docker/php-custom.ini:/usr/local/etc/php/conf.d/php-custom.ini
+      - ./scripts/local-php-custom.ini:/usr/local/etc/php/conf.d/php-custom.ini
       - ./scripts/local-gitconfig:/.gitconfig
     entrypoint: /usr/src/entrypoint.sh
     depends_on:
@@ -95,7 +95,7 @@ services:
       - ./docker/wordpress:/var/www/html
       - .:/var/www/html/matomo-for-wordpress
       - ./docker/wp-cli:/.wp-cli
-      - ./docker/php-custom.ini:/usr/local/etc/php/conf.d/php-custom.ini
+      - ./scripts/local-php-custom.ini:/usr/local/etc/php/conf.d/php-custom.ini
       - ./scripts/local-dev-entrypoint.sh:/usr/src/entrypoint.sh
       - ./scripts/local-gitconfig:/.gitconfig
     ports:

--- a/matomo.php
+++ b/matomo.php
@@ -7,7 +7,7 @@
  * Version: 5.1.6
  * Domain Path: /languages
  * WC requires at least: 2.4.0
- * WC tested up to: 9.4.2
+ * WC tested up to: 9.4.3
  *
  * Matomo - free/libre analytics platform
  *

--- a/plugins/WordPress/Commands/DownloadTestScreenshots.php
+++ b/plugins/WordPress/Commands/DownloadTestScreenshots.php
@@ -59,28 +59,12 @@ class DownloadTestScreenshots extends ConsoleCommand
     private function downloadArtifacts($artifactId, $artifactUrl)
     {
         $outputPath = StaticContainer::get('path.tmp') . '/' . $artifactId . '.zip';
-        Http::sendHttpRequestBy(
-            Http::getTransportMethod(),
-            $artifactUrl,
-            60,
-            null,
-            $outputPath,
-            null,
-            0,
-            false,
-            false,
-            false,
-            false,
-            'GET',
-            null,
-            null,
-            null,
-            [
-                'Accept: application/vnd.github+json',
-                'Authorization: Bearer ' . $this->getGithubToken(),
-                'X-GitHub-Api-Version: 2022-11-28',
-            ]
-        );
+
+        // PHP curl cannot be used due to https://github.com/orgs/community/discussions/88698
+        $command = "curl -L '$artifactUrl' --header 'Accept: application/vnd.github+json' --header 'X-GitHub-Api-Version: 2022-11-28' "
+            . "--header 'Authorization: Bearer " . $this->getGithubToken() . "' --output '" . $outputPath . "'";
+        passthru($command);
+
         return $outputPath;
     }
 

--- a/scripts/local-dev-entrypoint.sh
+++ b/scripts/local-dev-entrypoint.sh
@@ -250,8 +250,15 @@ if [[ "$INSTALLING_FROM_ZIP" != "1" ]]; then
   fi
 else
   echo "installing latest stable matomo..."
-  rm "/var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo" || true
+
+  if [ -L "/var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo" ]; then
+    rm "/var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo" || true
+  else
+    rm -r "/var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo" || true
+  fi
+
   /var/www/html/wp-cli.phar --allow-root --path=/var/www/html/$WORDPRESS_FOLDER plugin install --activate "https://downloads.wordpress.org/plugin/matomo.latest-stable.zip"
+  chown -R "${FIlE_OWNER_USERID:-1000}:${GID:-1000}" /var/www/html/$WORDPRESS_FOLDER/wp-content/plugins/matomo
 fi
 
 if [[ "$MULTISITE" = "1" ]]; then

--- a/scripts/local-php-custom.ini
+++ b/scripts/local-php-custom.ini
@@ -1,0 +1,2 @@
+[PHP]
+memory_limit = 2048M

--- a/scripts/local-php-custom.ini
+++ b/scripts/local-php-custom.ini
@@ -1,2 +1,4 @@
 [PHP]
 memory_limit = 2048M
+post_max_size = 128M
+upload_max_filesize = 128M

--- a/tests/e2e/baseline/desktop_firefox/mwp-admin.summary.thismonth.7.2.png
+++ b/tests/e2e/baseline/desktop_firefox/mwp-admin.summary.thismonth.7.2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f5bf14b46c062b1e13be48ea429d19b66ba4a90f3c326643b8f16aa647a123f
-size 257001
+oid sha256:8c0e92b4a2c74af30058d4265d05bca177b3f1212b297c7baf83d5f21ae0aba0
+size 256953

--- a/tests/e2e/baseline/desktop_firefox/mwp-admin.summary.thismonth.7.2.trunk.png
+++ b/tests/e2e/baseline/desktop_firefox/mwp-admin.summary.thismonth.7.2.trunk.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:367576e44a55d8151a616eb23ba1f6b227d8e820f8a3aa6ceed85df2a79a1f30
-size 271061
+oid sha256:ad70ce168df0fec9d5e6bac6c241d21f310a04bccaff6d02a41efb79585bb773
+size 271053

--- a/tests/e2e/baseline/desktop_firefox/mwp-admin.summary.thismonth.8.1.png
+++ b/tests/e2e/baseline/desktop_firefox/mwp-admin.summary.thismonth.8.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:367576e44a55d8151a616eb23ba1f6b227d8e820f8a3aa6ceed85df2a79a1f30
-size 271061
+oid sha256:ad70ce168df0fec9d5e6bac6c241d21f310a04bccaff6d02a41efb79585bb773
+size 271053

--- a/tests/e2e/baseline/desktop_firefox/mwp-admin.summary.thismonth.8.1.trunk.png
+++ b/tests/e2e/baseline/desktop_firefox/mwp-admin.summary.thismonth.8.1.trunk.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:76b5ac9d7971a670e5b9a89a318cbf7d8502eba7872d693e90b00027324c7369
-size 271090
+oid sha256:ad70ce168df0fec9d5e6bac6c241d21f310a04bccaff6d02a41efb79585bb773
+size 271053

--- a/tests/e2e/update.e2e.ts
+++ b/tests/e2e/update.e2e.ts
@@ -47,10 +47,15 @@ describe('MWP Updating', () => {
     await $('#install-plugin-submit').waitForClickable();
     await $('#install-plugin-submit').click();
 
-    await $('.update-from-upload-overwrite').waitForDisplayed({ timeout: 30000 });
-    await browser.execute(() => {
-      window.jQuery('.update-from-upload-overwrite')[0].click();
-    });
+    try {
+        await $('.update-from-upload-overwrite').waitForDisplayed({ timeout: 30000 });
+
+        await browser.execute(() => {
+            window.jQuery('.update-from-upload-overwrite')[0].click();
+        });
+    } catch (e) {
+        // ignore
+    }
 
     await browser.waitUntil(async () => {
       return await browser.execute(() => {

--- a/tests/e2e/update.e2e.ts
+++ b/tests/e2e/update.e2e.ts
@@ -40,21 +40,27 @@ describe('MWP Updating', () => {
     await browser.url(`${await Website.baseUrl()}/wp-admin/plugin-install.php`);
     await $('a.upload-view-toggle').waitForDisplayed();
 
-    await $('a.upload-view-toggle').click();
+    await browser.execute(() => {
+      window.jQuery('a.upload-view-toggle')[0].click();
+    });
+    await browser.pause(250);
+
     await $('#pluginzip').setValue(pathToRelease);
     await browser.pause(250);
 
     await $('#install-plugin-submit').waitForClickable();
-    await $('#install-plugin-submit').click();
+    await browser.execute(() => {
+      window.jQuery('#install-plugin-submit')[0].click();
+    });
 
     try {
-        await $('.update-from-upload-overwrite').waitForDisplayed({ timeout: 30000 });
+      await $('.update-from-upload-overwrite').waitForExist();
 
-        await browser.execute(() => {
-            window.jQuery('.update-from-upload-overwrite')[0].click();
-        });
+      await browser.execute(() => {
+        window.jQuery('.update-from-upload-overwrite')[0].click();
+      });
     } catch (e) {
-        // ignore
+      // ignore
     }
 
     await browser.waitUntil(async () => {
@@ -64,6 +70,6 @@ describe('MWP Updating', () => {
           window.jQuery('p:contains(Plugin downgraded successfully.)').length > 0
         );
       });
-    }, { timeout: 60000 });
+    }, {timeout: 60000});
   });
 });

--- a/tests/e2e/update.e2e.ts
+++ b/tests/e2e/update.e2e.ts
@@ -47,7 +47,7 @@ describe('MWP Updating', () => {
     await $('#install-plugin-submit').waitForClickable();
     await $('#install-plugin-submit').click();
 
-    await $('.update-from-upload-overwrite').waitForDisplayed();
+    await $('.update-from-upload-overwrite').waitForDisplayed({ timeout: 30000 });
     await browser.execute(() => {
       window.jQuery('.update-from-upload-overwrite')[0].click();
     });


### PR DESCRIPTION
### Description:

Most of Matomo assumes it will include the ending '/', including scheduled reports, so it must be included for generated URLs to be correct.

Fixes #1217 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
