### PR TITLE
[CRITICAL BREAKING] Fix class name concatenation for version check

### DIFF
--- a/classes/WpMatomo/Admin/Admin.php
+++ b/classes/WpMatomo/Admin/Admin.php
@@ -86,7 +86,7 @@ class Admin extends Feature {
 		$version       = count( $version_parts ) > 1 ? $version_parts[0] : $raw_version;
 
 		if ( version_compare( $version, '7.0', '>=' ) ) {
-			$classes .= 'mtm-wp-gte-7';
+			$classes .= ' mtm-wp-gte-7';
 		}
 
 		return $classes;


### PR DESCRIPTION
### Description

5.10.1 introduced a breaking change. By adding the `mtm-wp-gte-7` class without a "space", the WordPress FSE no longer displays correctly, instead the admin menu gets displayed over the FSE, and the FSE get's pushed off-screen to the right. 

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
