### PR TITLE
add adblock detection to MWP admin pages

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -6,7 +6,12 @@
  * @package matomo
  */
 
+window.matomoAdminJsLoaded = true;
+
 window.jQuery(document).ready(function ($) {
+  // hide in case it was displayed while this file was loading
+  $('#matomo-adblocker-notice').removeClass('adblocker-found');
+
   // referral notice dismiss
   if (typeof mtmReferralDismissNoticeAjax !== 'undefined' && mtmReferralDismissNoticeAjax.ajax_url) {
     $(document).on( 'click', '#matomo-referral .notice-dismiss', function () {

--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // if accessed directly
 }
 
+use WpMatomo\Admin\AdBlockDetector;
 use WpMatomo\Admin\Admin;
 use WpMatomo\Admin\Chart;
 use WpMatomo\Admin\Dashboard;
@@ -64,6 +65,9 @@ class WpMatomo {
 		}
 
 		add_action( 'init', [ $this, 'init_plugin' ] );
+
+		$adblock_detector = new AdBlockDetector();
+		$adblock_detector->register_hooks();
 
 		$capabilities = new Capabilities( self::$settings );
 		$capabilities->register_hooks();

--- a/classes/WpMatomo/Admin/AdBlockDetector.php
+++ b/classes/WpMatomo/Admin/AdBlockDetector.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+namespace WpMatomo\Admin;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // if accessed directly
+}
+
+class AdBlockDetector {
+
+	public function register_hooks() {
+		if ( ! Admin::is_matomo_admin() ) {
+			return;
+		}
+
+		add_action( 'admin_head', [ $this, 'display_adblocker_notice' ] );
+	}
+
+	public function display_adblocker_notice() {
+		include __DIR__ . '/views/adblocker-notice.php';
+	}
+}

--- a/classes/WpMatomo/Admin/views/access.php
+++ b/classes/WpMatomo/Admin/views/access.php
@@ -7,7 +7,7 @@
  * @package matomo
  */
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+	exit; // if accessed directly
 }
 
 use WpMatomo\Access;

--- a/classes/WpMatomo/Admin/views/adblocker-notice.php
+++ b/classes/WpMatomo/Admin/views/adblocker-notice.php
@@ -23,18 +23,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 </style>
 <script>
 	window.addEventListener( 'DOMContentLoaded', function () {
-		function displayAdBlockNotice() {
-			if ( window.matomoAdminJsLoaded ) {
-				return;
-			}
-
-			var notice = document.querySelector( '#matomo-adblocker-notice' );
-			if ( notice ) {
-				notice.classList.add( 'adblocker-found' );
-			}
+		if ( window.matomoAdminJsLoaded ) {
+			return;
 		}
 
-		setTimeout(displayAdBlockNotice, 5000);
+		var notice = document.querySelector( '#matomo-adblocker-notice' );
+		if ( notice ) {
+			notice.classList.add( 'adblocker-found' );
+		}
 	} );
 </script>
 

--- a/classes/WpMatomo/Admin/views/adblocker-notice.php
+++ b/classes/WpMatomo/Admin/views/adblocker-notice.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<style>
+	#matomo-adblocker-notice {
+		display: none;
+	}
+
+	#matomo-adblocker-notice.adblocker-found {
+		display: block;
+	}
+</style>
+<script>
+	window.addEventListener( 'DOMContentLoaded', function () {
+		function displayAdBlockNotice() {
+			if ( window.matomoAdminJsLoaded ) {
+				return;
+			}
+
+			var notice = document.querySelector( '#matomo-adblocker-notice' );
+			if ( notice ) {
+				notice.classList.add( 'adblocker-found' );
+			}
+		}
+
+		setTimeout(displayAdBlockNotice, 5000);
+	} );
+</script>
+
+<div id="matomo-adblocker-notice" class="notice notice-error">
+	<p>
+		<strong><?php esc_html_e( 'Error', 'matomo' ); ?>:</strong>
+		<?php esc_html_e( 'In case you are using an ad blocker, please disable it for this site to make sure Matomo works without any issues.', 'matomo' ); ?>
+	</p>
+</div>


### PR DESCRIPTION
### Description

Fixes MWP-825

Changes:
* In admin.js file, set flag when script is loaded.
* In all MWP admin pages, output JS that checks on DOM ready if the flag is set. If not, an error is shown to users about their adblocker.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
