### PR TITLE
add tests checking whether matomo API can be accessed directly

### DIFF
--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -98,7 +98,8 @@ class Auth extends \Piwik\Plugins\Login\Auth
     private function isAppPasswordInTokenAuthAllowed()
     {
         $wordPressConfig = Config::getInstance()->WordPress;
-        return !empty( $wordPressConfig['allow_app_password_as_token_auth'] ) && strval( $wordPressConfig['allow_app_password_as_token_auth'] ) === '1';
+        $allowed = !empty( $wordPressConfig['allow_app_password_as_token_auth'] ) && strval( $wordPressConfig['allow_app_password_as_token_auth'] ) === '1';
+        return $allowed;
     }
 
     private function authApiWithTokenAuthAppPassword()

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -100,7 +100,10 @@ describe( 'Matomo API', function () {
       });
 
       let json = await response.json();
-      expect(json).toEqual([]);
+      expect(json).toEqual({
+        message: 'Unable to authenticate with the provided token. It is either invalid or expired.',
+        result: 'error',
+      });
 
       // check an authenticated request
       response = await fetch(url, {

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -78,5 +78,56 @@ describe( 'Matomo API', function () {
         data: null,
       });
     });
+
+    it('should be possible to send API requests to the Matomo API endpoint', async () => {
+      const url = `${await Website.baseUrl()}/wp-content/plugins/matomo/app/index.php?module=API&method=SitesManager.getSitesIdWithAtLeastViewAccess&format=json`;
+
+      const nonce = await Website.getWpNonce(); // TODO: should this be called a nonce or app password? can't remember what terminology WP uses
+      if (!nonce) {
+        throw new Error('No application password found!');
+      }
+
+      // check an unauthenticated request (sanity check)
+      const userPass = `root:${nonce}`;
+      let response = await fetch(url, {
+        method: 'POST',
+      });
+
+      let json = await response.json();
+      expect(json).toEqual([]);
+
+      // check an authenticated request
+      response = await fetch(url, {
+        method: 'POST',
+        headers:{
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: new URLSearchParams({
+          token_auth: userPass,
+        }),
+      });
+
+      json = await response.json();
+      expect(json).toEqual(['1']);
+    });
+
+    it('should not be allowed to send an app password to the Matomo API endpoint as a GET request query parameter', async () => {
+      const url = `${await Website.baseUrl()}/wp-content/plugins/matomo/app/index.php?module=API&method=SitesManager.getSitesIdWithAtLeastViewAccess&format=json`;
+
+      const nonce = await Website.getWpNonce(); // TODO: should this be called a nonce or app password? can't remember what terminology WP uses
+      if (!nonce) {
+        throw new Error('No application password found!');
+      }
+
+      const userPass = `root:${nonce}`;
+      const response = await fetch(`${url}&token_auth=${userPass}`, {
+        method: 'GET',
+      });
+
+      const json = await response.json();
+      expect(json).toEqual({
+        message: 'Invalid token auth or token auth was not provided as a POST parameter.',
+      });
+    });
   });
 });

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -91,6 +91,12 @@ describe( 'Matomo API', function () {
       const userPass = `root:${nonce}`;
       let response = await fetch(url, {
         method: 'POST',
+        headers:{
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: new URLSearchParams({
+          token_auth: 'wrong:token',
+        }),
       });
 
       let json = await response.json();

--- a/tests/e2e/matomo-api.e2e.ts
+++ b/tests/e2e/matomo-api.e2e.ts
@@ -127,6 +127,7 @@ describe( 'Matomo API', function () {
       const json = await response.json();
       expect(json).toEqual({
         message: 'Invalid token auth or token auth was not provided as a POST parameter.',
+        result: 'error',
       });
     });
   });

--- a/tests/e2e/website.ts
+++ b/tests/e2e/website.ts
@@ -196,7 +196,7 @@ class Website {
           await $('label[for="woocommerce_cod_enabled"]').click();
           await $('.woocommerce-save-button').click();
           await browser.waitUntil(async () => {
-            return window.jQuery('#message:contains(Your settings have been saved)').length > 0;
+            return await browser.execute(() => window.jQuery('#message:contains(Your settings have been saved)').length > 0);
           }, { timeout: 30000 });
         } else if (isWoocommerceCodToggleFound || html.includes('data-gateway_id="cod"')) {
           await browser.execute(() => {


### PR DESCRIPTION
### Description:

Refs #1252 

Changes:
* new e2e test accessing the Matomo API directly rather than through the WordPress REST API.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
