### PR TITLE
initialize AjaxTracker instance lazily

### DIFF
--- a/classes/WpMatomo/AIBotTracking.php
+++ b/classes/WpMatomo/AIBotTracking.php
@@ -65,8 +65,7 @@ class AIBotTracking {
 	 */
 	public function __construct( $settings, $tracker = null ) {
 		$this->settings = $settings;
-		$this->tracker  = isset( $tracker ) ? $tracker : new AjaxTracker( $settings );
-		$this->tracker->setRequestTimeout( 1 );
+		$this->tracker  = $tracker;
 	}
 
 	public function register_hooks() {
@@ -128,10 +127,11 @@ class AIBotTracking {
 			$url = AjaxTracker::getCurrentUrl();
 		}
 
-		$this->tracker->setUrl( $url );
+		$tracker = $this->get_tracker();
+		$tracker->setUrl( $url );
 
 		// cannot count bytes echo'd so no response size tracked
-		$this->tracker->doTrackPageViewIfAIBot( $response_code, null, $request_elapsed_ms, $source );
+		$tracker->doTrackPageViewIfAIBot( $response_code, null, $request_elapsed_ms, $source );
 	}
 
 	public function should_track_current_page() {
@@ -203,7 +203,10 @@ class AIBotTracking {
 			return false;
 		}
 
-		if ( ! AjaxTracker::isUserAgentAIBot( $this->tracker->userAgent ) ) {
+		$tracker = $this->get_tracker();
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		if ( ! AjaxTracker::isUserAgentAIBot( $tracker->userAgent ) ) {
 			return false;
 		}
 
@@ -215,5 +218,14 @@ class AIBotTracking {
 		}
 
 		return true;
+	}
+
+	private function get_tracker() {
+		if ( empty( $this->tracker ) ) {
+			$this->tracker = new AjaxTracker( $this->settings );
+			$this->tracker->setRequestTimeout( 1 );
+		}
+
+		return $this->tracker;
 	}
 }


### PR DESCRIPTION
### Description

AjaxTracker uses some WP functions that may not be usable when the AIBotTracking class is created. So we create it on demand to avoid any issues.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
