### PR TITLE
ensure only valid archiving requests are invoked directly in onSendHttpRequestBy

### DIFF
--- a/plugins/WordPress/WordPress.php
+++ b/plugins/WordPress/WordPress.php
@@ -27,6 +27,7 @@ use Piwik\Plugins\WordPress\Workaround\ProcessedReportForceShortDateFormat;
 use Piwik\Plugins\WordPress\Workaround\ProcessedReportInnerCallHooks;
 use Piwik\Scheduler\Task;
 use Piwik\Url;
+use Piwik\UrlHelper;
 use Piwik\Version;
 use Piwik\Widget\WidgetsList;
 use WpMatomo;
@@ -329,15 +330,8 @@ class WordPress extends Plugin
     		return;
 	    }
 
-        if ((strpos($url, 'module=API&method=API.get') !== false
-             && strpos($url, '&trigger=archivephp') !== false
-             && Url::isValidHost(parse_url($url, PHP_URL_HOST)))
-            ||
-            (strpos($url, 'module=API&method=CoreAdminHome.archiveReports') !== false
-             && strpos($url, '&trigger=archivephp') !== false
-             && Url::isValidHost(parse_url($url, PHP_URL_HOST)))
-        ) {
-            // archiving query... we avoid issueing an http request for many reasons...
+        if ($this->isLocalArchivingApiRequest($url)) {
+            // archiving query... we avoid issuing an http request for many reasons...
             // eg user might be using self signed certificate and request fails
             // eg http requests may not be allowed
             // eg because the WP user wouldn't be logged in the auth wouldn't work
@@ -347,7 +341,7 @@ class WordPress extends Plugin
             	WordPress::$is_archiving = true;
             	// refs #118 because there is no actual user when archiving there is also no token etc
                 $urlQuery = parse_url($url, PHP_URL_QUERY);
-                $request = new Request($urlQuery, array('serialize' => 1));
+                $request = new Request($urlQuery, ['serialize' => 1]);
                 $response = $request->process();
 	            WordPress::$is_archiving = false;
             });
@@ -396,6 +390,50 @@ class WordPress extends Plugin
             $headers = $headers->getAll();
         }
         $response = wp_remote_retrieve_body($wpResponse);
+    }
+
+    /**
+     * @param string $url
+     * @return bool
+     */
+    private function isLocalArchivingApiRequest($url)
+    {
+        $host = parse_url($url, PHP_URL_HOST);
+        if (!Url::isValidHost($host)) {
+            return false;
+        }
+
+        $urlQuery = parse_url($url, PHP_URL_QUERY);
+        if ($urlQuery === null || $urlQuery === '') {
+            return false;
+        }
+
+        // parse with the SAME parser the dispatcher (Piwik\API\Request) uses. parse_str and
+        // UrlHelper::getArrayFromQueryString disagree on URL-encoded key names — parse_str
+        // decodes %6dethod to method, getArrayFromQueryString does not — so validating with
+        // parse_str while the dispatcher reads getArrayFromQueryString lets an attacker show
+        // one method to the check and run another.
+        $query = UrlHelper::getArrayFromQueryString($urlQuery);
+
+        if (($query['module'] ?? null) !== 'API') {
+            return false;
+        }
+        if (($query['trigger'] ?? null) !== 'archivephp') {
+            return false;
+        }
+
+        // allowlist of archive methods, all other methods are denied
+        $allowedMethods = ['API.get', 'CoreAdminHome.archiveReports'];
+        if (!in_array($query['method'] ?? null, $allowedMethods, true)) {
+            return false;
+        }
+
+        // deny attempt at bulk requests if found
+        if (array_key_exists('urls', $query)) {
+            return false;
+        }
+
+        return true;
     }
 
     public function onGenerateReportEnd()

