### PR TITLE
make sure Matomo roles can view the admin dashboard

### DIFF
--- a/classes/WpMatomo/Roles.php
+++ b/classes/WpMatomo/Roles.php
@@ -32,6 +32,30 @@ class Roles {
 
 	public function register_hooks() {
 		add_action( 'init', [ $this, 'add_roles' ] );
+		add_action( 'matomo_update', [ $this, 'on_update' ] );
+	}
+
+	/**
+	 * Adds role capabilities to Matomo roles in case they changed
+	 * between Matomo for WordPress versions.
+	 *
+	 * Note: at the moment, we don't remove capbilities in case a user
+	 * has used a plugin to manipulate them.
+	 *
+	 * @return void
+	 */
+	public function on_update() {
+		if ( ! $this->has_set_up_roles() ) {
+			$this->add_roles();
+			return;
+		}
+
+		$roles = $this->get_matomo_roles();
+		foreach ( $roles as $role_name => $config ) {
+			foreach ( $config['capabilities'] as $capability => $ignore ) {
+				wp_roles()->add_cap( $role_name, $capability );
+			}
+		}
 	}
 
 	public function get_available_roles_for_configuration() {
@@ -64,20 +88,36 @@ class Roles {
 	public function get_matomo_roles() {
 		return [
 			self::ROLE_VIEW      => [
-				'name'       => 'Matomo View',
-				'defaultCap' => Capabilities::KEY_VIEW,
+				'name'         => 'Matomo View',
+				'capabilities' => [
+					Capabilities::KEY_VIEW => true,
+					'read'                 => true,
+					'view_admin_dashboard' => true,
+				],
 			],
 			self::ROLE_WRITE     => [
-				'name'       => 'Matomo Write',
-				'defaultCap' => Capabilities::KEY_WRITE,
+				'name'         => 'Matomo Write',
+				'capabilities' => [
+					Capabilities::KEY_WRITE => true,
+					'read'                  => true,
+					'view_admin_dashboard'  => true,
+				],
 			],
 			self::ROLE_ADMIN     => [
-				'name'       => 'Matomo Admin',
-				'defaultCap' => Capabilities::KEY_ADMIN,
+				'name'         => 'Matomo Admin',
+				'capabilities' => [
+					Capabilities::KEY_ADMIN => true,
+					'read'                  => true,
+					'view_admin_dashboard'  => true,
+				],
 			],
 			self::ROLE_SUPERUSER => [
-				'name'       => 'Matomo Super User',
-				'defaultCap' => Capabilities::KEY_SUPERUSER,
+				'name'         => 'Matomo Super User',
+				'capabilities' => [
+					Capabilities::KEY_SUPERUSER => true,
+					'read'                      => true,
+					'view_admin_dashboard'      => true,
+				],
 			],
 		];
 	}
@@ -85,7 +125,7 @@ class Roles {
 	public function add_roles( $force = false ) {
 		if ( ! $this->has_set_up_roles() || $force ) {
 			foreach ( $this->get_matomo_roles() as $role_name => $config ) {
-				add_role( $role_name, $config['name'], [ $config['defaultCap'] => true ] );
+				add_role( $role_name, $config['name'], $config['capabilities'] );
 			}
 			$this->mark_roles_set_up();
 		}

--- a/classes/WpMatomo/Roles.php
+++ b/classes/WpMatomo/Roles.php
@@ -39,8 +39,8 @@ class Roles {
 	 * Adds role capabilities to Matomo roles in case they changed
 	 * between Matomo for WordPress versions.
 	 *
-	 * Note: at the moment, we don't remove capbilities in case a user
-	 * has used a plugin to manipulate them.
+	 * Note: at the moment we don't remove capabilities that shouldn't
+	 * be there, in case a user has used another WP plugin to customize them.
 	 *
 	 * @return void
 	 */

--- a/classes/WpMatomo/Updater.php
+++ b/classes/WpMatomo/Updater.php
@@ -214,6 +214,8 @@ class Updater {
 		if ( $this->settings->should_disable_addhandler() ) {
 			wp_schedule_single_event( time() + 10, ScheduledTasks::EVENT_DISABLE_ADDHANDLER );
 		}
+
+		do_action( 'matomo_update' );
 	}
 
 	public function is_upgrade_in_progress() {

--- a/scripts/local-dev-entrypoint.sh
+++ b/scripts/local-dev-entrypoint.sh
@@ -549,6 +549,23 @@ EOF
   wp_new_post post "10-new-ways-to-whatever" "Learn 10 exciting new ways to WHATEVER!"
   wp_new_post post "why-use-our-stuff" "Why you should be using our stuff and whatnot!"
 
+  # create users with matomo roles
+  echo "adding test users..."
+  function wp_new_user() {
+    ROLE="${1}_role"
+    USERID="${1//_}user"
+    USEREMAIL="${USERID}@nowhere.com"
+
+    if ! /var/www/html/wp-cli.phar --path=/var/www/html/$WORDPRESS_FOLDER --allow-root --user=$WP_ADMIN_USER user exists "$USERID"; then
+      /var/www/html/wp-cli.phar --path=/var/www/html/$WORDPRESS_FOLDER --allow-root --user=$WP_ADMIN_USER user create "$USERID" "$USEREMAIL" --user_pass="$USERID" --role="$ROLE"
+    fi
+  }
+
+  wp_new_user matomo_view
+  wp_new_user matomo_write
+  wp_new_user matomo_admin
+  wp_new_user matomo_superuser
+
   # setup everything required for unit tests
   if [ "$WORDPRESS_VERSION" = "trunk" ]; then
     WORDPRESS_SVN_FOLDER="trunk"

--- a/tests/e2e/mwp-roles.e2e.ts
+++ b/tests/e2e/mwp-roles.e2e.ts
@@ -22,7 +22,7 @@ describe('MWP Roles', () => {
     it('should display the wordpress admin dashboard when the user has view access', async () => {
         await Website.login('matomoviewuser', 'matomoviewuser');
 
-        await $('#dashboard-widgets-wrap').waitForExist({ timeout: 60000 });
+        await $('form#your-profile').waitForExist({ timeout: 60000 });
 
         const menuItems = await browser.execute(() => {
             return window

--- a/tests/e2e/mwp-roles.e2e.ts
+++ b/tests/e2e/mwp-roles.e2e.ts
@@ -28,7 +28,7 @@ describe('MWP Roles', () => {
             return window
                 .jQuery('.wp-menu-name')
                 .toArray()
-                .map((e) => window.jQuery(e).text());
+                .map((e) => window.jQuery(e).text().trim());
         });
 
         expect(menuItems).toContain('Dashboard');
@@ -44,7 +44,7 @@ describe('MWP Roles', () => {
             return window
                 .jQuery('.wp-submenu a')
                 .toArray()
-                .map((e) => window.jQuery(e).text());
+                .map((e) => window.jQuery(e).text().trim());
         });
 
         expect(matomoMenuItems).toEqual(['Summary', 'Reporting', 'Help', 'Marketplace']);

--- a/tests/e2e/mwp-roles.e2e.ts
+++ b/tests/e2e/mwp-roles.e2e.ts
@@ -1,0 +1,57 @@
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ *
+ */
+
+import Website from './website.js';
+import SummaryPage from './pageobjects/mwp-admin/summary.page.js';
+import OverviewPage from './pageobjects/matomo-reporting/visitors/overview.page';
+
+describe('MWP Roles', () => {
+    before(async () => {
+        await Website.logout();
+    });
+
+    after(async () => {
+        await Website.login();
+    });
+
+    it('should display the wordpress admin dashboard when the user has view access', async () => {
+        await Website.login('matomoviewuser', 'matomoviewuser');
+
+        await $('#dashboard-widgets-wrap').waitForExist({ timeout: 60000 });
+
+        const menuItems = await browser.execute(() => {
+            return window
+                .jQuery('.wp-menu-name')
+                .toArray()
+                .map((e) => window.jQuery(e).text());
+        });
+
+        expect(menuItems).toContain('Dashboard');
+        expect(menuItems).toContain('Matomo Analytics');
+    });
+
+    it('should display MWP pages when the user has view access', async () => {
+        await SummaryPage.open();
+
+        await $('#dashboard-widgets canvas').waitForExist({ timeout: 60000 });
+
+        const matomoMenuItems = await browser.execute(() => {
+            return window
+                .jQuery('.wp-submenu a')
+                .toArray()
+                .map((e) => window.jQuery(e).text());
+        });
+
+        expect(matomoMenuItems).toEqual(['Summary', 'Reporting', 'Help', 'Marketplace']);
+    });
+
+    it('should display the Matomo backend correctly when the user has view access', async () => {
+        await OverviewPage.open();
+        await $('.dataTableVizEvolution').waitForExist({ timeout: 60000 });
+    });
+});

--- a/tests/e2e/website.ts
+++ b/tests/e2e/website.ts
@@ -68,7 +68,7 @@ class Website {
     this.site = siteSlug;
   }
 
-  async login() {
+  async login(user?: string, pass?: string) {
     if (this.loggedIn) {
       return;
     }
@@ -84,8 +84,8 @@ class Website {
           window.jQuery('#user_login').val(l);
           window.jQuery('#user_pass').val(p);
         },
-        process.env.WORDPRESS_USER_LOGIN || 'root',
-        process.env.WORDPRESS_USER_PASS || 'pass'
+        user || process.env.WORDPRESS_USER_LOGIN || 'root',
+        pass || process.env.WORDPRESS_USER_PASS || 'pass'
       );
       await $('#wp-submit').click();
 
@@ -95,6 +95,17 @@ class Website {
         }));
       }, { timeout: 60000 });
     });
+  }
+
+  async logout() {
+    const logoutLink = $('#wp-admin-bar-logout a');
+    if (await logoutLink.isExisting()) {
+        await browser.execute(() => {
+            window.jQuery('#wp-admin-bar-logout a')[0].click();
+        });
+
+        await $('#user_login').waitForExist({ timeout: 60000 });
+    }
   }
 
   async getWpNonce() {

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -11,6 +11,10 @@
  * @todo find why this warning is triggered
  * phpcs:disable WordPress.Security.EscapeOutput.DeprecatedWhitelistCommentFound
  */
+
+define( 'WP_DEBUG_LOG', true );
+define( 'WP_DEBUG_DISPLAY', false );
+
 $tests_dir = getenv( 'WP_TESTS_DIR' );
 
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -22,6 +22,8 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 
 	private $original_wpdb = null;
 
+	protected $overwrite_wpdb = true;
+
 	/**
 	 * The ROLLBACK executed by WP_UnitTestCase sometimes does not rollback to the correct
 	 * state, which causes succeeding tests to fail. (Specifically, it can revert to
@@ -37,7 +39,10 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->overwrite_wpdb();
+		if ( $this->overwrite_wpdb ) {
+			$this->overwrite_wpdb();
+		}
+
 		$this->set_ajax_die_handler();
 
 		if ( is_multisite() ) {
@@ -56,7 +61,10 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 		$this->wordpress_fixture->tear_down();
 
 		$this->remove_ajax_die_handler();
-		$this->restore_wpdb();
+
+		if ( $this->overwrite_wpdb ) {
+			$this->restore_wpdb();
+		}
 
 		parent::tearDown();
 

--- a/tests/phpunit/wpmatomo/db/test-wordpress.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpress.php
@@ -14,7 +14,14 @@ class DbWordPressTest extends MatomoAnalytics_TestCase {
 	private $db;
 
 	public function setUp(): void {
+		global $wpdb;
+
+		$this->overwrite_wpdb = false;
+
 		parent::setUp();
+
+		$wpdb->show_errors( false );
+
 		$this->db = new WordPress(
 			array(
 				'enable_ssl'     => false,

--- a/tests/phpunit/wpmatomo/db/test-wordpresstracker.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpresstracker.php
@@ -14,6 +14,8 @@ class DbWordPressTrackerTest extends MatomoAnalytics_TestCase {
 	private $db;
 
 	public function setUp(): void {
+		$this->overwrite_wpdb = false;
+
 		parent::setUp();
 		$this->db = new WordPress(
 			array(

--- a/tests/phpunit/wpmatomo/db/test-wordpresstracker.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpresstracker.php
@@ -14,9 +14,12 @@ class DbWordPressTrackerTest extends MatomoAnalytics_TestCase {
 	private $db;
 
 	public function setUp(): void {
+		global $wpdb;
+
 		$this->overwrite_wpdb = false;
 
 		parent::setUp();
+		$wpdb->suppress_errors( true );
 		$this->db = new WordPress(
 			array(
 				'enable_ssl'     => false,

--- a/tests/phpunit/wpmatomo/test-roles.php
+++ b/tests/phpunit/wpmatomo/test-roles.php
@@ -30,6 +30,40 @@ class RolesTest extends MatomoUnit_TestCase {
 		$this->assertHasMatomoRoles();
 	}
 
+	public function test_on_update_adds_any_missing_capabilities() {
+		$this->assertHasMatomoRoles();
+
+		$wp_roles = wp_roles();
+		$wp_roles->remove_cap( Roles::ROLE_VIEW, 'read' );
+		$wp_roles->add_cap( Roles::ROLE_WRITE, 'read', false );
+		$wp_roles->remove_cap( Roles::ROLE_ADMIN, 'view_admin_dashboard' );
+		$wp_roles->add_cap( Roles::ROLE_SUPERUSER, 'view_admin_dashboard', false );
+
+		// sanity check
+		try {
+			$this->assertHasMatomoRoles();
+			$this->fail( 'test did not succeed in removing capabilities' );
+		} catch ( \Exception $ex ) {
+			// ignore
+		}
+
+		$this->roles->on_update();
+
+		$this->assertHasMatomoRoles();
+	}
+
+	public function test_on_update_installs_roles_if_they_do_not_exist() {
+		$this->assertHasMatomoRoles();
+
+		$this->roles->uninstall();
+
+		$this->assertNotHasMatomoRoles();
+
+		$this->roles->on_update();
+
+		$this->assertHasMatomoRoles();
+	}
+
 	public function test_uninstall() {
 		$this->assertHasMatomoRoles();
 
@@ -92,9 +126,48 @@ class RolesTest extends MatomoUnit_TestCase {
 	}
 
 	private function assertHasMatomoRoles() {
-		$this->assertNotEmpty( get_role( Roles::ROLE_VIEW ) );
-		$this->assertNotEmpty( get_role( Roles::ROLE_WRITE ) );
-		$this->assertNotEmpty( get_role( Roles::ROLE_ADMIN ) );
-		$this->assertNotEmpty( get_role( Roles::ROLE_SUPERUSER ) );
+		$role = get_role( Roles::ROLE_VIEW );
+		$this->assertNotEmpty( $role );
+		$this->assertEquals(
+			[
+				Capabilities::KEY_VIEW => true,
+				'read'                 => true,
+				'view_admin_dashboard' => true,
+			],
+			$role->capabilities
+		);
+
+		$role = get_role( Roles::ROLE_WRITE );
+		$this->assertNotEmpty( $role );
+		$this->assertEquals(
+			[
+				Capabilities::KEY_WRITE => true,
+				'read'                  => true,
+				'view_admin_dashboard'  => true,
+			],
+			$role->capabilities
+		);
+
+		$role = get_role( Roles::ROLE_ADMIN );
+		$this->assertNotEmpty( $role );
+		$this->assertEquals(
+			[
+				Capabilities::KEY_ADMIN => true,
+				'read'                  => true,
+				'view_admin_dashboard'  => true,
+			],
+			$role->capabilities
+		);
+
+		$role = get_role( Roles::ROLE_SUPERUSER );
+		$this->assertNotEmpty( $role );
+		$this->assertEquals(
+			[
+				Capabilities::KEY_SUPERUSER => true,
+				'read'                      => true,
+				'view_admin_dashboard'      => true,
+			],
+			$role->capabilities
+		);
 	}
 }

--- a/tests/phpunit/wpmatomo/test-updater.php
+++ b/tests/phpunit/wpmatomo/test-updater.php
@@ -16,9 +16,14 @@ class UpdaterTest extends MatomoAnalytics_TestCase {
 	private $updater;
 
 	public function setUp(): void {
+		global $wpdb;
+
+		$this->overwrite_wpdb      = false;
 		$this->disable_temp_tables = true;
 
 		parent::setUp();
+
+		$wpdb->show_errors( false );
 
 		$this->updater = new Updater( new Settings() );
 	}


### PR DESCRIPTION
### Description:

Changes:
* Add read and view_admin_dashboard capabilities to Matomo for WordPress roles so users with those roles can view the WordPress admin dashboard and menu.
* Add hook that is executed when Matomo for WordPress updates.
* Use new update hook to add capabilities to existing roles on update.
* Add test users to local docker environment.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
