### PR TITLE
check against plugin name when looking through non-core matomo plugins instead of path

### DIFF
--- a/classes/WpMatomo/Installer.php
+++ b/classes/WpMatomo/Installer.php
@@ -442,11 +442,11 @@ class Installer {
 		$plugin_files = is_array( $plugin_files ) ? $plugin_files : [];
 
 		foreach ( $plugin_files as $file ) {
-			if ( strpos( $file, 'matomo/matomo.php' ) !== false ) {
+			$plugin_name = basename( dirname( $file ) );
+			if ( 'matomo' === $plugin_name ) {
 				continue;
 			}
 
-			$plugin_name = basename( dirname( $file ) );
 			if ( empty( $installed_components[ $plugin_name ] ) ) {
 				return false;
 			}

--- a/tests/e2e/matomo.tag-manager.e2e.ts
+++ b/tests/e2e/matomo.tag-manager.e2e.ts
@@ -81,6 +81,7 @@ describe('Matomo > Tag Manager', () => {
 
     await ContainerTriggersPage.disableModalScroll();
     await ContainerTriggersPage.disableHoverStyles();
+    await browser.pause(1000);
     await expect(
       await browser.checkFullPageScreen('matomo.tag-manager.publish-modal')
     ).toBeLessThanOrEqual(0.05);

--- a/tests/e2e/mwp-admin.multisite.general.e2e.ts
+++ b/tests/e2e/mwp-admin.multisite.general.e2e.ts
@@ -44,9 +44,9 @@ describe('MultiSite General', function() {
     Website.switchSite('test2');
 
     // for some reason on the first load, the app/bootstrap.php cannot be found
-    await GetStartedPage.open();
-    await browser.pause(3000);
-    await GetStartedPage.open();
+    await Website.retry(3, async () => {
+      await GetStartedPage.open();
+    });
 
     await GetStartedPage.prepareWpAdminForScreenshot();
     await removeSystemReportNotification();

--- a/tests/e2e/mwp-admin.multisite.network-admin.e2e.ts
+++ b/tests/e2e/mwp-admin.multisite.network-admin.e2e.ts
@@ -34,9 +34,9 @@ describe('Network Admin', function() {
 
   it('should display the multisite get started page correctly', async () => {
     // for some reason on the first load, the app/bootstrap.php cannot be found
-    await NetworkMultiSitePage.open();
-    await browser.pause(3000);
-    await NetworkMultiSitePage.open();
+    await Website.retry(3, async () => {
+      await NetworkMultiSitePage.open();
+    });
 
     await NetworkMultiSitePage.prepareWpAdminForScreenshot();
     await expect(

--- a/tests/e2e/pageobjects/mwp-admin/marketplace.page.ts
+++ b/tests/e2e/pageobjects/mwp-admin/marketplace.page.ts
@@ -47,7 +47,7 @@ class MwpMarketplaceSetupWizard {
     await $('#pluginzip').setValue(pathToPlugin);
     await browser.pause(500);
     await $('#install-plugin-submit').click();
-    await $('.button=Activate Plugin').waitForDisplayed();
+    await $('.button=Activate Plugin').waitForDisplayed({ timeout: 30000 });
 
     await $('.button=Activate Plugin').click();
     await browser.waitUntil(() => {

--- a/tests/e2e/website.ts
+++ b/tests/e2e/website.ts
@@ -296,7 +296,7 @@ class Website {
           window.jQuery('p:contains(Plugin downgraded successfully.)').length > 0
         );
       });
-    }, {timeout: 60000});
+    }, { timeout: 120000 });
   }
 }
 

--- a/tests/e2e/website.ts
+++ b/tests/e2e/website.ts
@@ -246,7 +246,7 @@ class Website {
     this.wordPressFolderOverride = null;
   }
 
-  private async retry<R>(times: number, fn: () => Promise<R>) {
+  public async retry<R>(times: number, fn: () => Promise<R>) {
     while (times > 0) {
       try {
         return await fn();


### PR DESCRIPTION
### Description:

Some users use windows so checking the path directly is not ideal.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
