### PR TITLE
Fix fatal error from undefined AjaxTracker::isUserAgentAIBot() method

### DIFF
--- a/classes/WpMatomo/AIBotTracking.php
+++ b/classes/WpMatomo/AIBotTracking.php
@@ -195,6 +195,15 @@ class AIBotTracking {
 			return true;
 		}
 
+		// Check settings early to avoid calling methods that may not exist
+		// in the bundled MatomoTracker library (e.g. isUserAgentAIBot).
+		if (
+			! $this->settings->is_ai_bot_tracking_enabled()
+			|| ! $this->settings->is_tracking_enabled()
+		) {
+			return false;
+		}
+
 		if ( ! $this->should_track_current_page() ) {
 			return false;
 		}
@@ -206,13 +215,8 @@ class AIBotTracking {
 		$tracker = $this->get_tracker();
 
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		if ( ! AjaxTracker::isUserAgentAIBot( $tracker->userAgent ) ) {
-			return false;
-		}
-
-		if (
-			! $this->settings->is_ai_bot_tracking_enabled()
-			|| ! $this->settings->is_tracking_enabled()
+		if ( ! method_exists( AjaxTracker::class, 'isUserAgentAIBot' )
+			|| ! AjaxTracker::isUserAgentAIBot( $tracker->userAgent )
 		) {
 			return false;
 		}


### PR DESCRIPTION
## Summary

After updating to 5.8.0, our site started returning HTTP 500 on every frontend page. `AIBotTracking::is_doing_ai_bot_tracking_this_request()` calls `AjaxTracker::isUserAgentAIBot()`, but that method doesn't exist in the shipped `AjaxTracker` or its parent `MatomoTracker`. Fresh re-upload of 5.8.0 files didn't help -- the method just isn't there.

### 🐛 Bug Fixes

- Moved the `is_ai_bot_tracking_enabled()` / `is_tracking_enabled()` settings check above the `isUserAgentAIBot()` call in `is_doing_ai_bot_tracking_this_request()`. The `track_ai_bots` setting defaults to `false`, but the old code hit the undefined method before it ever checked the setting, so the fatal error fired even with the feature turned off.
- Added a `method_exists()` guard around the `isUserAgentAIBot()` call. If somebody does enable AI bot tracking but the bundled tracker library still doesn't have the method, the code skips tracking instead of crashing the site.

### 🔧 Technical details

The call chain is: `wp_footer` hook -> `do_ai_bot_tracking()` -> `is_doing_ai_bot_tracking_this_request()` -> crash at line 209. The `AIBotTracking` class is instantiated unconditionally in `WpMatomo.php` (no guard on the setting), and `register_hooks()` always adds the `wp_footer` action. So every frontend page load hits the broken code path.

Error:
```
Fatal error: Uncaught Error: Call to undefined method WpMatomo\AjaxTracker::isUserAgentAIBot()
in classes/WpMatomo/AIBotTracking.php:209
```

### 🔬 Test Plan

- [ ] Confirm site no longer returns HTTP 500 on frontend pages
- [ ] Confirm AI bot tracking still works if the method gets added to MatomoTracker in a future update
- [ ] Verify no regressions in standard Matomo tracking

### 📝 Additional Notes

This is a minimal, non-breaking fix. The settings check was already in the method -- it just needed to run earlier. The `method_exists()` guard is there as a safety net so this kind of thing can't take down a site again.

The longer-term fix is probably shipping the `isUserAgentAIBot()` method in the bundled `matomo-php-tracker` library.

### 🔗 Related Issues

- Closes #1380