### PR TITLE
Fix: Prevent JSON pollution in WooCommerce Checkout

### DIFF
--- a/classes/WpMatomo/Ecommerce/Woocommerce.php
+++ b/classes/WpMatomo/Ecommerce/Woocommerce.php
@@ -122,8 +122,13 @@ class Woocommerce extends Base {
 		if ( 'pending' === $old_status && 'processing' === $new_status ) {
 			$this->logger->log( sprintf( 'Order ID = %s status changed from pending to processing, attempting to track it', $order_id ) );
 
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			echo $this->on_order( $order_id );
+			// Prevent echo during REST/AJAX to avoid JSON pollution
+			if ( ! ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				echo $this->on_order( $order_id );
+			} else {
+				$this->logger->log( 'Skipped echoing Matomo script: Request is REST/AJAX' );
+			}
 		}
 	}
 
@@ -158,8 +163,11 @@ class Woocommerce extends Base {
 					$order instanceof WC_Order
 					&& hash_equals( $order->get_order_key(), $order_key )
 				) {
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $this->on_order( $order_id );
+					// Prevent echo during REST/AJAX to avoid JSON pollution
+					if ( ! ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) ) {
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo $this->on_order( $order_id );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## **Issue: JSON Response Pollution in WooCommerce Checkout**

### **The Problem**

The Matomo for WordPress plugin currently breaks the WooCommerce Checkout specifically during "instant" transactions (e.g. 0.00 orders or 100% discount vouchers).

In these scenarios, WooCommerce processes the order via a REST API/AJAX request and expects a clean JSON response. However, Matomo's ecommerce logic triggers `echo` statements containing `<script>` tags during the order status transition. This "pollutes" the JSON payload, leading to a frontend parse error: *"There was an error processing your order."*

### **Technical Root Cause**

In `classes/WpMatomo/Ecommerce/Woocommerce.php`, the methods `on_order_status_change` and `maybe_track_order_complete` use `echo $this->on_order($order_id);`.
When the checkout is handled via the Store API (`/wc/store/v1/checkout`), these scripts are injected into the HTTP response body before or after the JSON object, making the response invalid.

### **The Proposed Fix**

Wrap the `echo` statements in a conditional check to ensure they only execute during standard template rendering and not during background API or AJAX requests.

**Code Logic:**

```php
if ( ! ( ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) ) ) {
    echo $this->on_order( $order_id );
}

```

### **Environment**

* **PHP Version:** 8.5.2
* **WordPress:** 6.9.1
* **WooCommerce:** 10.4.3