### PR TITLE
update wp-statistics import test for newest version

### DIFF
--- a/tests/phpunit/wpmatomo/wpstatistics/test-import.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/test-import.php
@@ -86,6 +86,9 @@ class ImportTest extends MatomoAnalytics_TestCase {
 				\WP_STATISTICS\Install::create_table( is_multisite() );
 				\WP_STATISTICS\Install::create_options();
 			} else {
+				\WP_STATISTICS\Option::saveOptionGroup( 'migrated', false, 'db' );
+				\WP_STATISTICS\Option::saveOptionGroup( 'check', false, 'db' );
+
 				if ( is_multisite() ) {
 					// phpcs:ignore WordPress.DB
 					$blog_ids = $wpdb->get_col( "SELECT `blog_id` FROM $wpdb->blogs" );
@@ -96,6 +99,18 @@ class ImportTest extends MatomoAnalytics_TestCase {
 					}
 				} else {
 					\WP_Statistics\Service\Database\Managers\MigrationHandler::runMigrations();
+				}
+
+				// invoke the schema migration process manually, since the HTTP request
+				// wp-statistics normally makes to start it asynchronously, does not work
+				// in the test environment
+				try {
+					$process = WP_Statistics()->getBackgroundProcess( 'schema_migration_process' );
+					$method  = new \ReflectionMethod( $process, 'handle' );
+					$method->setAccessible( true );
+					$method->invoke( $process );
+				} catch ( \WPDieException $ex ) {
+					// ignore
 				}
 			}
 


### PR DESCRIPTION
### Description:

Fixes wp-statistics related test failure.

e2e test failures are unrelated and will be fixed in another PR.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
