### PR TITLE
ensure environment re-bootstraps after environment is destroyed during multisite site switch

### DIFF
--- a/classes/WpMatomo/Bootstrap.php
+++ b/classes/WpMatomo/Bootstrap.php
@@ -171,5 +171,6 @@ class Bootstrap {
 
 		self::$environment_bootstrapped  = false;
 		self::$bootstrapped_by_wordpress = false;
+		self::$assume_not_bootstrapped   = true;
 	}
 }

--- a/tests/phpunit/wpmatomo/test-scheduled-tasks.php
+++ b/tests/phpunit/wpmatomo/test-scheduled-tasks.php
@@ -200,7 +200,7 @@ class ScheduledTasksTest extends MatomoAnalytics_TestCase {
 		switch_to_blog( $main_site );
 
 		$this->tasks->update_geo_ip2_db();
-		$this->assertEquals( 1, $this->geoip_update_call_count );
+		$this->assertEquals( 2, $this->geoip_update_call_count );
 	}
 
 	public function get_container_config_for_geoip_fail() {


### PR DESCRIPTION
### Description:

After destroying the Matomo environment when switching sites, since Matomo files will already be included, it will seem like Matomo is already bootstrapped. To make sure the Matomo environment is set up with the other site we must force the bootstrapping to take place again.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