--- a/tests/phpunit/plugins/WordPress/test-wordpress.php
+++ b/tests/phpunit/plugins/WordPress/test-wordpress.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+use Piwik\Access;
+use Piwik\DataTable;
+use Piwik\Plugin\Manager;
+use Piwik\Plugins\API\API;
+use Piwik\Plugins\CoreAdminHome\API as CoreAdminHomeAPI;
+
+/**
+ * @package matomo
+ * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+ */
+class WordPressTest extends MatomoAnalytics_SharedFixture_TestCase {
+
+	/**
+	 * @var \Piwik\Plugins\WordPress\WordPress
+	 */
+	private $plugin;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->plugin = Manager::getInstance()->getLoadedPlugin( 'WordPress' );
+		$this->assertNotEmpty( $this->plugin, 'WordPress plugin must be loaded to test its HTTP hook.' );
+
+		// short-circuit every outbound HTTP request for non-archiving requests.
+		// (onSendHttpRequestBy uses wp_remote_request() when the request doesn't look
+		// like an archiving request).
+		add_filter( 'pre_http_request', [ $this, 'stub_http_response' ], 10, 3 );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', [ $this, 'stub_http_response' ] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * pre_http_request filter: returns a canned non-200 response so rejected URLs never
+	 * reach the network.
+	 */
+	public function stub_http_response( $preempt, $parsed_args, $url ) {
+		return [
+			'headers'  => [],
+			'body'     => '',
+			'response' => [
+				'code'    => 503,
+				'message' => 'stubbed for test',
+			],
+		];
+	}
+
+	public function test_onSendHttpRequestBy_should_dispatch_legitimate_api_get_archive_url() {
+		// short circuit API.get to skip archiving (slow and uneeded for this test)
+		API::setSingletonInstance( $this->make_api_get_stub() );
+
+		$url = 'http://localhost/wp-admin/admin.php?page=matomo-reporting&format=json'
+			. '&module=API&method=API.get&idSite=1&period=day&date=today&trigger=archivephp';
+
+		$result = $this->invoke_onSendHttpRequestBy( $url );
+
+		$this->assertSame( 200, $result['status'] );
+		$this->assertEquals( '[]', $result['response'] );
+
+		// superuser access shouldn't leak out of the method
+		$this->assertFalse( Access::getInstance()->hasSuperUserAccess() );
+	}
+
+	public function test_onSendHttpRequestBy_should_dispatch_legitimate_coreadminhome_archive_reports_url() {
+		// short circuit CoreAdminHome.archiveReports to skip archiving (slow and uneeded for this test)
+		CoreAdminHomeAPI::setSingletonInstance( $this->make_coreadminhome_archive_stub() );
+
+		$url = 'http://localhost/wp-admin/admin.php?page=matomo-reporting'
+			. '&module=API&method=CoreAdminHome.archiveReports&idSite=1&period=day&date=today&trigger=archivephp';
+
+		$result = $this->invoke_onSendHttpRequestBy( $url );
+
+		$this->assertSame( 200, $result['status'] );
+		$this->assertNotEmpty( $result['response'] );
+
+		// superuser access shouldn't leak out of the method
+		$this->assertFalse( Access::getInstance()->hasSuperUserAccess() );
+	}
+
+	public function test_onSendHttpRequestBy_should_not_dispatch_crafted_duplicate_method_url_as_super_user() {
+		$url = 'http://localhost/wp-admin/admin.php?page=matomo-reporting'
+			. '&module=API&method=API.get&trigger=archivephp'
+			. '&method=API.getBulkRequest&urls[]=method%3DAPI.getMatomoVersion';
+
+		$result = $this->invoke_onSendHttpRequestBy( $url );
+
+		$this->assert_is_wp_remote_stub_response( $result );
+
+		// superuser access shouldn't leak out of the method
+		$this->assertFalse( Access::getInstance()->hasSuperUserAccess() );
+	}
+
+	public function test_onSendHttpRequestBy_rejects_getbulkrequest_method_alone() {
+		$url = 'http://localhost/wp-admin/admin.php?page=matomo-reporting'
+			. '&module=API&method=API.getBulkRequest&trigger=archivephp'
+			. '&urls[]=method%3DAPI.getMatomoVersion';
+
+		$result = $this->invoke_onSendHttpRequestBy( $url );
+
+		$this->assert_is_wp_remote_stub_response( $result );
+		$this->assertFalse( Access::getInstance()->hasSuperUserAccess() );
+	}
+
+	public function test_onSendHttpRequestBy_rejects_encoded_duplicate_method_key_instead_of_bypassing_allowlist() {
+		$url = 'http://localhost/wp-admin/admin.php?page=matomo-reporting'
+			. '&module=API&method=API.getMatomoVersion&%6dethod=API.get&trigger=archivephp';
+
+		$result = $this->invoke_onSendHttpRequestBy( $url );
+
+		$this->assert_is_wp_remote_stub_response( $result );
+		$this->assertFalse( Access::getInstance()->hasSuperUserAccess() );
+	}
+
+	private function make_api_get_stub() {
+		$container = \Piwik\Container\StaticContainer::getContainer();
+		return new class(
+			$container->get( \Piwik\Plugin\SettingsProvider::class ),
+			$container->get( \Piwik\Plugins\API\ProcessedReport::class )
+		) extends API {
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			public function get( $idSite, $period, $date, $segment = \false, $columns = \false ) {
+				return new DataTable();
+			}
+		};
+	}
+
+	private function make_coreadminhome_archive_stub() {
+		$container = \Piwik\Container\StaticContainer::getContainer();
+		return new class(
+			$container->get( \Piwik\Scheduler\Scheduler::class ),
+			$container->get( \Piwik\Archive\ArchiveInvalidator::class ),
+			$container->get( \Piwik\Tracker\Failures::class ),
+			$container->get( \Piwik\Plugins\CoreAdminHome\OptOutManager::class )
+		) extends CoreAdminHomeAPI {
+			// phpcs:ignore PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.intFound, WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			public function archiveReports( int $idSite, string $period, string $date, $segment = \false, $plugin = \false, $report = \false ) {
+				return [
+					'idarchives' => [],
+					'nb_visits'  => 0,
+				];
+			}
+		};
+	}
+
+	private function invoke_onSendHttpRequestBy( $url ) {
+		$response = null;
+		$status   = null;
+		$headers  = null;
+
+		// full $params so the generic HTTP fall-through does not raise undefined-index
+		// warnings (the test error handler turns those into exceptions).
+		$params = [
+			'headers'         => [],
+			'httpMethod'      => 'GET',
+			'timeout'         => 1,
+			'body'            => '',
+			'userAgent'       => null,
+			'destinationPath' => null,
+		];
+
+		$threw = null;
+		try {
+			$this->plugin->onSendHttpRequestBy( $url, $params, $response, $status, $headers );
+		} catch ( Exception $e ) {
+			// rejected URLs fall through to wp_remote_request which is expected to fail
+			// (it points at a closed port).
+			$threw = $e;
+		}
+
+		return [
+			'response'  => $response,
+			'status'    => $status,
+			'headers'   => $headers,
+			'exception' => $threw,
+		];
+	}
+
+	private function assert_bulk_request_response_not_present( $response ) {
+		if ( null === $response || '' === $response ) {
+			$this->assertTrue( true );
+			return;
+		}
+
+		$this->assertStringNotContainsString( '<row>', $response );
+		$this->assertStringNotContainsString( '<result>', $response );
+		$this->assertStringNotContainsString( '"result"', $response );
+	}
+
+	private function assert_is_wp_remote_stub_response( $result ) {
+		$this->assertNotSame( 200, $result['status'] );
+		$this->assert_bulk_request_response_not_present( $result['response'] );
+	}
+}

