### PR TITLE
workaround core issue 23601

### DIFF
--- a/classes/WpMatomo/AjaxTracker.php
+++ b/classes/WpMatomo/AjaxTracker.php
@@ -208,7 +208,8 @@ class AjaxTracker extends \MatomoTracker {
 			return;
 		}
 
-		$proxy_client_headers = $config->General['proxy_client_headers'];
+		$general = $config->General;
+		$proxy_client_headers = isset( $general['proxy_client_headers'] ) ? $general['proxy_client_headers'] : [];
 		if ( ! is_array( $proxy_client_headers ) ) {
 			$proxy_client_headers = [];
 		}

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -524,7 +524,8 @@ class Settings {
 		$user_agents = $this->get_global_option( self::GLOBAL_USER_AGENT_EXCLUSIONS );
 		if ( ! is_array( $user_agents ) ) {
 			// only bootstrap if we can't access the SitesManager API.
-			// if we always
+			// if we always bootstrap, it is possible to try initializing the FrontController before Matomo
+			// installation completes, which will fail.
 			if ( ! class_exists( \Piwik\Plugins\SitesManager\API::class ) ) {
 				Bootstrap::do_bootstrap();
 			}

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -14,6 +14,7 @@
 namespace WpMatomo;
 
 use Piwik\CliMulti\Process;
+use Piwik\Tracker\Cache;
 use WpMatomo\Admin\CookieConsent;
 use WpMatomo\Admin\TrackingSettings;
 
@@ -37,6 +38,7 @@ class Settings {
 	const DISABLE_ASYNC_ARCHIVING_OPTION_NAME  = 'matomo_disable_async_archiving';
 	const USE_SESSION_VISITOR_ID_OPTION_NAME   = 'use_session_visitor_id';
 	const SERVER_SIDE_TRACKING_DELAY_SECS      = 'server_side_tracking_delay_secs';
+	const GLOBAL_USER_AGENT_EXCLUSIONS         = 'global_user_agent_exclusions';
 
 	// NOTE: this is not a setting value, but is stored with setting values to avoid
 	// adding an extra get_option call to every WordPress backoffice request.
@@ -118,6 +120,7 @@ class Settings {
 		'maxmind_license_key'                      => '',
 		self::SHOW_GET_STARTED_PAGE                => 1,
 		self::DISABLE_ASYNC_ARCHIVING_OPTION_NAME  => false,
+		self::GLOBAL_USER_AGENT_EXCLUSIONS         => null,
 	];
 
 	/**
@@ -239,6 +242,10 @@ class Settings {
 		$this->settings_changed = [];
 
 		foreach ( $keys_changed as $key_changed ) {
+			if ( self::GLOBAL_USER_AGENT_EXCLUSIONS === $key_changed ) {
+				Cache::clearCacheGeneral();
+			}
+
 			do_action( 'matomo_setting_change_' . $key_changed );
 		}
 	}
@@ -506,5 +513,22 @@ class Settings {
 		}
 
 		return (int) $parts[0];
+	}
+
+	public function set_global_user_agent_exclusions( $user_agents ) {
+		Bootstrap::do_bootstrap();
+
+		$this->set_global_option( self::GLOBAL_USER_AGENT_EXCLUSIONS, $user_agents );
+	}
+
+	public function get_global_user_agent_exclusions() {
+		$user_agents = $this->get_global_option( self::GLOBAL_USER_AGENT_EXCLUSIONS );
+		if ( ! is_array( $user_agents ) ) {
+			Bootstrap::do_bootstrap();
+
+			$user_agents = \Piwik\Plugins\SitesManager\API::getInstance()->getExcludedUserAgentsGlobal();
+			$user_agents = explode( ',', $user_agents );
+		}
+		return $user_agents;
 	}
 }

--- a/classes/WpMatomo/Settings.php
+++ b/classes/WpMatomo/Settings.php
@@ -243,6 +243,7 @@ class Settings {
 
 		foreach ( $keys_changed as $key_changed ) {
 			if ( self::GLOBAL_USER_AGENT_EXCLUSIONS === $key_changed ) {
+				Bootstrap::do_bootstrap();
 				Cache::clearCacheGeneral();
 			}
 
@@ -516,15 +517,17 @@ class Settings {
 	}
 
 	public function set_global_user_agent_exclusions( $user_agents ) {
-		Bootstrap::do_bootstrap();
-
 		$this->set_global_option( self::GLOBAL_USER_AGENT_EXCLUSIONS, $user_agents );
 	}
 
 	public function get_global_user_agent_exclusions() {
 		$user_agents = $this->get_global_option( self::GLOBAL_USER_AGENT_EXCLUSIONS );
 		if ( ! is_array( $user_agents ) ) {
-			Bootstrap::do_bootstrap();
+			// only bootstrap if we can't access the SitesManager API.
+			// if we always
+			if ( ! class_exists( \Piwik\Plugins\SitesManager\API::class ) ) {
+				Bootstrap::do_bootstrap();
+			}
 
 			$user_agents = \Piwik\Plugins\SitesManager\API::getInstance()->getExcludedUserAgentsGlobal();
 			$user_agents = explode( ',', $user_agents );

--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -10,6 +10,7 @@
 namespace Piwik\Plugins\WordPress;
 
 use Exception;
+use Piwik\Access;
 use Piwik\API\Request;
 use Piwik\Common;
 use Piwik\Config;
@@ -73,7 +74,16 @@ class WordPress extends Plugin
             'Visualization.beforeRender' => 'onBeforeRenderView',
             'AssetManager.getStylesheetFiles'  => 'getStylesheetFiles',
             'Controller.CorePluginsAdmin.safemode.end' => 'modifySafemodeHtml',
+            'Tracker.setTrackerCacheGeneral' => ['function' => 'setTrackerCacheGeneral', 'after' => true],
         );
+    }
+
+    public function setTrackerCacheGeneral(&$cache)
+    {
+        $settings = WpMatomo::$settings ?: new Settings();
+        Access::doAsSuperUser(function () use(&$cache, $settings) { // see SitesManager::setTrackerCacheGeneral
+            $cache['global_excluded_user_agents'] = $settings->get_global_user_agent_exclusions();
+        });
     }
 
     public function allowUpdateSiteForMeasurableSettings($finalParameters)

--- a/tests/e2e/baseline/desktop_firefox/matomo-reporting.ecommerce.ecommerce-log.png
+++ b/tests/e2e/baseline/desktop_firefox/matomo-reporting.ecommerce.ecommerce-log.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d7de869a4d83a92ca359947f89b1e1c92b23dd12664ad4a15e9d93df58aa4523
-size 132768
+oid sha256:4f6d9d0f5e0fc5268a3893fe7e1a16a127168d92676e2ad13911991f0f4253c2
+size 132888

--- a/tests/e2e/baseline/desktop_firefox/matomo-reporting.visitors.visits-log.png
+++ b/tests/e2e/baseline/desktop_firefox/matomo-reporting.visitors.visits-log.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6a627813208bef45af7794257b55ee40a4a7bf197a3bd63d4ff5d9b887ad6d6
-size 251639
+oid sha256:61b0fa294ec16f71bf5790c2c1e6ad2944e027a983d332e57b9d90b9b8e0b1bb
+size 251148

--- a/tests/phpunit/wpmatomo/admin/test-exclusionsettings.php
+++ b/tests/phpunit/wpmatomo/admin/test-exclusionsettings.php
@@ -7,6 +7,7 @@ use Piwik\Plugins\SitesManager\API;
 use WpMatomo\Admin\ExclusionSettings;
 use WpMatomo\Capabilities;
 use WpMatomo\Admin\InvalidIpException;
+use WpMatomo\Settings;
 
 class AdminExclusionSettingsTest extends MatomoAnalytics_TestCase {
 
@@ -46,10 +47,12 @@ class AdminExclusionSettingsTest extends MatomoAnalytics_TestCase {
 		$this->exclusion_settings->show_settings();
 		$output = ob_get_clean();
 
+		$settings = new Settings();
+
 		// verify actually saved
 		$this->assertEquals( '127.0.0.1,127.0.0.2', API::getInstance()->getExcludedIpsGlobal() );
 		$this->assertEquals( 'test,test2', API::getInstance()->getExcludedQueryParametersGlobal() );
-		$this->assertEquals( 'firefox,safari', API::getInstance()->getExcludedUserAgentsGlobal() );
+		$this->assertEquals( [ 'firefox', 'safari' ], $settings->get_global_user_agent_exclusions() );
 		$this->assertNotEmpty( API::getInstance()->getKeepURLFragmentsGlobal() );
 	}
 

--- a/tests/phpunit/wpmatomo/test-settings.php
+++ b/tests/phpunit/wpmatomo/test-settings.php
@@ -6,7 +6,7 @@
 use WpMatomo\Admin\TrackingSettings;
 use WpMatomo\Settings;
 
-class SettingsTest extends MatomoUnit_TestCase {
+class SettingsTest extends MatomoAnalytics_TestCase {
 
 	/**
 	 * @var Settings
@@ -15,6 +15,8 @@ class SettingsTest extends MatomoUnit_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->create_set_super_admin();
 
 		$this->settings = $this->make_settings();
 	}
@@ -345,5 +347,68 @@ class SettingsTest extends MatomoUnit_TestCase {
 			[ '', 0 ],
 			[ null, 0 ],
 		];
+	}
+
+	public function test_excluded_user_agent_with_comma_can_be_saved_through_mwp() {
+		$user_agent        = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36';
+		$simple_user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:128.0) Gecko/20100101 Firefox/128.0';
+
+		$this->settings->set_global_user_agent_exclusions( [ $user_agent, $simple_user_agent ] );
+		$this->settings->save();
+
+		$settings2         = new Settings();
+		$saved_user_agents = $settings2->get_global_user_agent_exclusions();
+		$this->assertEquals( [ $user_agent, $simple_user_agent ], $saved_user_agents );
+	}
+
+	public function test_get_global_user_agent_exclusions_prioritizes_mwp_stored_user_agents() {
+		$user_agents = [ 'testuseragent', 'anothertestuseragent' ];
+		$user_agents = implode( ',', $user_agents );
+
+		\Piwik\Plugins\SitesManager\API::getInstance()->setGlobalExcludedUserAgents( $user_agents );
+
+		$other_user_agents = [ 'someotheruseragent', 'yetanotheruseragent' ];
+		$this->settings->set_global_user_agent_exclusions( $other_user_agents );
+		$this->settings->save();
+
+		$settings          = new Settings();
+		$saved_user_agents = $settings->get_global_user_agent_exclusions();
+
+		$this->assertEquals( $other_user_agents, $saved_user_agents );
+	}
+
+	public function test_get_global_user_agent_exclusions_defaults_to_matomo_stored_user_agents() {
+		$user_agents = [ 'testuseragent', 'anothertestuseragent' ];
+		$user_agents = implode( ',', $user_agents );
+
+		\Piwik\Plugins\SitesManager\API::getInstance()->setGlobalExcludedUserAgents( $user_agents );
+
+		$settings          = new Settings();
+		$saved_user_agents = $settings->get_global_user_agent_exclusions();
+
+		$this->assertEquals( $user_agents, $saved_user_agents );
+	}
+
+	public function test_excluded_user_agents_in_mwp_are_added_to_tracker_cache_general() {
+		$user_agents = [ 'testuseragent', 'anothertestuseragent' ];
+		$user_agents = implode( ',', $user_agents );
+
+		\Piwik\Plugins\SitesManager\API::getInstance()->setGlobalExcludedUserAgents( $user_agents );
+
+		$tracker_cache = \Piwik\Tracker\Cache::getCacheGeneral();
+		$this->assertEquals( [ 'testuseragent', 'anothertestuseragent' ], $tracker_cache['global_excluded_user_agents'] );
+
+		$other_user_agents = [ 'someotheruseragent', 'yetanotheruseragent' ];
+		$this->settings->set_global_user_agent_exclusions( $other_user_agents );
+		$this->settings->save();
+
+		WpMatomo::$settings->init_settings(); // force static Settings instance to reload data
+
+		// sanity check
+		$matomo_user_agents = \Piwik\Plugins\SitesManager\API::getInstance()->getExcludedUserAgentsGlobal();
+		$this->assertEquals( $user_agents, $matomo_user_agents );
+
+		$tracker_cache = \Piwik\Tracker\Cache::getCacheGeneral();
+		$this->assertEquals( $other_user_agents, $tracker_cache['global_excluded_user_agents'] );
 	}
 }

--- a/tests/phpunit/wpmatomo/test-settings.php
+++ b/tests/phpunit/wpmatomo/test-settings.php
@@ -386,7 +386,7 @@ class SettingsTest extends MatomoAnalytics_TestCase {
 		$settings          = new Settings();
 		$saved_user_agents = $settings->get_global_user_agent_exclusions();
 
-		$this->assertEquals( $user_agents, $saved_user_agents );
+		$this->assertEquals( [ 'testuseragent', 'anothertestuseragent' ], $saved_user_agents );
 	}
 
 	public function test_excluded_user_agents_in_mwp_are_added_to_tracker_cache_general() {


### PR DESCRIPTION
### Description:

Because of https://github.com/matomo-org/matomo/issues/23601, user agents with commas cannot be excluded from tracking. To workaround this issue, MWP now stores excluded user agents as an array with other MWP specific settings.

The Matomo setting will be used as a fallback if this new space is empty, so no data migration is needed.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
