### PR TITLE
add new INI config to allow passing WP app passwords as the token auth in Matomo API requests

### DIFF
--- a/classes/WpMatomo/API.php
+++ b/classes/WpMatomo/API.php
@@ -192,11 +192,18 @@ class API {
 			}
 		}
 
+		$methods = [ $method ];
+		if ( ! in_array( 'POST', $methods, true ) ) {
+			// we allow posting to all methods so users can pass the app password as the token_auth
+			// instead of as a header if needed
+			$methods[] = 'POST';
+		}
+
 		register_rest_route(
 			self::VERSION,
 			'/' . $wp_api_module . '/' . $wp_api_action . '/',
 			[
-				'methods'             => $method,
+				'methods'             => $methods,
 				'callback'            => [ $this, 'execute_api_method' ],
 				'permission_callback' => '__return_true', // permissions are checked in the method itself
 				'matomoModule'        => $api_module,

--- a/classes/WpMatomo/API.php
+++ b/classes/WpMatomo/API.php
@@ -79,6 +79,7 @@ class API {
 		$this->register_route( 'SegmentEditor', 'getAll' );
 		$this->register_route( 'SitesManager', 'getAllSites' );
 		$this->register_route( 'SitesManager', 'getAllSitesId' );
+		$this->register_route( 'SitesManager', 'getSitesIdWithAtLeastViewAccess' );
 		$this->register_route( 'UsersManager', 'getUsers' );
 		$this->register_route( 'UsersManager', 'getUsersLogin' );
 		$this->register_route( 'UsersManager', 'getUser' );

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -96,7 +96,7 @@ class Auth extends \Piwik\Plugins\Login\Auth
     private function isAppPasswordInTokenAuthAllowed()
     {
         $wordPressConfig = Config::getInstance()->WordPress;
-        return !empty( $wordPressConfig['allow_app_password_as_token_auth'] ) && $wordPressConfig['allow_app_password_as_token_auth'] === '1';
+        return !empty( $wordPressConfig['allow_app_password_as_token_auth'] ) && strval( $wordPressConfig['allow_app_password_as_token_auth'] ) === '1';
     }
 
     private function authApiWithTokenAuthAppPassword()

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -11,6 +11,8 @@ namespace Piwik\Plugins\WordPress;
 
 use Piwik\AuthResult;
 use Piwik\Config;
+use Piwik\Container\StaticContainer;
+use Piwik\Log\LoggerInterface;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\SettingsServer;
 use Piwik\Tracker\TrackerConfig;
@@ -101,18 +103,22 @@ class Auth extends \Piwik\Plugins\Login\Auth
 
     private function authApiWithTokenAuthAppPassword()
     {
-        if (!function_exists('wp_validate_application_password')) {
-            return null;
-        }
-
         $tokenAuth = $this->token_auth;
         if (empty($tokenAuth)) {
             return null;
         }
 
+        $logger = StaticContainer::get(LoggerInterface::class);
+
+        if (!function_exists('wp_validate_application_password')) {
+            $logger->debug('WordPress\\Auth: wp_validate_application_password does not exist');
+            return null;
+        }
+
         $parts = explode(':', $tokenAuth);
         if (count($parts) !== 2) {
-            return null; // TODO: log
+            $logger->debug('WordPress\\Auth: app password provided in token_auth has incorrect format, expected "username:apppassword".');
+            return null;
         }
 
         if (

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -10,7 +10,8 @@
 namespace Piwik\Plugins\WordPress;
 
 use Piwik\AuthResult;
-use Piwik\Config;use Piwik\Plugins\UsersManager\Model;
+use Piwik\Config;
+use Piwik\Plugins\UsersManager\Model;
 use Piwik\SettingsServer;
 use Piwik\Tracker\TrackerConfig;
 use WpMatomo\User;

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -115,8 +115,11 @@ class Auth extends \Piwik\Plugins\Login\Auth
             return null; // TODO: log
         }
 
-        if (!empty($_GET['token_auth'])) {
-            return null; // TODO: log
+        if (
+            empty($_SERVER['REQUEST_METHOD'])
+            || strtoupper($_SERVER['REQUEST_METHOD']) !== 'POST'
+        ) {
+            throw new \Exception('Invalid token auth or token auth was not provided as a POST parameter.');
         }
 
         [$user, $pass] = $parts;

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -10,7 +10,7 @@
 namespace Piwik\Plugins\WordPress;
 
 use Piwik\AuthResult;
-use Piwik\Plugins\UsersManager\Model;
+use Piwik\Config;use Piwik\Plugins\UsersManager\Model;
 use Piwik\SettingsServer;
 use Piwik\Tracker\TrackerConfig;
 use WpMatomo\User;
@@ -45,6 +45,11 @@ class Auth extends \Piwik\Plugins\Login\Auth
 	            // api authentication using token
 		        return parent::authenticate();
 	        }
+        } else if ($this->isAppPasswordInTokenAuthAllowed()) {
+            $result = $this->authApiWithTokenAuthAppPassword();
+            if (!empty($result)) {
+                return $result;
+            }
         }
 
         $login = 'anonymous';
@@ -73,6 +78,60 @@ class Auth extends \Piwik\Plugins\Login\Auth
 
         if (!$isUserLoggedIn) {
             return null;
+        }
+
+        $login = User::get_matomo_user_login($loggedInUserId);
+
+        $userModel = new Model();
+        $matomoUser = $userModel->getUser($login);
+        if (empty($matomoUser)) {
+            return null;
+        }
+
+        $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
+        return new AuthResult($code, $login, $this->token_auth);
+    }
+
+    private function isAppPasswordInTokenAuthAllowed()
+    {
+        $wordPressConfig = Config::getInstance()->WordPress;
+        return !empty( $wordPressConfig['allow_app_password_as_token_auth'] ) && $wordPressConfig['allow_app_password_as_token_auth'] === '1';
+    }
+
+    private function authApiWithTokenAuthAppPassword()
+    {
+        if (!function_exists('wp_validate_application_password')) {
+            return null;
+        }
+
+        $tokenAuth = $this->token_auth;
+        if (empty($tokenAuth)) {
+            return null;
+        }
+
+        $parts = explode(':', $tokenAuth);
+        if (count($parts) !== 2) {
+            return null; // TODO: log
+        }
+
+        if (!empty($_GET['token_auth'])) {
+            return null; // TODO: log
+        }
+
+        [$user, $pass] = $parts;
+
+        $callback = function () { return true; };
+
+        add_filter('application_password_is_api_request', $callback);
+        try {
+            $authenticated = wp_authenticate_application_password(null, $user, $pass);
+            if (!($authenticated instanceof \WP_User)) {
+                return null;
+            }
+            $loggedInUserId = $authenticated->ID;
+
+        } finally {
+            remove_filter('application_password_is_api_request', $callback);
         }
 
         $login = User::get_matomo_user_login($loggedInUserId);

--- a/tests/e2e/apiobjects/matomo.api.ts
+++ b/tests/e2e/apiobjects/matomo.api.ts
@@ -9,10 +9,6 @@
 import fetch from 'node-fetch';
 import Website from '../website.js';
 
-function toSnakeCase(s: string) {
-  return s.replace(/([A-Z])/g, '_$1').replace(/^_/, '').toLowerCase();
-}
-
 class MatomoApi {
   async track(idsite: string, params: URLSearchParams) {
     const trackingEndpoint = `${await Website.baseUrl()}/wp-content/plugins/matomo/app/matomo.php`;
@@ -44,7 +40,7 @@ class MatomoApi {
   async call(restMethod: string, apiMethod: string, params: URLSearchParams = new URLSearchParams()) {
     const [module, action] = apiMethod.split('.');
     const wpAction = action === 'get' ? 'get' : action.replace(/^(get|add|create)/, '');
-    const wordpressUrl = `${await Website.baseUrl()}/index.php?rest_route=/matomo/v1/${toSnakeCase(module)}/${toSnakeCase(wpAction)}`;
+    const wordpressUrl = `${await Website.baseUrl()}/index.php?rest_route=/matomo/v1/${this.toSnakeCase(module)}/${this.toSnakeCase(wpAction)}`;
 
     const fullUrl = `${wordpressUrl}&${params}`;
 
@@ -99,6 +95,10 @@ class MatomoApi {
     }
 
     return result;
+  }
+
+  toSnakeCase(s: string) {
+    return s.replace(/([A-Z])/g, '_$1').replace(/^_/, '').toLowerCase();
   }
 }
 

--- a/tests/e2e/apiobjects/matomo.cli.ts
+++ b/tests/e2e/apiobjects/matomo.cli.ts
@@ -34,7 +34,7 @@ class MatomoCli {
     command = `docker compose --env-file .env.default --env-file .env run --rm exec matomo:console ${command}`;
 
     try {
-    execSync(command);
+      execSync(command);
     } catch (e) {
       console.log(e.stdout.toString());
       console.log(e.stderr.toString());

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -1,0 +1,75 @@
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+import MatomoIni from './apiobjects/matomo.ini.js';
+import MatomoApi from './apiobjects/matomo.api.js';
+import Website from './website.js';
+
+describe( 'Matomo API', function () {
+  describe('Authentication', function () {
+    before(async () => {
+      await MatomoIni.set('WordPress', 'allow_app_password_as_token_auth', 1);
+    });
+
+    after(async () => {
+      await MatomoIni.set('WordPress', 'allow_app_password_as_token_auth', 1);
+    });
+
+    // NOTE: authenticating via header is tested implicitly by GlobalSetup
+    it('should allow authenticating via app password in token_auth when feature is enabled', async () => {
+      const module = 'SitesManager';
+      const action = 'SitesIdWithAtLeastViewAccess';
+      const wordpressUrl = `${await Website.baseUrl()}/index.php?rest_route=/matomo/v1/${MatomoApi.toSnakeCase(module)}/${MatomoApi.toSnakeCase(action)}`;
+
+      const nonce = await Website.getWpNonce();
+      if (!nonce) {
+        throw new Error('No application password found!');
+      }
+
+      const userPass = `root:${nonce}`;
+
+      const response = await fetch(wordpressUrl, {
+        method: 'POST',
+        headers:{
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: new URLSearchParams({
+          token_auth: userPass,
+        }),
+      });
+
+      const json = await response.json();
+      expect(json).toEqual([1]);
+    });
+
+    it('should not allow using a app password as a token_auth in a non-POST request', async () => {
+      const module = 'SitesManager';
+      const action = 'SitesIdWithAtLeastViewAccess';
+      const wordpressUrl = `${await Website.baseUrl()}/index.php?rest_route=/matomo/v1/${MatomoApi.toSnakeCase(module)}/${MatomoApi.toSnakeCase(action)}`;
+
+      const nonce = await Website.getWpNonce();
+      if (!nonce) {
+        throw new Error('No application password found!');
+      }
+
+      const userPass = `root:${nonce}`;
+
+      try {
+        await fetch(`${wordpressUrl}&token_auth=${userPass}`, {
+          method: 'GET',
+        });
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect((e as Error).message).toEqual(''); // TODO
+        return;
+      }
+
+      throw new Error('did not throw');
+    });
+  });
+});

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -60,9 +60,12 @@ describe( 'Matomo API', function () {
       const userPass = `root:${nonce}`;
 
       try {
-        await fetch(`${wordpressUrl}&token_auth=${userPass}`, {
+        const response = await fetch(`${wordpressUrl}&token_auth=${userPass}`, {
           method: 'GET',
         });
+
+        const json = await response.json();
+        console.log('found error api response', json);
       } catch (e) {
         expect(e).toBeInstanceOf(Error);
         expect((e as Error).message).toEqual(''); // TODO

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -44,7 +44,7 @@ describe( 'Matomo API', function () {
       });
 
       const json = await response.json();
-      expect(json).toEqual([1]);
+      expect(json).toEqual(['1']);
     });
 
     it('should not allow using a app password as a token_auth in a non-POST request', async () => {

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -59,20 +59,16 @@ describe( 'Matomo API', function () {
 
       const userPass = `root:${nonce}`;
 
-      try {
-        const response = await fetch(`${wordpressUrl}&token_auth=${userPass}`, {
-          method: 'GET',
-        });
+      const response = await fetch(`${wordpressUrl}&token_auth=${userPass}`, {
+        method: 'GET',
+      });
 
-        const json = await response.json();
-        console.log('found error api response', json);
-      } catch (e) {
-        expect(e).toBeInstanceOf(Error);
-        expect((e as Error).message).toEqual(''); // TODO
-        return;
-      }
-
-      throw new Error('did not throw');
+      const json = await response.json();
+      expect(json).toEqual({
+        code: 'matomo_error',
+        message: 'Invalid token auth or token auth was not provided as a POST parameter.',
+        data: null,
+      });
     });
   });
 });

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -17,7 +17,7 @@ describe( 'Matomo API', function () {
     });
 
     after(async () => {
-      await MatomoIni.set('WordPress', 'allow_app_password_as_token_auth', 1);
+      await MatomoIni.set('WordPress', 'allow_app_password_as_token_auth', 0);
     });
 
     // NOTE: authenticating via header is tested implicitly by GlobalSetup
@@ -31,9 +31,17 @@ describe( 'Matomo API', function () {
         throw new Error('No application password found!');
       }
 
-      const userPass = `root:${nonce}`;
+      // check an unauthenticated request (sanity check)
+      let response = await fetch(wordpressUrl, {
+        method: 'POST',
+      });
 
-      const response = await fetch(wordpressUrl, {
+      let json = await response.json();
+      expect(json).toEqual([]);
+
+      // check an authenticated request
+      const userPass = `root:${nonce}`;
+      response = await fetch(wordpressUrl, {
         method: 'POST',
         headers:{
           'Content-Type': 'application/x-www-form-urlencoded'
@@ -43,7 +51,7 @@ describe( 'Matomo API', function () {
         }),
       });
 
-      const json = await response.json();
+      json = await response.json();
       expect(json).toEqual(['1']);
     });
 

--- a/tests/e2e/pageobjects/page.ts
+++ b/tests/e2e/pageobjects/page.ts
@@ -154,7 +154,12 @@ export default class Page {
       window.jQuery('#wpadminbar,#adminmenumain').hide();
       window.jQuery('#footer-upgrade').hide();
     });
-    await browser.pause(1000);
+
+    await browser.waitUntil(async () => {
+      return await browser.execute(() => {
+        return !window.jQuery('#wpadminbar').is(':visible');
+      });
+    });
   }
 
   async undoChangesToWpAdminForScreenshot() {

--- a/tests/e2e/tracking.e2e.ts
+++ b/tests/e2e/tracking.e2e.ts
@@ -33,7 +33,7 @@ describe('Tracking', () => {
     await BlogPostPage.open();
     await BlogPostPage.waitForTrackingRequest();
 
-    await browser.pause(1500); // just to make sure everything gets tracked
+    await browser.pause(3000); // just to make sure everything gets tracked
 
     const counters = await MatomoApi.call('GET', 'Live.getCounters', new URLSearchParams({
       idSite: '1',

--- a/tests/e2e/website.ts
+++ b/tests/e2e/website.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {browser, $, expect} from '@wdio/globals';
+import { browser, $ } from '@wdio/globals';
 import fetch from 'node-fetch';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -186,47 +186,49 @@ class Website {
     });
 
     if (!isPaymentsSetup) {
-      const isWooCommerceCodInputFound = await $('#woocommerce_cod_enabled').isExisting();
-      const isWoocommerceCodToggleFound = await $('tr[data-gateway_id="cod"] .woocommerce-input-toggle').isExisting();
+      await this.retry(3, async () => {
+        const isWooCommerceCodInputFound = await $('#woocommerce_cod_enabled').isExisting();
+        const isWoocommerceCodToggleFound = await $('tr[data-gateway_id="cod"] .woocommerce-input-toggle').isExisting();
 
-      const html = await browser.execute(() => window.querySelector('html').innerHTML);
+        const html = await browser.execute(() => document.querySelector('html')!.innerHTML);
 
-      if (isWooCommerceCodInputFound || html.includes('#woocommerce_cod_enabled')) {
-        await $('label[for="woocommerce_cod_enabled"]').click();
-        await $('.woocommerce-save-button').click();
-        await browser.waitUntil(async () => {
-          return window.jQuery('#message:contains(Your settings have been saved)').length > 0;
-        }, { timeout: 30000 });
-      } else if (isWoocommerceCodToggleFound || html.includes('data-gateway_id="cod"')) {
-        await browser.execute(() => {
-          window.jQuery('tr[data-gateway_id="cod"] .woocommerce-input-toggle--disabled').closest('a')[0].click();
-        });
-
-        try {
-          await $('tr[data-gateway_id="cod"] .woocommerce-input-toggle--enabled').waitForExist({ timeout: 90000 });
-        } catch (e) {
-          await this.dumpHtml();
-          throw e;
-        }
-
-        if (await $('.woocommerce-save-button').isExisting()) {
+        if (isWooCommerceCodInputFound || html.includes('#woocommerce_cod_enabled')) {
+          await $('label[for="woocommerce_cod_enabled"]').click();
+          await $('.woocommerce-save-button').click();
+          await browser.waitUntil(async () => {
+            return window.jQuery('#message:contains(Your settings have been saved)').length > 0;
+          }, { timeout: 30000 });
+        } else if (isWoocommerceCodToggleFound || html.includes('data-gateway_id="cod"')) {
           await browser.execute(() => {
-            window.jQuery('.woocommerce-save-button')[0].click();
+            window.jQuery('tr[data-gateway_id="cod"] .woocommerce-input-toggle--disabled').closest('a')[0].click();
           });
 
           try {
-            await browser.waitUntil(async () => {
-              return await browser.execute(() => window.jQuery('.woocommerce-save-button[disabled],tr[data-gateway_id="cod"] .woocommerce-input-toggle--enabled').length > 0);
-            }, { timeout: 60000 });
+            await $('tr[data-gateway_id="cod"] .woocommerce-input-toggle--enabled').waitForExist({ timeout: 90000 });
           } catch (e) {
             await this.dumpHtml();
             throw e;
           }
-        } else {
-          console.log(html);
-          throw new Error('unknown page html in woocommerce setup');
+
+          if (await $('.woocommerce-save-button').isExisting()) {
+            await browser.execute(() => {
+              window.jQuery('.woocommerce-save-button')[0].click();
+            });
+
+            try {
+              await browser.waitUntil(async () => {
+                return await browser.execute(() => window.jQuery('.woocommerce-save-button[disabled],tr[data-gateway_id="cod"] .woocommerce-input-toggle--enabled').length > 0);
+              }, { timeout: 60000 });
+            } catch (e) {
+              await this.dumpHtml();
+              throw e;
+            }
+          } else {
+            console.log(html);
+            throw new Error('unknown page html in woocommerce setup');
+          }
         }
-      }
+      });
     }
 
     this.isWooCommerceSetup = true;

--- a/tests/e2e/website.ts
+++ b/tests/e2e/website.ts
@@ -189,13 +189,15 @@ class Website {
       const isWooCommerceCodInputFound = await $('#woocommerce_cod_enabled').isExisting();
       const isWoocommerceCodToggleFound = await $('tr[data-gateway_id="cod"] .woocommerce-input-toggle').isExisting();
 
-      if (isWooCommerceCodInputFound) {
+      const html = await browser.execute(() => window.querySelector('html').innerHTML);
+
+      if (isWooCommerceCodInputFound || html.includes('#woocommerce_cod_enabled')) {
         await $('label[for="woocommerce_cod_enabled"]').click();
         await $('.woocommerce-save-button').click();
         await browser.waitUntil(async () => {
           return window.jQuery('#message:contains(Your settings have been saved)').length > 0;
         }, { timeout: 30000 });
-      } else if (isWoocommerceCodToggleFound) {
+      } else if (isWoocommerceCodToggleFound || html.includes('data-gateway_id="cod"')) {
         await browser.execute(() => {
           window.jQuery('tr[data-gateway_id="cod"] .woocommerce-input-toggle--disabled').closest('a')[0].click();
         });
@@ -221,7 +223,7 @@ class Website {
             throw e;
           }
         } else {
-          await this.dumpHtml();
+          console.log(html);
           throw new Error('unknown page html in woocommerce setup');
         }
       }

--- a/tests/e2e/website.ts
+++ b/tests/e2e/website.ts
@@ -181,18 +181,21 @@ class Website {
     await $('tr[data-gateway_id="cod"] .woocommerce-input-toggle,#woocommerce_cod_enabled').waitForExist({ timeout: 60000 });
 
     const isPaymentsSetup = await browser.execute(() => {
-      return window.jQuery('tr[data-gateway_id="cod"] .woocommerce-input-toggle--enabled').length > 0;
+      return window.jQuery('tr[data-gateway_id="cod"] .woocommerce-input-toggle--enabled').length > 0
+        || window.jQuery('#woocommerce_cod_enabled').is(':checked');
     });
 
     if (!isPaymentsSetup) {
       const isWooCommerceCodInputFound = await $('#woocommerce_cod_enabled').isExisting();
+      const isWoocommerceCodToggleFound = await $('tr[data-gateway_id="cod"] .woocommerce-input-toggle').isExisting();
+
       if (isWooCommerceCodInputFound) {
         await $('label[for="woocommerce_cod_enabled"]').click();
         await $('.woocommerce-save-button').click();
         await browser.waitUntil(async () => {
           return window.jQuery('#message:contains(Your settings have been saved)').length > 0;
         }, { timeout: 30000 });
-      } else {
+      } else if (isWoocommerceCodToggleFound) {
         await browser.execute(() => {
           window.jQuery('tr[data-gateway_id="cod"] .woocommerce-input-toggle--disabled').closest('a')[0].click();
         });
@@ -200,7 +203,7 @@ class Website {
         try {
           await $('tr[data-gateway_id="cod"] .woocommerce-input-toggle--enabled').waitForExist({ timeout: 90000 });
         } catch (e) {
-          console.log(await browser.execute(() => document.body.innerHTML));
+          await this.dumpHtml();
           throw e;
         }
 
@@ -214,10 +217,12 @@ class Website {
               return await browser.execute(() => window.jQuery('.woocommerce-save-button[disabled],tr[data-gateway_id="cod"] .woocommerce-input-toggle--enabled').length > 0);
             }, { timeout: 60000 });
           } catch (e) {
-            const html = await browser.execute(() => document.body.innerHTML);
-            console.log('html', html);
+            await this.dumpHtml();
             throw e;
           }
+        } else {
+          await this.dumpHtml();
+          throw new Error('unknown page html in woocommerce setup');
         }
       }
     }

--- a/tests/phpunit/wpmatomo/test-api.php
+++ b/tests/phpunit/wpmatomo/test-api.php
@@ -98,7 +98,7 @@ class ApiTest extends MatomoAnalytics_TestCase {
 	public function test_dispatch_matomo_api_must_use_correct_method() {
 		$this->create_set_super_admin();
 
-		$request  = new WP_REST_Request( 'POST', '/' . API::VERSION . '/api/matomo_version' );
+		$request  = new WP_REST_Request( 'PUT', '/' . API::VERSION . '/api/matomo_version' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		// some newer wp versions have a dot at the end
@@ -144,7 +144,7 @@ class ApiTest extends MatomoAnalytics_TestCase {
 		$this->assertEquals(
 			array(
 				'code'    => 'matomo_error',
-				'message' => 'Please specify a value for \'name\'.',
+				'message' => 'Please specify a value for \'idGoal\'.',
 				'data'    => null,
 			),
 			$response->get_data()

--- a/tests/phpunit/wpmatomo/test-api.php
+++ b/tests/phpunit/wpmatomo/test-api.php
@@ -191,6 +191,10 @@ class ApiTest extends MatomoAnalytics_TestCase {
 	}
 
 	public function test_dispatch_matomo_api_with_token_auth_in_get_fails() {
+		if ( version_compare( getenv( 'WORDPRESS_VERSION' ), '6.0', '<' ) ) {
+			$this->markTestSkipped();
+		}
+
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 
 		\Piwik\Config::getInstance()->WordPress = [

--- a/tests/phpunit/wpmatomo/test-api.php
+++ b/tests/phpunit/wpmatomo/test-api.php
@@ -180,4 +180,53 @@ class ApiTest extends MatomoAnalytics_TestCase {
 			$response->get_data()
 		);
 	}
+
+	public function test_dispatch_matomo_api_allows_post_for_all_methods() {
+		$this->create_set_super_admin();
+
+		$request  = new WP_REST_Request( 'POST', '/' . API::VERSION . '/api/matomo_version' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertStringStartsWith( '5.', $response->get_data() );
+		$this->assertTrue( strlen( $response->get_data() ) < 15 );
+	}
+
+	public function test_dispatch_matomo_api_with_token_auth_in_get_fails() {
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		\Piwik\Config::getInstance()->WordPress = [
+			'allow_app_password_as_token_auth' => 1,
+		];
+
+		$request = new WP_REST_Request( 'GET', '/' . API::VERSION . '/api/matomo_version' );
+		$request->set_param( 'token_auth', 'user:dummy' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals(
+			array(
+				'code'    => 'matomo_error',
+				'message' => 'Invalid token auth or token auth was not provided as a POST parameter.',
+				'data'    => null,
+			),
+			$response->get_data()
+		);
+	}
+
+	public function test_dispatch_matomo_api_ignores_app_passwords_with_incorrect_format() {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		\Piwik\Config::getInstance()->WordPress = [
+			'allow_app_password_as_token_auth' => 1,
+		];
+
+		$request = new WP_REST_Request( 'GET', '/' . API::VERSION . '/api/matomo_version' );
+		$request->set_param( 'token_auth', 'dummy' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals(
+			array(
+				'code'    => 'matomo_no_access_exception',
+				'message' => 'You must be logged in to access this functionality.',
+				'data'    => null,
+			),
+			$response->get_data()
+		);
+	}
 }


### PR DESCRIPTION
### Description:

Refs #1252 

Changes:
* Add new INI config setting (`[WordPress] allow_app_password_as_token_auth`) that allows passing WP app passwords as the Matomo token_auth. They will only be used if sent in a POST.
* Allow POST requests to all Matomo API methods accessible through the WP REST API so the above mechanism can be used.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
