### PR TITLE
use same defaults for charset/collate as wordpress does

### DIFF
--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -31,6 +31,9 @@ class Installer {
 	const OPTION_NAME_INSTALL_DATE    = 'matomo-install-date';
 	const OPTION_NAME_INSTALL_VERSION = 'matomo-install-version';
 
+	const DEFAULT_DB_CHARSET = 'utf8';
+	const DEFAULT_DB_COLLATE = '';
+
 	/**
 	 * @var Settings
 	 */
@@ -354,12 +357,12 @@ class Installer {
 			}
 		}
 
-		$charset = $wpdb->charset ? $wpdb->charset : 'utf8';
+		$charset = $wpdb->charset ? $wpdb->charset : self::DEFAULT_DB_CHARSET;
 		if ( defined( 'MATOMO_DB_CHARSET' ) && MATOMO_DB_CHARSET ) {
 			$charset = MATOMO_DB_CHARSET;
 		}
 
-		$collation = $wpdb->collate ? $wpdb->collate : 'utf8mb4_general_ci';
+		$collation = $wpdb->collate ? $wpdb->collate : self::DEFAULT_DB_COLLATE;
 		if ( defined( 'MATOMO_DB_COLLATE' ) && MATOMO_DB_COLLATE ) {
 			$collation = MATOMO_DB_COLLATE;
 		}

--- a/tests/phpunit/wpmatomo/admin/test-systemreport.php
+++ b/tests/phpunit/wpmatomo/admin/test-systemreport.php
@@ -123,5 +123,4 @@ class AdminSystemReportTest extends MatomoAnalytics_TestCase {
 
 		$wpdb->query( "ALTER TABLE $new_table_name RENAME $old_table_name" );
 	}
-
 }


### PR DESCRIPTION
### Description:

As title.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
