### PR TITLE
recognize new mariadb specific queries in the custom WordPress database adapter

### DIFF
--- a/classes/WpMatomo/Db/WordPress.php
+++ b/classes/WpMatomo/Db/WordPress.php
@@ -279,7 +279,10 @@ class WordPress extends Mysqli {
 			$test_sql = trim( $test_sql );
 		}
 
-		if ( preg_match( '/^\s*(select)\s/i', $test_sql ) ) {
+		if (
+			preg_match( '/^\s*(select)\s/i', $test_sql )
+			|| preg_match( '/\sfor select\s/i', $test_sql )
+		) {
 			// WordPress does not fetch any result when doing a query w/ a select... it's only supposed to be used for things like
 			// insert / update / drop ...
 			$result = $this->fetchAll( $sql, $bind );

--- a/tests/phpunit/wpmatomo/db/test-wordpress.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpress.php
@@ -271,6 +271,10 @@ class DbWordPressTest extends MatomoAnalytics_TestCase {
 		$this->assertNull( $row['message'] );
 	}
 
+	public function test_query_recognizes_mariadb_set_for_queries() {
+		throw new \Exception( 'unimplemented' );
+	}
+
 	private function insert_many_values() {
 		$this->insert_access( 'foo', 'view' );
 		$this->insert_access( 'bar', 'write' );

--- a/tests/phpunit/wpmatomo/db/test-wordpress.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpress.php
@@ -272,7 +272,26 @@ class DbWordPressTest extends MatomoAnalytics_TestCase {
 	}
 
 	public function test_query_recognizes_mariadb_set_for_queries() {
-		throw new \Exception( 'unimplemented' );
+		\Piwik\Config::getInstance()->database['schema'] = 'Mariadb';
+		\Piwik\Db\Schema::unsetInstance();
+
+		$params         = new \Piwik\ArchiveProcessor\Parameters(
+			new \Piwik\Site( 1 ),
+			\Piwik\Period\Factory::build( 'day', 'today' ),
+			new \Piwik\Segment( '', [ 1 ] )
+		);
+		$log_aggregator = new \Piwik\DataAccess\LogAggregator( $params );
+
+		$sql = $log_aggregator->getQueryByDimensionSql( [], false, [], false, false, false, 120, false );
+
+		// make sure SQL we're testing has MariaDB specific SQL
+		$this->assertStringContainsString( 'SET STATEMENT max_statement_time', $sql['sql'] );
+
+		// test that the query works in MWP
+		$statement = $log_aggregator->queryVisitsByDimension( [], false, [], false, false, false, 120, false );
+		$row       = $statement->fetch();
+
+		$this->assertIsArray( $row );
 	}
 
 	private function insert_many_values() {


### PR DESCRIPTION
### Description:

As title. Matomo core now prefixes SELECT statements with a SET ... FOR for MariaDB.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
