### PR TITLE
only instantiate woocommerce feature if woocommerce is available

### DIFF
--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -258,8 +258,11 @@ class WpMatomo {
 			$tracker = new AjaxTracker( self::$settings );
 
 			$sync_config = new SiteSync\SyncConfig( self::$settings );
-			$woocommerce = new Woocommerce( $tracker, self::$settings, $sync_config );
-			$woocommerce->register_hooks();
+
+			if ( function_exists( 'WC' ) ) {
+				$woocommerce = new Woocommerce( $tracker, self::$settings, $sync_config );
+				$woocommerce->register_hooks();
+			}
 
 			$easy_digital_downloads = new EasyDigitalDownloads( $tracker, self::$settings, $sync_config );
 			$easy_digital_downloads->register_hooks();


### PR DESCRIPTION
### Description:

As title.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
