### PR TITLE
if server side order tracking fails, do not mark order as tracked

### DIFF
--- a/app/vendor/matomo/matomo-php-tracker/MatomoTracker.php
+++ b/app/vendor/matomo/matomo-php-tracker/MatomoTracker.php
@@ -573,7 +573,7 @@ namespace {
             $this->doBulkRequests = \true;
         }
         /**
-         * Disables the bulk request feature. Make sure to call `doBulkTrack()` before disabling it if you have stored  
+         * Disables the bulk request feature. Make sure to call `doBulkTrack()` before disabling it if you have stored
          * tracking actions previously as this method won't be sending any previously stored actions before disabling it.
          *
          */
@@ -665,7 +665,7 @@ namespace {
          * Returns the PageView id. If the id was manually set using `setPageViewId()`, that id will be returned.
          * If the id was not set manually, the id that was automatically generated in last `doTrackPageView()` will
          * be returned. If there was no last page view, this will be false.
-         * 
+         *
          * @return mixed The PageView id as string or false if there is none yet.
          */
         public function getPageviewId()

--- a/classes/WpMatomo/AjaxTracker.php
+++ b/classes/WpMatomo/AjaxTracker.php
@@ -60,6 +60,7 @@ class AjaxTracker extends \MatomoTracker {
 		$has_wc_session = function_exists( 'WC' ) && isset( WC()->session );
 		if ( $has_wc_session ) {
 			$visitor_id = WC()->session->get( ServerSideVisitorId::VISITOR_ID_SESSION_VAR_NAME );
+			$this->logger->log("setting visitor ID from session: " . $visitor_id);
 			if ( ! empty( $visitor_id ) ) {
 				$this->hasCookie = true; // do not set cookies for this visitor
 				try {
@@ -74,6 +75,7 @@ class AjaxTracker extends \MatomoTracker {
 		}
 
 		if ( empty( $this->forcedVisitorId ) && $this->loadVisitorIdCookie() ) {
+			$this->logger->log("setting visitor ID from cookie: " . $this->cookieVisitorId);
 			if ( ! empty( $this->cookieVisitorId ) ) {
 				$this->has_cookie = true;
 				try {

--- a/classes/WpMatomo/AjaxTracker.php
+++ b/classes/WpMatomo/AjaxTracker.php
@@ -112,10 +112,16 @@ class AjaxTracker extends \MatomoTracker {
 		// 1) Not send any response no matter what happens
 		// 2) Never exit at any point
 
-		$response = wp_remote_request( $url . '&bots=1', $args );
+		$url = $url . '&bots=1';
 
-		if (is_wp_error($response)) {
-			$this->logger->log_exception('ajax_tracker', new \Exception($response->get_error_message()));
+		$this->logger->log( 'AjaxTracker: wp_remote_request to ' . $url );
+
+		$response = wp_remote_request( $url, $args );
+
+		$this->logger->log( 'AjaxTracker: wp_remote_request response is ' . json_encode( $response ) );
+
+		if ( is_wp_error( $response ) ) {
+			$this->logger->log_exception( 'ajax_tracker', new \Exception( $response->get_error_message() ) );
 		}
 
 		return $response;

--- a/classes/WpMatomo/AjaxTracker.php
+++ b/classes/WpMatomo/AjaxTracker.php
@@ -57,25 +57,35 @@ class AjaxTracker extends \MatomoTracker {
 			$this->disableCookieSupport();
 		}
 
-		if ( $this->loadVisitorIdCookie() ) {
-			if ( ! empty( $this->cookieVisitorId ) ) {
-				$this->has_cookie = true;
+		$has_wc_session = function_exists( 'WC' ) && isset( WC()->session );
+		if ( $has_wc_session ) {
+			$visitor_id = WC()->session->get( ServerSideVisitorId::VISITOR_ID_SESSION_VAR_NAME );
+			if ( ! empty( $visitor_id ) ) {
+				$this->hasCookie = true; // do not set cookies for this visitor
 				try {
-					$this->setVisitorId( $this->cookieVisitorId );
-				} catch (\Exception $ex) {
+					$this->setVisitorId( $visitor_id );
+				} catch ( \Exception $ex ) {
 					// do not fatal if the visitor ID is invalid for some reason
 					if ( ! $this->is_invalid_visitor_id_error( $ex ) ) {
 						throw $ex;
 					}
 				}
 			}
-		} else if ( function_exists( 'WC' ) && isset( WC()->session ) ) {
-			$visitor_id = WC()->session->get( ServerSideVisitorId::VISITOR_ID_SESSION_VAR_NAME );
-			if ( ! empty( $visitor_id ) ) {
-				$this->hasCookie = true; // do not set cookies for this visitor, since it would have no effect anyway
+		}
+
+		if ( empty( $this->forcedVisitorId ) && $this->loadVisitorIdCookie() ) {
+			if ( ! empty( $this->cookieVisitorId ) ) {
+				$this->has_cookie = true;
 				try {
-					$this->setVisitorId( $visitor_id );
-				} catch ( \Exception $ex ) {
+					$this->setVisitorId( $this->cookieVisitorId );
+
+					// save first used visitor ID for this session so we can keep using it, in case
+					// the visitor ID cookie in a user's browser changes (either due to developer error
+					// or some strange configuration we don't know about)
+					if ( $has_wc_session ) {
+						WC()->session->set( ServerSideVisitorId::VISITOR_ID_SESSION_VAR_NAME, $this->cookieVisitorId );
+					}
+				} catch (\Exception $ex) {
 					// do not fatal if the visitor ID is invalid for some reason
 					if ( ! $this->is_invalid_visitor_id_error( $ex ) ) {
 						throw $ex;

--- a/classes/WpMatomo/AjaxTracker.php
+++ b/classes/WpMatomo/AjaxTracker.php
@@ -97,7 +97,7 @@ class AjaxTracker extends \MatomoTracker {
 
 	protected function sendRequest( $url, $method = 'GET', $data = null, $force = false ) {
 		if ( ! $this->idSite ) {
-			$this->logger->log('ecommerce tracking could not find idSite, cannot send request');
+			$this->logger->log( 'ecommerce tracking could not find idSite, cannot send request' );
 			return; // not installed or synced yet
 		}
 		$args = array(

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -127,6 +127,13 @@ class Base {
 						}
 
 						$tracker_method = $methods[ $call[0] ];
+
+						if ( 'doTrackEcommerceOrder' === $tracker_method ) {
+							$this->logger->log('sapi: ' . (defined('PHP_SAPI') ? PHP_SAPI : 'not defined'));
+							$this->logger->log('request: ' . var_export($_REQUEST, true));
+							$this->logger->log('cookie: ' . var_export($_COOKIE, true));
+						}
+
 						array_shift( $call );
 						call_user_func_array( [ $this->tracker, $tracker_method ], $call );
 					} catch ( Exception $e ) {

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -50,9 +50,10 @@ class Base {
 	private $ajax_tracker_calls = [];
 
 	public function __construct( AjaxTracker $tracker, Settings $settings ) {
-		$this->logger   = new Logger();
-		$this->tracker  = $tracker;
-		$this->settings = $settings;
+		$this->logger      = new Logger();
+		$this->tracker     = $tracker;
+		$this->settings    = $settings;
+		$this->sync_config = new WpMatomo\Site\Sync\SyncConfig( $settings );
 
 		// by using prefix we make sure it will be removed on unistall and make sure it's clear it belongs to us
 		$this->key_order_tracked = Settings::OPTION_PREFIX . $this->key_order_tracked;
@@ -109,6 +110,8 @@ class Base {
 	 */
 	protected function wrap_script( $script ) {
 		if ( $this->should_track_background() ) {
+			$debug = $this->is_tracker_debug_enabled();
+
 			$failed = false;
 
 			foreach ( $this->ajax_tracker_calls as $call ) {
@@ -119,6 +122,10 @@ class Base {
 				];
 				if ( ! empty( $call[0] ) && ! empty( $methods[ $call[0] ] ) ) {
 					try {
+						if ( $debug ) {
+							$this->tracker->setDebugStringAppend( 'debug=1' );
+						}
+
 						$tracker_method = $methods[ $call[0] ];
 						array_shift( $call );
 						call_user_func_array( [ $this->tracker, $tracker_method ], $call );
@@ -130,6 +137,8 @@ class Base {
 						if ( 'doTrackEcommerceOrder' === $tracker_method ) {
 							$failed = true;
 						}
+					} finally {
+						$this->tracker->DEBUG_APPEND_URL = '';
 					}
 				}
 			}
@@ -154,5 +163,10 @@ class Base {
 		}
 
 		return $script;
+	}
+
+	private function is_tracker_debug_enabled() {
+		return strval( $this->sync_config->get_config_value( 'Tracker', 'debug' ) ) === '1'
+			|| strval( $this->sync_config->get_config_value( 'Tracker', 'debug_on_demand' ) ) === '1';
 	}
 }

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -128,12 +128,6 @@ class Base {
 
 						$tracker_method = $methods[ $call[0] ];
 
-						if ( 'doTrackEcommerceOrder' === $tracker_method ) {
-							$this->logger->log('sapi: ' . (defined('PHP_SAPI') ? PHP_SAPI : 'not defined'));
-							$this->logger->log('request: ' . var_export($_REQUEST, true));
-							$this->logger->log('cookie: ' . var_export($_COOKIE, true));
-						}
-
 						array_shift( $call );
 						call_user_func_array( [ $this->tracker, $tracker_method ], $call );
 					} catch ( Exception $e ) {

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -103,8 +103,14 @@ class Base {
 		return $code;
 	}
 
+	/**
+	 * @param string $script
+	 * @return string|false the JS script code or `false` if a server side order tracking request failed
+	 */
 	protected function wrap_script( $script ) {
 		if ( $this->should_track_background() ) {
+			$failed = false;
+
 			foreach ( $this->ajax_tracker_calls as $call ) {
 				$methods = [
 					'addEcommerceItem'         => 'addEcommerceItem',
@@ -118,10 +124,20 @@ class Base {
 						call_user_func_array( [ $this->tracker, $tracker_method ], $call );
 					} catch ( Exception $e ) {
 						$this->logger->log_exception( $call[0], $e );
+
+						// let the caller know order tracking failed so we don't mark the order as tracked
+						// in Matomo for WordPress
+						if ( 'trackEcommerceOrder' === $call ) {
+							$failed = true;
+						}
 					}
 				}
 			}
 			$this->ajax_tracker_calls = [];
+
+			if ( $failed ) {
+				return false;
+			}
 
 			return '';
 		}

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -128,6 +128,10 @@ class Base {
 
 						$tracker_method = $methods[ $call[0] ];
 
+						if ( 'doTrackEcommerceOrder' === $tracker_method || 'doTrackEcommerceCartUpdate' === $tracker_method ) {
+							$this->logger->log('cookie: ' . var_export($_COOKIE, true));
+						}
+
 						array_shift( $call );
 						call_user_func_array( [ $this->tracker, $tracker_method ], $call );
 					} catch ( Exception $e ) {

--- a/classes/WpMatomo/Ecommerce/Base.php
+++ b/classes/WpMatomo/Ecommerce/Base.php
@@ -127,7 +127,7 @@ class Base {
 
 						// let the caller know order tracking failed so we don't mark the order as tracked
 						// in Matomo for WordPress
-						if ( 'trackEcommerceOrder' === $call ) {
+						if ( 'doTrackEcommerceOrder' === $tracker_method ) {
 							$failed = true;
 						}
 					}

--- a/classes/WpMatomo/Ecommerce/MatomoTestEcommerce.php
+++ b/classes/WpMatomo/Ecommerce/MatomoTestEcommerce.php
@@ -11,6 +11,8 @@ namespace WpMatomo\Ecommerce;
  */
 class MatomoTestEcommerce extends Base {
 
+	private $force_track_in_background = false;
+
 	/**
 	 * Render public the wrap_script method. Required for the unit tests
 	 *
@@ -33,5 +35,13 @@ class MatomoTestEcommerce extends Base {
 	 */
 	public function make_matomo_js_tracker_call( $params ) {
 		return parent::make_matomo_js_tracker_call( $params );
+	}
+
+	public function set_force_track_in_background( $force_track ) {
+		$this->force_track_in_background = $force_track;
+	}
+
+	protected function should_track_background() {
+		return $this->force_track_in_background || parent::should_track_background();
 	}
 }

--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -267,14 +267,18 @@ class Woocommerce extends Base {
 
 		$this->logger->log( sprintf( 'Tracked ecommerce order %s with number %s', $order_id, $order_id_to_track ) );
 
-		$this->save_order_metadata(
-			$order,
-			[
-				$this->key_order_tracked => 1,
-			]
-		);
+		$wrapped_script = $this->wrap_script( $tracking_code );
 
-		return $this->wrap_script( $tracking_code );
+		if ( false !== $wrapped_script ) {
+			$this->save_order_metadata(
+				$order,
+				[
+					$this->key_order_tracked => 1,
+				]
+			);
+		}
+
+		return strval( $wrapped_script );
 	}
 
 	private function isWC3() {

--- a/tests/phpunit/wpmatomo/ecommerce/test-base.php
+++ b/tests/phpunit/wpmatomo/ecommerce/test-base.php
@@ -10,6 +10,9 @@ class BaseTest extends MatomoAnalytics_TestCase {
 	 * @var Settings
 	 */
 	protected $settings;
+
+	private $ajax_tracker;
+
 	/**
 	 * @var MatomoTestEcommerce
 	 */
@@ -19,10 +22,24 @@ class BaseTest extends MatomoAnalytics_TestCase {
 		parent::setUp();
 		$this->settings = new Settings();
 
+		$this->ajax_tracker = new class( $this->settings ) extends AjaxTracker {
+			public $tracked_urls = [];
+
+			public $force_failure = false;
+
+			protected function sendRequest( $url, $method = 'GET', $data = null, $force = false ) {
+				if ( $this->force_failure ) {
+					throw new \Exception( 'forced error' );
+				}
+
+				$this->tracked_urls[] = $method . ' ' . $url;
+			}
+		};
+
 		/*
 		 * use a custom object which provide public methods of the Base class
 		 */
-		$this->base = new MatomoTestEcommerce( new AjaxTracker( $this->settings ), $this->settings );
+		$this->base = new MatomoTestEcommerce( $this->ajax_tracker, $this->settings );
 	}
 
 	public function test_wrap_script_on_set_ecommerce_view() {
@@ -88,5 +105,142 @@ class BaseTest extends MatomoAnalytics_TestCase {
 			"$cdata_end</script>" . PHP_EOL,
 			$this->base->wrap_script( $this->base->make_matomo_js_tracker_call( $params ) )
 		);
+	}
+
+	public function test_wrap_script_does_server_side_tracking_when_should_track_in_background() {
+		$this->base->set_force_track_in_background( true );
+
+		$tracking_code = '';
+
+		$tracking_code .= $this->base->make_matomo_js_tracker_call(
+			[
+				'addEcommerceItem',
+				'sku1',
+				'title',
+				[ 'cat1', 'cat2' ],
+				123,
+				2,
+			]
+		);
+
+		$tracking_code .= $this->base->make_matomo_js_tracker_call(
+			[
+				'trackEcommerceCartUpdate',
+				234,
+			]
+		);
+
+		$tracking_code .= $this->base->make_matomo_js_tracker_call(
+			[
+				'addEcommerceItem',
+				'sku1',
+				'title',
+				[ 'cat1', 'cat2' ],
+				123,
+				3,
+			]
+		);
+
+		$tracking_code .= $this->base->make_matomo_js_tracker_call(
+			[
+				'trackEcommerceOrder',
+				'order1',
+				356,
+			]
+		);
+
+		$result = $this->base->wrap_script( $tracking_code );
+
+		$this->assertIsString( $result );
+		$this->assertEquals( '', $result );
+
+		$expected_requests = [
+			'GET http://example.org/wp-content/plugins/matomo/app/matomo.php?idsite=1&rec=1&apiv=1&url=&urlref=&idgoal=0&revenue=234&ec_items=%5B%5B%22sku1%22%2C%22title%22%2C%5B%22cat1%22%2C%22cat2%22%5D%2C%22123%22%2C2%5D%5D',
+			'GET http://example.org/wp-content/plugins/matomo/app/matomo.php?idsite=1&rec=1&apiv=1&url=&urlref=&idgoal=0&revenue=356&ec_items=%5B%5B%22sku1%22%2C%22title%22%2C%5B%22cat1%22%2C%22cat2%22%5D%2C%22123%22%2C3%5D%5D&ec_id=order1',
+		];
+
+		$actual_urls = $this->remove_random_params_from( $this->ajax_tracker->tracked_urls );
+
+		$this->assertEquals( $expected_requests, $actual_urls );
+	}
+
+	public function test_wrap_script_ignores_server_side_tracking_errors_for_non_order_tracking_methods() {
+		$this->base->set_force_track_in_background( true );
+		$this->ajax_tracker->force_failure = true;
+
+		$tracking_code = $this->base->make_matomo_js_tracker_call(
+			[
+				'addEcommerceItem',
+				'sku1',
+				'title',
+				[ 'cat1', 'cat2' ],
+				123,
+				2,
+			]
+		);
+
+		$result = $this->base->wrap_script( $tracking_code );
+		$this->assertIsString( $result );
+		$this->assertEquals( '', $result );
+
+		$this->assertEmpty( $this->ajax_tracker->tracked_urls );
+
+		$tracking_code = $this->base->make_matomo_js_tracker_call(
+			[
+				'trackEcommerceCartUpdate',
+				234,
+			]
+		);
+
+		$result = $this->base->wrap_script( $tracking_code );
+		$this->assertIsString( $result );
+		$this->assertEquals( '', $result );
+
+		$this->assertEmpty( $this->ajax_tracker->tracked_urls );
+	}
+
+	public function test_wrap_script_notifies_caller_of_failed_server_side_order_tracking() {
+		$this->base->set_force_track_in_background( true );
+		$this->ajax_tracker->force_failure = true;
+
+		$tracking_code = $this->base->make_matomo_js_tracker_call(
+			[
+				'addEcommerceItem',
+				'sku1',
+				'title',
+				[ 'cat1', 'cat2' ],
+				123,
+				2,
+			]
+		);
+
+		$result = $this->base->wrap_script( $tracking_code );
+		$this->assertIsString( $result );
+		$this->assertEquals( '', $result );
+
+		$this->assertEmpty( $this->ajax_tracker->tracked_urls );
+
+		$tracking_code .= $this->base->make_matomo_js_tracker_call(
+			[
+				'trackEcommerceOrder',
+				'order1',
+				356,
+			]
+		);
+
+		$result = $this->base->wrap_script( $tracking_code );
+		$this->assertFalse( $result );
+
+		$this->assertEmpty( $this->ajax_tracker->tracked_urls );
+	}
+
+	private function remove_random_params_from( $urls ) {
+		foreach ( $urls as &$url ) {
+			$params_to_remove = [ 'r', '_id', '_idts' ];
+			foreach ( $params_to_remove as $param ) {
+				$url = preg_replace( '/&' . preg_quote( $param, '/' ) . '=[^&]+/', '', $url );
+			}
+		}
+		return $urls;
 	}
 }


### PR DESCRIPTION
### Description:

TODO

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
