### PR TITLE
fix two issues in matomo/wordpress auth bridge

### DIFF
--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -42,8 +42,21 @@ class Auth extends \Piwik\Plugins\Login\Auth
         $isUserLoggedIn = function_exists('is_user_logged_in') && is_user_logged_in();
         if ($isUserLoggedIn) {
 	        if (is_null($this->login) && empty($this->hashedPassword)) {
+                $current_user = wp_get_current_user();
+
 	            // api authentication using token
-		        return parent::authenticate();
+		        $result = parent::authenticate();
+                // the Matomo login is derived from (and may differ from) the WP user_login, so we
+                // compare the token's identity against the current user's mapped Matomo login.
+                if (
+                    $result
+                    && $result->getIdentity()
+                    && $current_user
+                    && $current_user->ID
+                    && User::get_matomo_user_login($current_user->ID) === $result->getIdentity()
+                ) {
+                    return $result;
+                }
 	        }
         } else if ($this->isAppPasswordInTokenAuthAllowed()) {
             $result = $this->authApiWithTokenAuthAppPassword();

--- a/plugins/WordPress/WpPasswordVerifier.php
+++ b/plugins/WordPress/WpPasswordVerifier.php
@@ -11,6 +11,8 @@ namespace Piwik\Plugins\WordPress;
 
 use Piwik\Piwik;
 use Piwik\Plugins\Login\PasswordVerifier;
+use Piwik\Plugins\UsersManager\Model;
+use WpMatomo\User;
 
 if (!defined( 'ABSPATH')) {
     exit; // if accessed directly
@@ -26,19 +28,15 @@ class WpPasswordVerifier extends PasswordVerifier
 		 */
 		Piwik::postEvent('Login.beforeLoginCheckAllowed');
 
-		if (function_exists('is_user_logged_in')
-			&& is_user_logged_in()
-		) {
-			$user = wp_get_current_user();
-			// check if this password is the login's password
-			// wp_authenticate should make sure that lockout/brute force feature by security plugins are used etc
-			$authenticatedUser = wp_authenticate($user->user_login, $password);
-			if ($authenticatedUser
-			       && $authenticatedUser instanceof \WP_User
-			       && $authenticatedUser->ID
-			       && $authenticatedUser->ID === $user->ID) {
+		// find the WP user for the given matomo user
+		$wpUser = $this->findWordPressUser($userLogin);
+		if ($wpUser instanceof \WP_User && $wpUser->ID) {
+			// wp_authenticate makes sure lockout/brute force features by security plugins are applied etc
+			$authenticatedUser = wp_authenticate($wpUser->user_login, $password);
+			if ($authenticatedUser instanceof \WP_User
+				&& (int) $authenticatedUser->ID === (int) $wpUser->ID) {
 				return true;
-			};
+			}
 		}
 
 		/**
@@ -48,5 +46,36 @@ class WpPasswordVerifier extends PasswordVerifier
 		Piwik::postEvent('Login.recordFailedLoginAttempt');
 
 		return false;
+	}
+
+	private function findWordPressUser($matomoLogin)
+	{
+		if (empty($matomoLogin) || !function_exists('get_user_by')) {
+			return null;
+		}
+
+		// common case: the Matomo login is identical to the WordPress user_login.
+		$wpUser = get_user_by('login', $matomoLogin);
+		if (
+            $wpUser instanceof \WP_User
+			&& $matomoLogin === User::get_matomo_user_login($wpUser->ID)
+        ) {
+			return $wpUser;
+		}
+
+		// the Matomo login may have been sanitized/truncated/prefixed and differ from the WP
+		// user_login, so fall back to resolving it via the (shared) email of the Matomo user.
+		$matomoUser = (new Model())->getUser($matomoLogin);
+		if (!empty($matomoUser['email'])) {
+			$wpUser = get_user_by('email', $matomoUser['email']);
+			if (
+                $wpUser instanceof \WP_User
+				&& $matomoLogin === User::get_matomo_user_login($wpUser->ID)
+            ) {
+				return $wpUser;
+			}
+		}
+
+		return null;
 	}
 }

--- a/tests/phpunit/plugins/WordPress/test-auth.php
+++ b/tests/phpunit/plugins/WordPress/test-auth.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\WordPress\Auth;
+use WpMatomo\User;
+
+/**
+ * @package matomo
+ */
+class WordPressAuthTest extends MatomoAnalytics_TestCase {
+
+	public function test_authenticate_succeeds_when_token_belongs_to_the_logged_in_user() {
+		$wp_user_id = $this->create_mapped_user( 'testuser', 'testuser@example.com', 'testuser' );
+		$token      = $this->create_token_for( 'testuser' );
+
+		wp_set_current_user( $wp_user_id );
+
+		$result = $this->authenticate_with_token( $token );
+
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'testuser', $result->getIdentity() );
+	}
+
+	public function test_authenticate_succeeds_when_matomo_login_differs_from_wp_username() {
+		// WP user 'testuser2' is mapped to a renamed Matomo login 'wp_testuser2'. The token belongs to 'wp_testuser2',
+		// so authentication must succeed even though it does not match the WP user_login.
+		$wp_user_id = $this->create_mapped_user( 'testuser2', 'testuser2@example.com', 'wp_testuser2' );
+		$token      = $this->create_token_for( 'wp_testuser2' );
+
+		wp_set_current_user( $wp_user_id );
+
+		$result = $this->authenticate_with_token( $token );
+
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'wp_testuser2', $result->getIdentity() );
+	}
+
+	public function test_authenticate_rejects_a_token_belonging_to_a_different_user() {
+		$testuser_id = $this->create_mapped_user( 'testuser', 'testuser@example.com', 'testuser' );
+		$this->create_mapped_user( 'testuser3', 'testuser3@example.com', 'testuser3' );
+		$testuser3_token = $this->create_token_for( 'testuser3' );
+
+		// logged in as testuser, but presenting testuser3's token_auth
+		wp_set_current_user( $testuser_id );
+
+		$result = $this->authenticate_with_token( $testuser3_token );
+
+		$this->assertFalse( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'anonymous', $result->getIdentity() );
+	}
+
+	public function test_authenticate_is_anonymous_when_no_user_is_logged_in() {
+		$this->create_mapped_user( 'testuser', 'testuser@example.com', 'testuser' );
+		$token = $this->create_token_for( 'testuser' );
+
+		wp_set_current_user( 0 );
+
+		$result = $this->authenticate_with_token( $token );
+
+		$this->assertFalse( $result->wasAuthenticationSuccessful() );
+	}
+
+	private function authenticate_with_token( $token ) {
+		$auth = new Auth();
+		$auth->setLogin( null );
+		$auth->setPassword( null );
+		$auth->setTokenAuth( $token );
+		return $auth->authenticate();
+	}
+
+	private function create_mapped_user( $wp_login, $email, $matomo_login ) {
+		// use a role the user sync ignores so it doesn't auto-create a Matomo user (which would
+		// otherwise occupy the email and conflict with the user we create below; email is unique).
+		$wp_user_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => $wp_login,
+				'user_email' => $email,
+			)
+		);
+
+		$model = new Model();
+
+		// make sure no other Matomo user already holds this (unique) email.
+		$existing = $model->getUserByEmail( $email );
+		if ( ! empty( $existing['login'] ) && $existing['login'] !== $matomo_login ) {
+			$model->deleteUserOnly( $existing['login'] );
+		}
+
+		if ( ! $model->getUser( $matomo_login ) ) {
+			$model->addUser( $matomo_login, md5( 'pwd-' . $matomo_login ), $email, '2020-01-01 00:00:00' );
+		}
+
+		User::map_matomo_user_login( $wp_user_id, $matomo_login );
+
+		return $wp_user_id;
+	}
+
+	private function create_token_for( $matomo_login ) {
+		$model = new Model();
+		$token = $model->generateRandomTokenAuth();
+		$model->addTokenAuth( $matomo_login, $token, 'test token', '2020-01-01 00:00:00' );
+		return $token;
+	}
+}