--- a/tests/phpunit/wpmatomo/db/test-wordpress.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpress.php
@@ -6,7 +6,7 @@
 use Piwik\Common;
 use Piwik\Db\Adapter\WordPress;
 
-class DbWordPressTest extends MatomoAnalytics_TestCase {
+class DbWordPressTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var WordPress

--- a/tests/phpunit/wpmatomo/db/test-wordpress.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpress.php
@@ -282,10 +282,14 @@ class DbWordPressTest extends MatomoAnalytics_SharedFixture_TestCase {
 		\Piwik\Config::getInstance()->database['schema'] = 'Mariadb';
 		\Piwik\Db\Schema::unsetInstance();
 
-		$params         = new \Piwik\ArchiveProcessor\Parameters(
-			new \Piwik\Site( 1 ),
-			\Piwik\Period\Factory::build( 'day', 'today' ),
-			new \Piwik\Segment( '', [ 1 ] )
+		$params         = \Piwik\Access::doAsSuperUser(
+			function () {
+				return new \Piwik\ArchiveProcessor\Parameters(
+					new \Piwik\Site( 1 ),
+					\Piwik\Period\Factory::build( 'day', 'today' ),
+					new \Piwik\Segment( '', [ 1 ] )
+				);
+			}
 		);
 		$log_aggregator = new \Piwik\DataAccess\LogAggregator( $params );
 


### PR DESCRIPTION
### Description

As title. Refs AS-605.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