--- a/tests/phpunit/plugins/WordPress/test-wppasswordverifier.php
+++ b/tests/phpunit/plugins/WordPress/test-wppasswordverifier.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\WordPress\WpPasswordVerifier;
+use WpMatomo\User;
+
+/**
+ * @package matomo
+ */
+class WpPasswordVerifierTest extends MatomoAnalytics_TestCase {
+
+	/**
+	 * @var WpPasswordVerifier
+	 */
+	private $verifier;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->verifier = new WpPasswordVerifier();
+	}
+
+	public function test_returns_true_for_correct_password_when_matomo_login_matches_wp_username() {
+		$this->create_mapped_user( 'testuser', 'testuser@example.com', 'testpassword', 'testuser' );
+
+		$this->assertTrue( $this->verifier->isPasswordCorrect( 'testuser', 'testpassword' ) );
+	}
+
+	public function test_returns_false_for_incorrect_password() {
+		$this->create_mapped_user( 'testuser', 'testuser@example.com', 'testpassword', 'testuser' );
+
+		$this->assertFalse( $this->verifier->isPasswordCorrect( 'testuser', 'wrong-password' ) );
+	}
+
+	public function test_returns_true_for_correct_password_when_matomo_login_differs_from_wp_username() {
+		// the Matomo login ('wp_testuser') was sanitized/prefixed and differs from the WP user_login
+		// ('testuser'); it must still be resolved (via the shared email) and the password verified.
+		$this->create_mapped_user( 'testuser', 'testuser@example.com', 'secret-pass', 'wp_testuser' );
+
+		$this->assertTrue( $this->verifier->isPasswordCorrect( 'wp_testuser', 'secret-pass' ) );
+	}
+
+	public function test_returns_false_for_incorrect_password_when_matomo_login_differs_from_wp_username() {
+		$this->create_mapped_user( 'testuser', 'testuser@example.com', 'secret-pass', 'wp_testuser' );
+
+		$this->assertFalse( $this->verifier->isPasswordCorrect( 'wp_testuser', 'wrong-password' ) );
+	}
+
+	public function test_returns_false_for_unknown_login() {
+		$this->assertFalse( $this->verifier->isPasswordCorrect( 'this-login-does-not-exist', 'whatever' ) );
+	}
+
+	public function test_returns_false_for_empty_login() {
+		$this->assertFalse( $this->verifier->isPasswordCorrect( '', 'whatever' ) );
+	}
+
+	/**
+	 * Creates a WordPress user and a Matomo user (sharing the same email) mapped to the given Matomo
+	 * login.
+	 */
+	private function create_mapped_user( $wp_login, $email, $password, $matomo_login ) {
+		// use a role the user sync ignores so it doesn't auto-create a Matomo user (which would
+		// otherwise occupy the email and conflict with the user we create below).
+		$wp_user_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => $wp_login,
+				'user_email' => $email,
+				'user_pass'  => $password,
+			)
+		);
+
+		$model = new Model();
+
+		// make sure no other Matomo user already holds this (unique) email.
+		$existing = $model->getUserByEmail( $email );
+		if ( ! empty( $existing['login'] ) && $existing['login'] !== $matomo_login ) {
+			$model->deleteUserOnly( $existing['login'] );
+		}
+
+		if ( ! $model->getUser( $matomo_login ) ) {
+			$model->addUser( $matomo_login, md5( 'pwd-' . $matomo_login ), $email, '2020-01-01 00:00:00' );
+		}
+
+		User::map_matomo_user_login( $wp_user_id, $matomo_login );
+
+		return $wp_user_id;
+	}
+}


### PR DESCRIPTION
### Description

Changes:
* make sure token auth authentication is not possible outside of the current WP session
* make sure PasswordVerifier checks the password of the given user, not the currently logged in user

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
