### PR TITLE
several bug fixes around user and site sync + more test optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 == Changelog ===
 
+= 5.12.2 =
+* Bug fix: removing users from a blog did not correctly remove Matomo permissions. Matomo
+  permissions stayed valid until the daily sync executed.
+* Security: after authentication, if a user has more Matomo capabilities than their WP
+  capabilities allow, correct the user access row and only grant what their WP capabilities
+  allow.
+* Bug fix: multisite syncing and other functionality was broken for multisite installs
+  with > 100 sites.
+* Bug fix: make sure access syncing occurs when a user is granted superuser access and
+  if superuser access is revoked.
+* Bug fix: make sure user syncing can occur in REST, XML RPC and other non-frontend requests.
+* Bug fix: make sure site syncing can occur in REST, XML RPC and other non-frontend requests.
+* Bug fix: when saving user assigned WP role => matomo permission mappings, only sync changes
+  with Matomo after the changes are finalized in WordPress (or nothing gets synced until the
+  daily user sync).
+* Bug fix: drop Matomo tables and the WP => Matomo site mapping when a site is deleted in WP.
+* Bug fix: ensure Matomo capabilities are correctly assigned to users in safe mode.
+* Reliability: better handling of potential failures during the user and site sync processes.
+* Bug fix: make sure site and user syncing occur when a WP blog is restored (and Matomo is
+  activated for it).
+
 = 5.12.1 =
 * Security: remove unneeded token auth authentication path for Matomo API from WordPress/Auth.
 

--- a/assets/js/asset_manager_core_js.js
+++ b/assets/js/asset_manager_core_js.js
@@ -1,4 +1,4 @@
-/* Matomo Javascript - cb=bfbec82f15f35ee35eb7cd81014c1d0d*/
+/* Matomo Javascript - cb=0f897732ee5a0a9c0d482d299ca994fa*/
 
 /*!
  * Matomo - free/libre analytics platform

--- a/assets/js/asset_manager_core_js.js
+++ b/assets/js/asset_manager_core_js.js
@@ -1,4 +1,4 @@
-/* Matomo Javascript - cb=0f897732ee5a0a9c0d482d299ca994fa*/
+/* Matomo Javascript - cb=bfbec82f15f35ee35eb7cd81014c1d0d*/
 
 /*!
  * Matomo - free/libre analytics platform

--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -42,7 +42,7 @@ use WpMatomo\User\Sync as UserSync;
 
 class WpMatomo {
 
-	const VERSION = '5.12.1';
+	const VERSION = '5.12.2';
 
 	/**
 	 * @var \WpMatomo\Feature[]

--- a/classes/WpMatomo.php
+++ b/classes/WpMatomo.php
@@ -196,16 +196,25 @@ class WpMatomo {
 		}
 	}
 
+	/**
+	 * @param Settings $settings
+	 * @return \WpMatomo\Feature[]
+	 */
+	public static function get_safe_mode_features( $settings ) {
+		// being able to determine who has what access to Matomo is always necessary
+		$features = [ new Capabilities( $settings ) ];
+
+		if ( is_admin() ) {
+			$features[] = new Admin( $settings );
+			$features[] = new \WpMatomo\Admin\SafeModeMenu( $settings );
+		}
+
+		return $features;
+	}
+
 	private function get_all_features() {
 		if ( self::is_safe_mode() ) {
-			if ( is_admin() ) {
-				return [
-					new Admin( self::$settings ),
-					new \WpMatomo\Admin\SafeModeMenu( self::$settings ),
-				];
-			}
-
-			return [];
+			return self::get_safe_mode_features( self::$settings );
 		}
 
 		$site_config = new SiteSync\SyncConfig( self::$settings );

--- a/classes/WpMatomo/Access.php
+++ b/classes/WpMatomo/Access.php
@@ -60,10 +60,12 @@ class Access {
 		// synced across sites when the plugin is network activated
 		$this->settings->apply_changes( [ Settings::OPTION_KEY_CAPS_ACCESS => $caps_to_store ] );
 
+		// wp_roles_init must be invoked for the change to be finalized. the user sync will then
+		// read the WP roles to update user access
+		$wp_roles->init_roles();
+
 		$sync = new Sync();
 		$sync->sync_current_users();
-
-		$wp_roles->init_roles();
 
 		if ( $this->settings->is_network_enabled() ) {
 			// we do this in the background syncing across all sites...

--- a/classes/WpMatomo/Admin/views/info_multisite.php
+++ b/classes/WpMatomo/Admin/views/info_multisite.php
@@ -51,17 +51,38 @@ if ( ! defined( 'ABSPATH' ) ) {
 </p>
 
 <h2><?php esc_html_e( 'Matomo sites', 'matomo' ); ?></h2>
+<?php
+$matomo_sites_limit = 100;
+$matomo_sites       = [];
+$matomo_sites_total = 0;
+
+if ( function_exists( 'get_sites' ) ) {
+	$matomo_sites       = get_sites( [ 'number' => $matomo_sites_limit ] );
+	$matomo_sites_total = (int) get_sites( [ 'count' => true ] );
+}
+?>
 <ul class="matomo-list">
 	<?php
-	if ( function_exists( 'get_sites' ) ) {
-		foreach ( get_sites() as $matomo_site ) {
-			/** @var WP_Site $matomo_site */
-			switch_to_blog( $matomo_site->blog_id );
-			if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'matomo/matomo.php' ) ) {
-				echo '<li><a href="' . esc_url( admin_url( 'admin.php?page=matomo-reporting' ) ) . '">' . esc_html( $matomo_site->blogname ) . ' (Site ID: ' . esc_html( $matomo_site->blog_id ) . ')</a></li>';
-			}
-			restore_current_blog();
+	foreach ( $matomo_sites as $matomo_site ) {
+		/** @var WP_Site $matomo_site */
+		switch_to_blog( $matomo_site->blog_id );
+		if ( function_exists( 'is_plugin_active' ) && is_plugin_active( 'matomo/matomo.php' ) ) {
+			echo '<li><a href="' . esc_url( admin_url( 'admin.php?page=matomo-reporting' ) ) . '">' . esc_html( $matomo_site->blogname ) . ' (Site ID: ' . esc_html( $matomo_site->blog_id ) . ')</a></li>';
 		}
+		restore_current_blog();
 	}
 	?>
 </ul>
+<?php if ( $matomo_sites_total > $matomo_sites_limit ) : ?>
+	<p>
+		<?php
+		echo esc_html(
+			sprintf(
+				__( 'Note: only the first %1$s of %2$s sites in this network were checked.', 'matomo' ),
+				number_format_i18n( $matomo_sites_limit ),
+				number_format_i18n( $matomo_sites_total )
+			)
+		);
+		?>
+	</p>
+<?php endif; ?>

--- a/classes/WpMatomo/Capabilities.php
+++ b/classes/WpMatomo/Capabilities.php
@@ -212,26 +212,6 @@ class Capabilities extends Feature {
 		return false === $rank ? 0 : $rank + 1;
 	}
 
-	/**
-	 * Whether Matomo capabilities can be resolved for a user in this request. They cannot in safe
-	 * mode, where this feature is not registered and user_can() would report that nobody, not even
-	 * an administrator, has any Matomo capability.
-	 *
-	 * @return bool
-	 */
-	public static function is_capability_check_available() {
-		if ( ! class_exists( '\WpMatomo' ) ) {
-			return false;
-		}
-
-		$capabilities = \WpMatomo::get_active_feature( self::class );
-		if ( empty( $capabilities ) ) {
-			return false;
-		}
-
-		return false !== has_filter( 'user_has_cap', [ $capabilities, 'add_capabilities_to_user' ] );
-	}
-
 	protected function has_any_higher_permission( $cap_to_find, $allcaps ) {
 		$all_caps = $this->get_all_capabilities_sorted_by_highest_permission();
 		if ( ! in_array( $cap_to_find, $all_caps, true ) ) {

--- a/classes/WpMatomo/Capabilities.php
+++ b/classes/WpMatomo/Capabilities.php
@@ -42,6 +42,12 @@ class Capabilities extends Feature {
 	const KEY_STEALTH   = 'stealth_matomo';
 
 	/**
+	 * Matomo has Role classes for view/write/admin, but superuser access is a flag on the user
+	 * rather than a role, so there is no Matomo constant to reuse for it.
+	 */
+	const ROLE_SUPERUSER = 'superuser';
+
+	/**
 	 * @var Settings
 	 */
 	private $settings;
@@ -158,12 +164,72 @@ class Capabilities extends Feature {
 	}
 
 	public function get_all_capabilities_sorted_by_highest_permission() {
+		return array_keys( self::get_capability_role_map() );
+	}
+
+	/**
+	 * The Matomo access each Matomo capability corresponds to, highest permission first.
+	 *
+	 * The values are Matomo role IDs (Piwik\Access\Role\Admin::ID and friends), spelled out
+	 * literally because this map is reached from the user_has_cap filter, long before Matomo is
+	 * bootstrapped and those classes can be loaded. WpMatomoCapabilitiesTest asserts they match.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function get_capability_role_map() {
 		return [
-			self::KEY_SUPERUSER,
-			self::KEY_ADMIN,
-			self::KEY_WRITE,
-			self::KEY_VIEW,
+			self::KEY_SUPERUSER => self::ROLE_SUPERUSER,
+			self::KEY_ADMIN     => 'admin',
+			self::KEY_WRITE     => 'write',
+			self::KEY_VIEW      => 'view',
 		];
+	}
+
+	/**
+	 * @param int|\WP_User $user
+	 * @return string|null a Matomo role ID or self::ROLE_SUPERUSER, null when they are entitled to
+	 *                     no access at all
+	 */
+	public static function get_highest_role_for_user( $user ) {
+		foreach ( self::get_capability_role_map() as $capability => $role ) {
+			if ( user_can( $user, $capability ) ) {
+				return $role;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param string|null $role
+	 * @return int
+	 */
+	public static function get_role_ranking( $role ) {
+		$roles = array_reverse( array_values( self::get_capability_role_map() ) );
+
+		$rank = array_search( $role, $roles, true );
+
+		return false === $rank ? 0 : $rank + 1;
+	}
+
+	/**
+	 * Whether Matomo capabilities can be resolved for a user in this request. They cannot in safe
+	 * mode, where this feature is not registered and user_can() would report that nobody, not even
+	 * an administrator, has any Matomo capability.
+	 *
+	 * @return bool
+	 */
+	public static function is_capability_check_available() {
+		if ( ! class_exists( '\WpMatomo' ) ) {
+			return false;
+		}
+
+		$capabilities = \WpMatomo::get_active_feature( self::class );
+		if ( empty( $capabilities ) ) {
+			return false;
+		}
+
+		return false !== has_filter( 'user_has_cap', [ $capabilities, 'add_capabilities_to_user' ] );
 	}
 
 	protected function has_any_higher_permission( $cap_to_find, $allcaps ) {

--- a/classes/WpMatomo/Commands/MatomoCommands.php
+++ b/classes/WpMatomo/Commands/MatomoCommands.php
@@ -175,7 +175,9 @@ class MatomoCommands extends WP_CLI_Command {
 			$importer = new Importer( $logger );
 			if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_sites' ) ) {
 				$id_blog = ! empty( $assoc_args['blog'] ) ? $assoc_args['blog'] : null;
-				foreach ( get_sites() as $site ) {
+				// number => 0 means no limit. WP_Site_Query defaults to 100, which would silently
+				// skip importing into every blog after that
+				foreach ( get_sites( [ 'number' => 0 ] ) as $site ) {
 					/** @var WP_Site $site */
 					if ( is_null( $id_blog ) || ( $site->blog_id === $id_blog ) ) {
 						switch_to_blog( $site->blog_id );
@@ -214,7 +216,9 @@ class MatomoCommands extends WP_CLI_Command {
 	 */
 	public function update( $args, $assoc_args ) {
 		if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_sites' ) ) {
-			foreach ( get_sites() as $site ) {
+			// number => 0 means no limit. WP_Site_Query defaults to 100, which would silently leave
+			// every blog after that un-updated
+			foreach ( get_sites( [ 'number' => 0 ] ) as $site ) {
 				/** @var WP_Site $site */
 				switch_to_blog( $site->blog_id );
 				// this way we make sure all blogs get updated eventually

--- a/classes/WpMatomo/Db/Settings.php
+++ b/classes/WpMatomo/Db/Settings.php
@@ -104,14 +104,9 @@ class Settings {
 			$table_names[] = array_shift( $table_name_to_look_for );
 		}
 
-		$table_names_to_look_for = $this->get_matomo_tables();
-
-		foreach ( range( 2010, gmdate( 'Y' ) + 1 ) as $year ) {
-			foreach ( range( 1, 12 ) as $month ) {
-				$table_names_to_look_for[] = 'archive_numeric_' . $year . '_' . str_pad( $month, 2, '0' );
-				$table_names_to_look_for[] = 'archive_blob_' . $year . '_' . str_pad( $month, 2, '0' );
-			}
-		}
+		// filter and code that adds tables to the list of installed tables kept here for
+		// backwards compatibility
+		$table_names_to_look_for = [];
 		$table_names_to_look_for = apply_filters( 'matomo_install_tables', $table_names_to_look_for );
 
 		foreach ( $table_names_to_look_for as $table_name_to_look_for ) {

--- a/classes/WpMatomo/Db/Settings.php
+++ b/classes/WpMatomo/Db/Settings.php
@@ -99,7 +99,10 @@ class Settings {
 
 		$table_names = [];
 
-		$tables = $wpdb->get_results( 'SHOW TABLES LIKE "' . $this->prefix_table_name() . '%"', ARRAY_N );
+		$tables = $wpdb->get_results(
+			$wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $this->prefix_table_name() ) . '%' ),
+			ARRAY_N
+		);
 		foreach ( $tables as $table_name_to_look_for ) {
 			$table_names[] = array_shift( $table_name_to_look_for );
 		}

--- a/classes/WpMatomo/Request.php
+++ b/classes/WpMatomo/Request.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+namespace WpMatomo;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // if accessed directly
+}
+
+class Request {
+
+	/**
+	 * Returns whether this is a plain front end page view, as opposed to wp-admin (which includes
+	 * admin-ajax.php and admin-post.php), the REST API, WP-CLI, XML-RPC or cron.
+	 *
+	 * Note REST_REQUEST is only defined once rest_api_loaded() runs on parse_request, so a REST
+	 * request is indistinguishable from a front end one before then.
+	 *
+	 * @return bool
+	 */
+	public static function is_frontend() {
+		if ( is_admin() ) {
+			return false;
+		}
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return false;
+		}
+
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return false;
+		}
+
+		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+			return false;
+		}
+
+		return ! wp_doing_cron();
+	}
+}

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -21,6 +21,7 @@ use WpMatomo\Bootstrap;
 use WpMatomo\Feature;
 use WpMatomo\Installer;
 use WpMatomo\Logger;
+use WpMatomo\Request;
 use WpMatomo\Settings;
 use WpMatomo\Site;
 use WpMatomo\Site\Sync\SyncConfig;
@@ -57,8 +58,11 @@ class Sync extends Feature {
 		$this->config_sync = new SyncConfig( $settings );
 	}
 
-	public function is_active() {
-		return is_admin();
+	/**
+	 * @return bool
+	 */
+	private function is_sync_allowed_for_request() {
+		return ! Request::is_frontend();
 	}
 
 	public function register_hooks() {
@@ -71,6 +75,15 @@ class Sync extends Feature {
 	}
 
 	public function sync_current_site_ignore_error() {
+		if ( ! $this->is_sync_allowed_for_request() ) {
+			return;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			// these hooks are not admin only, so this may run somewhere wp-admin/includes is not loaded
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( ! is_plugin_active( 'matomo/matomo.php' ) ) {
 			// @see https://github.com/matomo-org/matomo-for-wordpress/issues/577
 			return;

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -18,6 +18,7 @@ use Piwik\Plugins\SitesManager;
 use Piwik\Plugins\SitesManager\Model;
 use WP_Site;
 use WpMatomo\Bootstrap;
+use WpMatomo\Db\Settings as DbSettings;
 use WpMatomo\Feature;
 use WpMatomo\Installer;
 use WpMatomo\Logger;
@@ -72,6 +73,31 @@ class Sync extends Feature {
 		add_action( 'update_option_timezone_string', [ $this, 'sync_current_site_ignore_error' ] );
 		add_action( 'matomo_setting_change_track_ecommerce', [ $this, 'sync_current_site_ignore_error' ] );
 		add_action( 'matomo_setting_change_site_currency', [ $this, 'sync_current_site_ignore_error' ] );
+		add_filter( 'wpmu_drop_tables', [ $this, 'on_drop_blog_tables' ], 10, 2 );
+		add_action( 'wp_delete_site', [ $this, 'on_delete_site' ], 10, 1 );
+	}
+
+	/**
+	 * @param string[] $tables
+	 * @param int      $blog_id
+	 *
+	 * @return string[]
+	 */
+	public function on_drop_blog_tables( $tables, $blog_id ) {
+		$matomo_tables = ( new DbSettings() )->get_installed_matomo_tables();
+
+		$this->logger->log( sprintf( 'Matomo will drop %s tables of deleted blog %s', count( $matomo_tables ), $blog_id ) );
+
+		return array_merge( (array) $tables, $matomo_tables );
+	}
+
+	/**
+	 * remove the matomo site mapping when a site is deleted
+	 *
+	 * @param WP_Site $old_site
+	 */
+	public function on_delete_site( $old_site ) {
+		Site::map_matomo_site_id( $old_site->id, null );
 	}
 
 	public function sync_current_site_ignore_error() {

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -36,7 +36,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
  */
 class Sync extends Feature {
-	const MAX_LENGTH_SITE_NAME = 90;
+	const MAX_LENGTH_SITE_NAME        = 90;
+	const MAKE_UNDELETE_BLOG_PRIORITY = 10;
 
 	/**
 	 * @var Logger
@@ -75,6 +76,27 @@ class Sync extends Feature {
 		add_action( 'matomo_setting_change_site_currency', [ $this, 'sync_current_site_ignore_error' ] );
 		add_filter( 'wpmu_drop_tables', [ $this, 'on_drop_blog_tables' ], 10, 2 );
 		add_action( 'wp_delete_site', [ $this, 'on_delete_site' ], 10, 1 );
+		add_action( 'make_undelete_blog', [ $this, 'on_undelete_blog' ], self::MAKE_UNDELETE_BLOG_PRIORITY, 1 );
+	}
+
+	/**
+	 * @param int $blog_id
+	 */
+	public function on_undelete_blog( $blog_id ) {
+		if ( ! $this->is_sync_allowed_for_request() ) {
+			return;
+		}
+
+		switch_to_blog( $blog_id );
+
+		try {
+			$this->sync_current_site();
+		} catch ( Exception $e ) {
+			// restoring a blog must not fail because Matomo could not be synced for it
+			$this->logger->log_exception( 'sync_site', $e );
+		}
+
+		restore_current_blog();
 	}
 
 	/**

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -127,6 +127,7 @@ class Sync extends Feature {
 						if ( $installer->can_be_installed() ) {
 							$installer->install();
 						} else {
+							$this->logger->log( sprintf( 'Matomo cannot be installed for blog: %s, skipping it.', $site->blog_id ) );
 							continue;
 						}
 					}

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -89,7 +89,9 @@ class Sync extends Feature {
 		Bootstrap::do_bootstrap();
 
 		if ( is_multisite() && function_exists( 'get_sites' ) ) {
-			foreach ( get_sites() as $site ) {
+			// number => 0 means no limit. WP_Site_Query defaults to 100, which would silently leave
+			// every blog after that without a Matomo site
+			foreach ( get_sites( [ 'number' => 0 ] ) as $site ) {
 				if ( 1 === (int) $site->deleted ) {
 					continue;
 				}

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -89,12 +89,7 @@ class Sync extends Feature {
 
 		switch_to_blog( $blog_id );
 
-		try {
-			$this->sync_current_site();
-		} catch ( Exception $e ) {
-			// restoring a blog must not fail because Matomo could not be synced for it
-			$this->logger->log_exception( 'sync_site', $e );
-		}
+		$this->sync_current_site_ignore_error();
 
 		restore_current_blog();
 	}

--- a/classes/WpMatomo/Site/Sync.php
+++ b/classes/WpMatomo/Site/Sync.php
@@ -180,10 +180,11 @@ class Sync extends Feature {
 					$success = false;
 					// we don't want to rethrow exception otherwise some other blogs might never sync
 					$this->logger->log( 'Matomo error syncing site: ' . $e->getMessage() );
+				} finally {
+					restore_current_blog();
 				}
 
 				$succeed_all = $succeed_all && $success;
-				restore_current_blog();
 			}
 		} else {
 			$success     = $this->sync_current_site();

--- a/classes/WpMatomo/Uninstaller.php
+++ b/classes/WpMatomo/Uninstaller.php
@@ -153,14 +153,19 @@ class Uninstaller {
 
 		$db_settings      = new \WpMatomo\Db\Settings();
 		$installed_tables = $db_settings->get_installed_matomo_tables();
+
+		if ( empty( $installed_tables ) ) {
+			return;
+		}
+
 		$this->logger->log( sprintf( 'Matomo will now drop %s matomo tables', count( $installed_tables ) ) );
 
+		$quoted_tables = [];
 		foreach ( $installed_tables as $table_name ) {
-			// temporary table are used in tests and just making sure they are being removed
-			// $wpdb->query( "DROP TEMPORARY TABLE IF EXISTS `$tableName`" );
-			// two spaces between drop and table so it won't be replaced in WP tests
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
-			$wpdb->query( "DROP TABLE IF EXISTS `$table_name`" );
+			$quoted_tables[] = '`' . $table_name . '`';
 		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
+		$wpdb->query( 'DROP TABLE IF EXISTS ' . implode( ', ', $quoted_tables ) );
 	}
 }

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -182,7 +182,7 @@ class Sync extends Feature {
 		switch_to_blog( $blog_id );
 
 		try {
-			$this->sync_current_users();
+			$this->sync_current_users_1000();
 		} catch ( Exception $e ) {
 			// restoring a blog must not fail because Matomo could not be synced for it
 			$this->logger->log_exception( 'user_sync', $e );

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -294,20 +294,24 @@ class Sync extends Feature {
 			function () use ( $user_model, $wp_user, $wp_user_id, $idsite ) {
 				$mapped_matomo_login = User::get_matomo_user_login( $wp_user_id );
 
-				$access = $this->sync_user_access( $wp_user, $idsite, $user_model );
-
-				if ( $access['login'] ) {
-					// the user still legitimately has access here, eg. a network super admin who is
-					// no longer a member of this blog
-					if ( $access['is_superuser'] ) {
-						$user_model->setSuperUserAccess( $access['login'], true );
-					}
-
+				$has_access = (bool) $this->sync_user_access_for_site( $wp_user, $idsite, $user_model );
+				if ( $has_access ) { // user has access
 					return;
 				}
 
-				if ( $mapped_matomo_login && ! $user_model->getSiteAccessCount( $mapped_matomo_login ) ) {
-					// user has access to no sites, delete the user also
+				// user has no access but was never mapped originally, and thus has no matomo user
+				if ( ! $mapped_matomo_login ) {
+					return;
+				}
+
+				// user still exists in matomo but has no access to matomo when determined by
+				// WP roles
+
+				// user does not have super user access (otherwise, a login would have been returned above)
+				$user_model->setSuperUserAccess( $mapped_matomo_login, false );
+
+				// user may still have access to other sites, but if they don't, delete the user entirely
+				if ( ! $user_model->getSiteAccessCount( $mapped_matomo_login ) ) {
 					$this->delete_matomo_user( $user_model, $mapped_matomo_login );
 				}
 			}
@@ -497,7 +501,6 @@ class Sync extends Feature {
 
 		$this->logger->log( 'Matomo will now sync ' . count( $users ) . ' users' );
 
-		$super_users                  = [];
 		$logins_with_some_view_access = [ 'anonmyous' ]; // may or may not exist... we don't want to delete this user though
 		$user_model                   = new Model();
 
@@ -508,16 +511,10 @@ class Sync extends Feature {
 			// todo if we used transactions we could commit it after a possibly new access has been added
 			// to prevent UI preventing randomly saying no access between deleting and adding access
 
-			$access = $this->sync_user_access( $user, $idsite, $user_model );
-
-			$matomo_login = $access['login'];
+			$matomo_login = $this->sync_user_access_for_site( $user, $idsite, $user_model );
 
 			if ( $matomo_login ) {
 				$logins_with_some_view_access[] = $matomo_login;
-
-				if ( $access['is_superuser'] ) {
-					$super_users[ $matomo_login ] = $user;
-				}
 
 				$locale = get_user_locale( $user->ID );
 				$lang   = self::get_matomo_lang_from_locale( $locale );
@@ -557,10 +554,6 @@ class Sync extends Feature {
 			}
 		}
 
-		foreach ( $super_users as $matomo_login => $user ) {
-			$user_model->setSuperUserAccess( $matomo_login, true );
-		}
-
 		$logins_with_some_view_access = array_unique( $logins_with_some_view_access );
 		$all_users                    = $user_model->getUsers( [] );
 		foreach ( $all_users as $all_user ) {
@@ -582,19 +575,24 @@ class Sync extends Feature {
 	 * @param int|string $idsite
 	 * @param Model      $user_model
 	 *
-	 * @return array{login: string|null, is_superuser: bool} login is null when the user should have
-	 *                                                       no access to this site at all
+	 * @return string|null matomo login or null when the user has no access
 	 */
-	protected function sync_user_access( $user, $idsite, $user_model ) {
+	protected function sync_user_access_for_site( $user, $idsite, $user_model ) {
 		$mapped_matomo_login = User::get_matomo_user_login( $user->ID );
 
 		$role = Capabilities::get_highest_role_for_user( $user );
 
 		if ( Capabilities::ROLE_SUPERUSER === $role ) {
-			return [
-				'login'        => $this->ensure_user_exists( $user ),
-				'is_superuser' => true,
-			];
+			$matomo_login = $this->ensure_user_exists( $user );
+
+			$user_model->setSuperUserAccess( $matomo_login, true );
+
+			// superuser_access already grants every site, so a per site row is redundant here. Left
+			// behind it outlives the superuser flag and goes on granting this site by itself, and it
+			// keeps getSiteAccessCount() non zero, which is what stops the identity being cleaned up
+			$user_model->deleteUserAccess( $matomo_login, [ $idsite ] );
+
+			return $matomo_login;
 		}
 
 		if ( null === $role ) {
@@ -602,10 +600,7 @@ class Sync extends Feature {
 				$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
 			}
 
-			return [
-				'login'        => null,
-				'is_superuser' => false,
-			];
+			return null;
 		}
 
 		$matomo_login = $this->ensure_user_exists( $user );
@@ -613,10 +608,7 @@ class Sync extends Feature {
 		$user_model->addUserAccess( $matomo_login, $role, [ $idsite ] );
 		$user_model->setSuperUserAccess( $matomo_login, false );
 
-		return [
-			'login'        => $matomo_login,
-			'is_superuser' => false,
-		];
+		return $matomo_login;
 	}
 
 	/**

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -317,7 +317,7 @@ class Sync extends Feature {
 
 		Access::doAsSuperUser(
 			function () use ( $user_model, $wp_user, $wp_user_id, $idsite ) {
-				$mapped_matomo_login = User::get_matomo_user_login( $wp_user_id );
+				$mapped_matomo_login = $this->get_own_matomo_user_login( $wp_user_id );
 
 				$has_access = (bool) $this->sync_user_access_for_site( $wp_user, $idsite, $user_model );
 				if ( $has_access ) { // user has access
@@ -346,11 +346,34 @@ class Sync extends Feature {
 	}
 
 	/**
+	 * Returns the matomo login mapped to the given user, if and only if the matomo login
+	 * is not currently mapped to another user. (should not normally happen unless in a
+	 * corrupted state)
+	 *
+	 * @param int $wp_user_id
+	 * @return string|null
+	 */
+	private function get_own_matomo_user_login( $wp_user_id ) {
+		$matomo_login = User::get_matomo_user_login( $wp_user_id );
+
+		if ( ! $matomo_login || $this->is_matomo_login_owned_by_other_wp_user( $matomo_login, $wp_user_id ) ) {
+			return null;
+		}
+
+		return $matomo_login;
+	}
+
+	/**
 	 * @param int $wp_user_id
 	 */
 	private function delete_matomo_user_for_current_blog( $wp_user_id ) {
-		$matomo_login = User::get_matomo_user_login( $wp_user_id );
+		$matomo_login = $this->get_own_matomo_user_login( $wp_user_id );
 		if ( ! $matomo_login ) {
+			// either never mapped, or the login belongs to another WP user.
+			// should not delete the matomo user in this case. instead we remove the
+			// corrupted mapping.
+			User::map_matomo_user_login( $wp_user_id, null );
+
 			return;
 		}
 
@@ -363,6 +386,13 @@ class Sync extends Feature {
 				$this->delete_matomo_user( $user_model, $matomo_login );
 			}
 		);
+
+		// in case a token somehow has been created for the user, invalidate the
+		// tracker cache so it will not be used in the tracker
+		$idsite = Site::get_matomo_site_id( get_current_blog_id() );
+		if ( $idsite ) {
+			$this->invalidate_tracker_cache( $idsite );
+		}
 	}
 
 	/**
@@ -648,7 +678,7 @@ class Sync extends Feature {
 	 * @return string|null matomo login or null when the user has no access
 	 */
 	protected function sync_user_access_for_site( $user, $idsite, $user_model ) {
-		$mapped_matomo_login = User::get_matomo_user_login( $user->ID );
+		$mapped_matomo_login = $this->get_own_matomo_user_login( $user->ID );
 
 		$role = Capabilities::get_highest_role_for_user( $user );
 

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -76,6 +76,7 @@ class Sync extends Feature {
 		add_action( 'add_user_to_blog', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
 		add_action( 'remove_user_from_blog', [ $this, 'on_remove_user_from_blog' ], $prio = 10, $args = 2 );
 		add_action( 'clean_user_cache', [ $this, 'on_clean_user_cache' ], $prio = 10, $args = 1 );
+		add_action( 'deleted_user', [ $this, 'on_deleted_user' ], $prio = 10, $args = 1 );
 		add_action( 'user_register', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
 		add_action( 'granted_super_admin', [ $this, 'on_super_admin_change' ], $prio = 10, $args = 1 );
 		add_action( 'revoked_super_admin', [ $this, 'on_super_admin_change' ], $prio = 10, $args = 1 );
@@ -94,6 +95,7 @@ class Sync extends Feature {
 		remove_action( 'add_user_to_blog', [ $this, 'sync_current_users_1000' ], 10 );
 		remove_action( 'remove_user_from_blog', [ $this, 'on_remove_user_from_blog' ], 10 );
 		remove_action( 'clean_user_cache', [ $this, 'on_clean_user_cache' ], 10 );
+		remove_action( 'deleted_user', [ $this, 'on_deleted_user' ], 10 );
 		remove_action( 'user_register', [ $this, 'sync_current_users_1000' ], 10 );
 		remove_action( 'granted_super_admin', [ $this, 'on_super_admin_change' ], 10 );
 		remove_action( 'revoked_super_admin', [ $this, 'on_super_admin_change' ], 10 );
@@ -140,6 +142,28 @@ class Sync extends Feature {
 		unset( $this->pending_removals[ $wp_user_id ][ $blog_id ] );
 
 		$this->sync_user_for_current_blog( $wp_user_id );
+	}
+
+	/**
+	 * @param int $wp_user_id
+	 */
+	public function on_deleted_user( $wp_user_id ) {
+		if ( ! $this->is_sync_allowed_for_request() ) {
+			return;
+		}
+
+		if ( get_userdata( $wp_user_id ) ) {
+			// user still exists, do not delete user from matomo (edge case that can happen
+			// on multisite installs)
+			return;
+		}
+
+		try {
+			$this->delete_matomo_user_for_current_blog( $wp_user_id );
+		} catch ( Exception $e ) {
+			// deleting a WordPress user must not fail because the Matomo cleanup did
+			$this->logger->log_exception( 'user_sync', $e );
+		}
 	}
 
 	/**
@@ -288,12 +312,42 @@ class Sync extends Feature {
 
 				if ( $mapped_matomo_login && ! $user_model->getSiteAccessCount( $mapped_matomo_login ) ) {
 					// user has access to no sites, delete the user also
-					$user_model->deleteUserOnly( $mapped_matomo_login );
-					$user_model->deleteUserOptions( $mapped_matomo_login );
-					$user_model->deleteUserAccess( $mapped_matomo_login );
+					$this->delete_matomo_user( $user_model, $mapped_matomo_login );
 				}
 			}
 		);
+	}
+
+	/**
+	 * @param int $wp_user_id
+	 */
+	private function delete_matomo_user_for_current_blog( $wp_user_id ) {
+		$matomo_login = User::get_matomo_user_login( $wp_user_id );
+		if ( ! $matomo_login ) {
+			return;
+		}
+
+		Bootstrap::do_bootstrap();
+
+		$user_model = new Model();
+
+		Access::doAsSuperUser(
+			function () use ( $user_model, $matomo_login ) {
+				$this->delete_matomo_user( $user_model, $matomo_login );
+			}
+		);
+	}
+
+	/**
+	 * Callers are responsible for being inside Access::doAsSuperUser().
+	 *
+	 * @param Model  $user_model
+	 * @param string $matomo_login
+	 */
+	private function delete_matomo_user( $user_model, $matomo_login ) {
+		$user_model->deleteUserOnly( $matomo_login );
+		$user_model->deleteUserOptions( $matomo_login );
+		$user_model->deleteUserAccess( $matomo_login );
 	}
 
 	public function sync_maybe_background() {
@@ -518,9 +572,7 @@ class Sync extends Feature {
 				&& ! empty( $all_user['login'] ) ) {
 				Access::doAsSuperUser(
 					function () use ( $user_model, $all_user ) {
-						$user_model->deleteUserOnly( $all_user['login'] );
-						$user_model->deleteUserOptions( $all_user['login'] );
-						$user_model->deleteUserAccess( $all_user['login'] );
+						$this->delete_matomo_user( $user_model, $all_user['login'] );
 					}
 				);
 				// the WP -> Matomo mapping is cleaned up via the UsersManager.deleteUser event

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -511,46 +511,66 @@ class Sync extends Feature {
 			// todo if we used transactions we could commit it after a possibly new access has been added
 			// to prevent UI preventing randomly saying no access between deleting and adding access
 
-			$matomo_login = $this->sync_user_access_for_site( $user, $idsite, $user_model );
-
-			if ( $matomo_login ) {
-				$logins_with_some_view_access[] = $matomo_login;
-
-				$locale = get_user_locale( $user->ID );
-				$lang   = self::get_matomo_lang_from_locale( $locale );
-				if (
-					! empty( $lang )
-					&& Plugin\Manager::getInstance()->isPluginActivated( 'LanguagesManager' )
-					&& Plugin\Manager::getInstance()->isPluginInstalled( 'LanguagesManager' )
-					&& API::getInstance()->isLanguageAvailable( $lang )
-				) {
-					$user_lang_model = new \Piwik\Plugins\LanguagesManager\Model();
-					$user_lang_model->setLanguageForUser( $matomo_login, $lang );
+			try {
+				if ( defined( 'MATOMO_PHPUNIT_TEST' ) && MATOMO_PHPUNIT_TEST ) {
+					/**
+					 * @internal tests only
+					 * @param WP_User    $user
+					 * @param int|string $idsite
+					 */
+					do_action( 'matomo_before_sync_user', $user, $idsite );
 				}
-			}
-			// phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
-			if ( 1 != $idsite ) {
-				// only needed if the actual site is not the default site... makes sure when they click in Matomo
-				// UI on "Dashboard" that the correct site is being opened by default
-				// eg if the linked site is actually idSite=2.
-				Access::doAsSuperUser(
-					function () use ( $matomo_login, &$idsite ) {
-						try {
-							UsersManager\API::unsetInstance();
-							// we need to unset the instance to make sure it fetches the
-							// up to date dependencies eg current plugin manager etc
 
-							UsersManager\API::getInstance()->setUserPreference(
-								$matomo_login,
-								UsersManager\API::PREFERENCE_DEFAULT_REPORT,
-								$idsite
-							);
-							//phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-						} catch ( Exception $e ) {
-							// ignore any error for now
-						}
+				$matomo_login = $this->sync_user_access_for_site( $user, $idsite, $user_model );
+
+				if ( $matomo_login ) {
+					$logins_with_some_view_access[] = $matomo_login;
+
+					$locale = get_user_locale( $user->ID );
+					$lang   = self::get_matomo_lang_from_locale( $locale );
+					if (
+						! empty( $lang )
+						&& Plugin\Manager::getInstance()->isPluginActivated( 'LanguagesManager' )
+						&& Plugin\Manager::getInstance()->isPluginInstalled( 'LanguagesManager' )
+						&& API::getInstance()->isLanguageAvailable( $lang )
+					) {
+						$user_lang_model = new \Piwik\Plugins\LanguagesManager\Model();
+						$user_lang_model->setLanguageForUser( $matomo_login, $lang );
 					}
-				);
+				}
+				// phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+				if ( 1 != $idsite ) {
+					// only needed if the actual site is not the default site... makes sure when they click in Matomo
+					// UI on "Dashboard" that the correct site is being opened by default
+					// eg if the linked site is actually idSite=2.
+					Access::doAsSuperUser(
+						function () use ( $matomo_login, &$idsite ) {
+							try {
+								UsersManager\API::unsetInstance();
+								// we need to unset the instance to make sure it fetches the
+								// up to date dependencies eg current plugin manager etc
+
+								UsersManager\API::getInstance()->setUserPreference(
+									$matomo_login,
+									UsersManager\API::PREFERENCE_DEFAULT_REPORT,
+									$idsite
+								);
+								//phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+							} catch ( Exception $e ) {
+								// ignore any error for now
+							}
+						}
+					);
+				}
+			} catch ( Exception $e ) {
+				// one user sync failure must not abort the whole sync
+				$this->logger->log_exception( 'user_sync', $e );
+
+				// make sure this user for whom syncing failed is not deleted
+				$login_to_keep = User::get_matomo_user_login( $user->ID );
+				if ( $login_to_keep ) {
+					$logins_with_some_view_access[] = $login_to_keep;
+				}
 			}
 		}
 
@@ -559,13 +579,18 @@ class Sync extends Feature {
 		foreach ( $all_users as $all_user ) {
 			if ( ! in_array( $all_user['login'], $logins_with_some_view_access, true )
 				&& ! empty( $all_user['login'] ) ) {
-				Access::doAsSuperUser(
-					function () use ( $user_model, $all_user ) {
-						$this->delete_matomo_user( $user_model, $all_user['login'] );
-					}
-				);
-				// the WP -> Matomo mapping is cleaned up via the UsersManager.deleteUser event
-				// that deleteUserOnly() fires (see WordPress::onDeleteMatomoUser).
+				try {
+					Access::doAsSuperUser(
+						function () use ( $user_model, $all_user ) {
+							$this->delete_matomo_user( $user_model, $all_user['login'] );
+						}
+					);
+					// the WP -> Matomo mapping is cleaned up via the UsersManager.deleteUser event
+					// that deleteUserOnly() fires (see WordPress::onDeleteMatomoUser).
+				} catch ( Exception $e ) {
+					// do not abort entirely if a single delete fails
+					$this->logger->log_exception( 'user_sync', $e );
+				}
 			}
 		}
 	}

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -52,6 +52,14 @@ class Sync extends Feature {
 	 */
 	private $user;
 
+	/**
+	 * Blogs a user is being removed from in this request, as [ wp_user_id ][ blog_id ] => true.
+	 * A single request can remove the same user from several blogs, see wpmu_delete_user().
+	 *
+	 * @var array
+	 */
+	private $pending_removals = [];
+
 	public function __construct() {
 		$this->logger = new Logger();
 		$this->user   = new User();
@@ -65,10 +73,91 @@ class Sync extends Feature {
 		add_action( 'add_user_role', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
 		add_action( 'remove_user_role', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
 		add_action( 'add_user_to_blog', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
-		add_action( 'remove_user_from_blog', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
+		add_action( 'remove_user_from_blog', [ $this, 'on_remove_user_from_blog' ], $prio = 10, $args = 2 );
+		add_action( 'clean_user_cache', [ $this, 'on_clean_user_cache' ], $prio = 10, $args = 1 );
 		add_action( 'user_register', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
 		add_action( 'update_option_WPLANG', [ $this, 'on_site_language_change' ], $prio = 10, $args = 0 );
 		add_action( 'profile_update', [ $this, 'sync_maybe_background' ], $prio = 10, $args = 0 );
+	}
+
+	/**
+	 * WordPress fires this action before it removes the user's capabilities, so we can't sync the
+	 * user here, the access it has to the site would not be removed. Instead, we remember them
+	 * and have on_clean_user_cache() do the actual re-syncing.
+	 *
+	 * @param int $wp_user_id
+	 * @param int $blog_id
+	 */
+	public function on_remove_user_from_blog( $wp_user_id, $blog_id ) {
+		$blog_id = (int) $blog_id;
+		$blog_id = $blog_id ? $blog_id : get_current_blog_id();
+
+		$this->pending_removals[ (int) $wp_user_id ][ $blog_id ] = true;
+	}
+
+	/**
+	 * Runs while WordPress is still switched to the blog the user was removed from, after their
+	 * capabilities are gone. Other callers of clean_user_cache() (wp_insert_user(),
+	 * add_user_to_blog(), ...) are ignored because they didn't queue anything.
+	 *
+	 * @param int $wp_user_id
+	 */
+	public function on_clean_user_cache( $wp_user_id ) {
+		$wp_user_id = (int) $wp_user_id;
+		$blog_id    = get_current_blog_id();
+
+		if ( empty( $this->pending_removals[ $wp_user_id ][ $blog_id ] ) ) {
+			return;
+		}
+
+		// only this blog is done, the same user may still be queued for others
+		unset( $this->pending_removals[ $wp_user_id ][ $blog_id ] );
+
+		$this->sync_user_for_current_blog( $wp_user_id );
+	}
+
+	/**
+	 * @param int $wp_user_id
+	 */
+	private function sync_user_for_current_blog( $wp_user_id ) {
+		$idsite = Site::get_matomo_site_id( get_current_blog_id() );
+		if ( ! $idsite ) {
+			return;
+		}
+
+		$wp_user = get_userdata( $wp_user_id );
+		if ( empty( $wp_user ) ) {
+			return;
+		}
+
+		Bootstrap::do_bootstrap();
+
+		$user_model = new Model();
+
+		Access::doAsSuperUser(
+			function () use ( $user_model, $wp_user, $wp_user_id, $idsite ) {
+				$mapped_matomo_login = User::get_matomo_user_login( $wp_user_id );
+
+				$access = $this->sync_user_access( $wp_user, $idsite, $user_model );
+
+				if ( $access['login'] ) {
+					// the user still legitimately has access here, eg. a network super admin who is
+					// no longer a member of this blog
+					if ( $access['is_superuser'] ) {
+						$user_model->setSuperUserAccess( $access['login'], true );
+					}
+
+					return;
+				}
+
+				if ( $mapped_matomo_login && ! $user_model->getSiteAccessCount( $mapped_matomo_login ) ) {
+					// user has access to no sites, delete the user also
+					$user_model->deleteUserOnly( $mapped_matomo_login );
+					$user_model->deleteUserOptions( $mapped_matomo_login );
+					$user_model->deleteUserAccess( $mapped_matomo_login );
+				}
+			}
+		);
 	}
 
 	public function sync_maybe_background() {
@@ -214,42 +303,20 @@ class Sync extends Feature {
 		API::unsetInstance();
 
 		foreach ( $users as $user ) {
-			$user_id = $user->ID;
-
 			// todo if we used transactions we could commit it after a possibly new access has been added
 			// to prevent UI preventing randomly saying no access between deleting and adding access
 
-			$mapped_matomo_login = User::get_matomo_user_login( $user_id );
+			$access = $this->sync_user_access( $user, $idsite, $user_model );
 
-			$matomo_login = null;
-
-			if ( user_can( $user, Capabilities::KEY_SUPERUSER ) ) {
-				$matomo_login                   = $this->ensure_user_exists( $user );
-				$super_users[ $matomo_login ]   = $user;
-				$logins_with_some_view_access[] = $matomo_login;
-			} elseif ( user_can( $user, Capabilities::KEY_ADMIN ) ) {
-				$matomo_login = $this->ensure_user_exists( $user );
-				$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
-				$user_model->addUserAccess( $matomo_login, Admin::ID, [ $idsite ] );
-				$user_model->setSuperUserAccess( $matomo_login, false );
-				$logins_with_some_view_access[] = $matomo_login;
-			} elseif ( user_can( $user, Capabilities::KEY_WRITE ) ) {
-				$matomo_login = $this->ensure_user_exists( $user );
-				$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
-				$user_model->addUserAccess( $matomo_login, Write::ID, [ $idsite ] );
-				$user_model->setSuperUserAccess( $matomo_login, false );
-				$logins_with_some_view_access[] = $matomo_login;
-			} elseif ( user_can( $user, Capabilities::KEY_VIEW ) ) {
-				$matomo_login = $this->ensure_user_exists( $user );
-				$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
-				$user_model->addUserAccess( $matomo_login, View::ID, [ $idsite ] );
-				$user_model->setSuperUserAccess( $matomo_login, false );
-				$logins_with_some_view_access[] = $matomo_login;
-			} elseif ( $mapped_matomo_login ) {
-				$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
-			}
+			$matomo_login = $access['login'];
 
 			if ( $matomo_login ) {
+				$logins_with_some_view_access[] = $matomo_login;
+
+				if ( $access['is_superuser'] ) {
+					$super_users[ $matomo_login ] = $user;
+				}
+
 				$locale = get_user_locale( $user->ID );
 				$lang   = self::get_matomo_lang_from_locale( $locale );
 				if (
@@ -308,6 +375,55 @@ class Sync extends Feature {
 				// that deleteUserOnly() fires (see WordPress::onDeleteMatomoUser).
 			}
 		}
+	}
+
+	/**
+	 * @param WP_User    $user
+	 * @param int|string $idsite
+	 * @param Model      $user_model
+	 *
+	 * @return array{login: string|null, is_superuser: bool} login is null when the user should have
+	 *                                                       no access to this site at all
+	 */
+	protected function sync_user_access( $user, $idsite, $user_model ) {
+		$mapped_matomo_login = User::get_matomo_user_login( $user->ID );
+
+		if ( user_can( $user, Capabilities::KEY_SUPERUSER ) ) {
+			return [
+				'login'        => $this->ensure_user_exists( $user ),
+				'is_superuser' => true,
+			];
+		}
+
+		$role = null;
+		if ( user_can( $user, Capabilities::KEY_ADMIN ) ) {
+			$role = Admin::ID;
+		} elseif ( user_can( $user, Capabilities::KEY_WRITE ) ) {
+			$role = Write::ID;
+		} elseif ( user_can( $user, Capabilities::KEY_VIEW ) ) {
+			$role = View::ID;
+		}
+
+		if ( null === $role ) {
+			if ( $mapped_matomo_login ) {
+				$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
+			}
+
+			return [
+				'login'        => null,
+				'is_superuser' => false,
+			];
+		}
+
+		$matomo_login = $this->ensure_user_exists( $user );
+		$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
+		$user_model->addUserAccess( $matomo_login, $role, [ $idsite ] );
+		$user_model->setSuperUserAccess( $matomo_login, false );
+
+		return [
+			'login'        => $matomo_login,
+			'is_superuser' => false,
+		];
 	}
 
 	/**

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -11,12 +11,10 @@ namespace WpMatomo\User;
 
 use Exception;
 use Piwik\Access;
-use Piwik\Access\Role\Admin;
-use Piwik\Access\Role\View;
-use Piwik\Access\Role\Write;
 use Piwik\Auth\Password;
 use Piwik\Common;
 use Piwik\Date;
+use Piwik\Db;
 use Piwik\Plugin;
 use Piwik\Plugins\LanguagesManager\API;
 use Piwik\Plugins\UsersManager;
@@ -114,6 +112,86 @@ class Sync extends Feature {
 		unset( $this->pending_removals[ $wp_user_id ][ $blog_id ] );
 
 		$this->sync_user_for_current_blog( $wp_user_id );
+	}
+
+	/**
+	 * Corrects a Matomo access row that grants the user more than their live WordPress capabilities
+	 * do, before anything reads it.
+	 *
+	 * Only ever downgrades. A user promoted in WordPress still waits for a regular sync.
+	 *
+	 * @param int        $wp_user_id
+	 * @param array|null $matomo_user the already fetched Matomo user row, to save a query
+	 *
+	 * @return bool whether the user was re-synced
+	 */
+	public function sync_user_if_access_exceeds_capabilities( $wp_user_id, $matomo_user = null ) {
+		if ( ! Capabilities::is_capability_check_available() ) {
+			return false;
+		}
+
+		$idsite = Site::get_matomo_site_id( get_current_blog_id() );
+		if ( ! $idsite ) {
+			return false;
+		}
+
+		$matomo_login = User::get_matomo_user_login( $wp_user_id );
+		if ( ! $matomo_login ) {
+			return false; // nothing was ever persisted for this user
+		}
+
+		$wp_user = get_userdata( $wp_user_id );
+		if ( empty( $wp_user ) ) {
+			return false;
+		}
+
+		Bootstrap::do_bootstrap();
+
+		$user_model = new Model();
+
+		if ( null === $matomo_user ) {
+			$matomo_user = $user_model->getUser( $matomo_login );
+		}
+
+		if ( empty( $matomo_user ) ) {
+			return false;
+		}
+
+		$live_rank      = Capabilities::get_role_ranking( Capabilities::get_highest_role_for_user( $wp_user ) );
+		$persisted_rank = $this->get_persisted_role_rank( $matomo_login, $matomo_user, $idsite );
+
+		if ( $persisted_rank <= $live_rank ) {
+			return false;
+		}
+
+		$this->sync_user_for_current_blog( $wp_user_id );
+
+		return true;
+	}
+
+	/**
+	 * @param string $matomo_login
+	 * @param array  $matomo_user
+	 * @param int    $idsite
+	 *
+	 * @return int
+	 */
+	private function get_persisted_role_rank( $matomo_login, $matomo_user, $idsite ) {
+		if ( ! empty( $matomo_user['superuser_access'] ) ) {
+			return Capabilities::get_role_ranking( Capabilities::ROLE_SUPERUSER );
+		}
+
+		$rows = Db::fetchAll(
+			'SELECT access FROM ' . Common::prefixTable( 'access' ) . ' WHERE login = ? AND idsite = ?',
+			[ $matomo_login, (int) $idsite ]
+		);
+
+		$rank = 0;
+		foreach ( $rows as $row ) {
+			$rank = max( $rank, Capabilities::get_role_ranking( $row['access'] ) );
+		}
+
+		return $rank;
 	}
 
 	/**
@@ -388,20 +466,13 @@ class Sync extends Feature {
 	protected function sync_user_access( $user, $idsite, $user_model ) {
 		$mapped_matomo_login = User::get_matomo_user_login( $user->ID );
 
-		if ( user_can( $user, Capabilities::KEY_SUPERUSER ) ) {
+		$role = Capabilities::get_highest_role_for_user( $user );
+
+		if ( Capabilities::ROLE_SUPERUSER === $role ) {
 			return [
 				'login'        => $this->ensure_user_exists( $user ),
 				'is_superuser' => true,
 			];
-		}
-
-		$role = null;
-		if ( user_can( $user, Capabilities::KEY_ADMIN ) ) {
-			$role = Admin::ID;
-		} elseif ( user_can( $user, Capabilities::KEY_WRITE ) ) {
-			$role = Write::ID;
-		} elseif ( user_can( $user, Capabilities::KEY_VIEW ) ) {
-			$role = View::ID;
 		}
 
 		if ( null === $role ) {

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -19,6 +19,7 @@ use Piwik\Plugin;
 use Piwik\Plugins\LanguagesManager\API;
 use Piwik\Plugins\UsersManager;
 use Piwik\Plugins\UsersManager\Model;
+use Piwik\Tracker\Cache as TrackerCache;
 use WP_User;
 use WpMatomo\Bootstrap;
 use WpMatomo\Capabilities;
@@ -316,6 +317,8 @@ class Sync extends Feature {
 				}
 			}
 		);
+
+		$this->invalidate_tracker_cache( $idsite );
 	}
 
 	/**
@@ -592,6 +595,25 @@ class Sync extends Feature {
 					$this->logger->log_exception( 'user_sync', $e );
 				}
 			}
+		}
+
+		$this->invalidate_tracker_cache( $idsite );
+	}
+
+	/**
+	 * This plugin does not provide token auths to authenticate with, but in case an
+	 * attacker is somehow able to create one, we want to make sure it can't be used,
+	 * so after syncing, we clear the tracker cache.
+	 *
+	 * @param int|string $idsite
+	 */
+	private function invalidate_tracker_cache( $idsite ) {
+		try {
+			TrackerCache::deleteCacheWebsiteAttributes( $idsite );
+		} catch ( Exception $e ) {
+			// the sync itself is done, so a cache that could not be cleared must not fail the
+			// request that triggered it
+			$this->logger->log_exception( 'user_sync', $e );
 		}
 	}
 

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -42,6 +42,12 @@ class Sync extends Feature {
 	const MAX_USER_NAME_LENGTH = 95;
 
 	/**
+	 * Above this many users on a blog, syncing them all is too much work for the request that
+	 * happened to change one of them. The scheduled task does it instead.
+	 */
+	const MAX_INLINE_SYNC_USERS = 1000;
+
+	/**
 	 * @var Logger
 	 */
 	private $logger;
@@ -417,9 +423,14 @@ class Sync extends Feature {
 		if ( $idsite ) {
 			$num_users = count_users();
 			$num_users = $num_users['total_users'];
-			if ( $num_users < 1000 ) {
+			if ( $num_users < self::MAX_INLINE_SYNC_USERS ) {
 				$users = $this->get_users();
 				$this->sync_users( $users, $idsite );
+			} else {
+				// too expensive to sync in this request
+				$this->logger->log( 'Deferring user sync to a scheduled task, since this blog has ' . $num_users . ' users' );
+
+				wp_schedule_single_event( time() + 5, ScheduledTasks::EVENT_SYNC );
 			}
 		}
 	}

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -105,7 +105,7 @@ class Sync extends Feature {
 		remove_action( 'revoked_super_admin', [ $this, 'on_super_admin_change' ], 10 );
 		remove_action( 'update_option_WPLANG', [ $this, 'on_site_language_change' ], 10 );
 		remove_action( 'profile_update', [ $this, 'sync_maybe_background' ], 10 );
-		remove_action( 'make_undelete_blog', [ $this, 'on_undelete_blog' ], 11 );
+		remove_action( 'make_undelete_blog', [ $this, 'on_undelete_blog' ], Site\Sync::MAKE_UNDELETE_BLOG_PRIORITY + 1 );
 	}
 
 	/**
@@ -678,8 +678,6 @@ class Sync extends Feature {
 	 * @return string|null matomo login or null when the user has no access
 	 */
 	protected function sync_user_access_for_site( $user, $idsite, $user_model ) {
-		$mapped_matomo_login = $this->get_own_matomo_user_login( $user->ID );
-
 		$role = Capabilities::get_highest_role_for_user( $user );
 
 		if ( Capabilities::ROLE_SUPERUSER === $role ) {
@@ -696,6 +694,8 @@ class Sync extends Feature {
 		}
 
 		if ( null === $role ) {
+			// make sure the mapped matomo login is actually for the current WP user
+			$mapped_matomo_login = $this->get_own_matomo_user_login( $user->ID );
 			if ( $mapped_matomo_login ) {
 				$user_model->deleteUserAccess( $mapped_matomo_login );
 			}
@@ -703,7 +703,7 @@ class Sync extends Feature {
 			return null;
 		}
 
-		// note: matomo_login may not be the same as mapped_matomo_login
+		// note: matomo_login may not be the same as the login this user was mapped to on the way in
 		$matomo_login = $this->ensure_user_exists( $user );
 		$user_model->deleteUserAccess( $matomo_login );
 		$user_model->addUserAccess( $matomo_login, $role, [ $idsite ] );

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -504,7 +504,7 @@ class Sync extends Feature {
 
 		$this->logger->log( 'Matomo will now sync ' . count( $users ) . ' users' );
 
-		$logins_with_some_view_access = [ 'anonmyous' ]; // may or may not exist... we don't want to delete this user though
+		$logins_with_some_view_access = [ 'anonymous' ]; // may or may not exist... we don't want to delete this user though
 		$user_model                   = new Model();
 
 		// need to make sure we recreate new instance later with latest dependencies in case they changed

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -208,10 +208,6 @@ class Sync extends Feature {
 	 * @return bool whether the user was re-synced
 	 */
 	public function sync_user_if_access_exceeds_capabilities( $wp_user_id, $matomo_user = null ) {
-		if ( ! Capabilities::is_capability_check_available() ) {
-			return false;
-		}
-
 		$idsite = Site::get_matomo_site_id( get_current_blog_id() );
 		if ( ! $idsite ) {
 			return false;

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -637,14 +637,14 @@ class Sync extends Feature {
 			// superuser_access already grants every site, so a per site row is redundant here. Left
 			// behind it outlives the superuser flag and goes on granting this site by itself, and it
 			// keeps getSiteAccessCount() non zero, which is what stops the identity being cleaned up
-			$user_model->deleteUserAccess( $matomo_login, [ $idsite ] );
+			$user_model->deleteUserAccess( $matomo_login );
 
 			return $matomo_login;
 		}
 
 		if ( null === $role ) {
 			if ( $mapped_matomo_login ) {
-				$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
+				$user_model->deleteUserAccess( $mapped_matomo_login );
 			}
 
 			return null;
@@ -652,7 +652,7 @@ class Sync extends Feature {
 
 		// note: matomo_login may not be the same as mapped_matomo_login
 		$matomo_login = $this->ensure_user_exists( $user );
-		$user_model->deleteUserAccess( $matomo_login, [ $idsite ] );
+		$user_model->deleteUserAccess( $matomo_login );
 		$user_model->addUserAccess( $matomo_login, $role, [ $idsite ] );
 		$user_model->setSuperUserAccess( $matomo_login, false );
 

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -257,7 +257,9 @@ class Sync extends Feature {
 
 	public function sync_all() {
 		if ( function_exists( 'is_multisite' ) && is_multisite() ) {
-			foreach ( get_sites() as $site ) {
+			// number => 0 means no limit. WP_Site_Query defaults to 100, which would silently leave
+			// every blog after that unsynced
+			foreach ( get_sites( [ 'number' => 0 ] ) as $site ) {
 				if ( 1 === (int) $site->deleted ) {
 					continue;
 				}

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -24,6 +24,7 @@ use WpMatomo\Bootstrap;
 use WpMatomo\Capabilities;
 use WpMatomo\Feature;
 use WpMatomo\Logger;
+use WpMatomo\Request;
 use WpMatomo\ScheduledTasks;
 use WpMatomo\Site;
 use WpMatomo\User;
@@ -63,10 +64,6 @@ class Sync extends Feature {
 		$this->user   = new User();
 	}
 
-	public function is_active() {
-		return is_admin();
-	}
-
 	public function register_hooks() {
 		add_action( 'add_user_role', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
 		add_action( 'remove_user_role', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
@@ -81,6 +78,24 @@ class Sync extends Feature {
 	}
 
 	/**
+	 * Tests only
+	 *
+	 * @internal
+	 */
+	public function remove_hooks() {
+		remove_action( 'add_user_role', [ $this, 'sync_current_users_1000' ], 10 );
+		remove_action( 'remove_user_role', [ $this, 'sync_current_users_1000' ], 10 );
+		remove_action( 'add_user_to_blog', [ $this, 'sync_current_users_1000' ], 10 );
+		remove_action( 'remove_user_from_blog', [ $this, 'on_remove_user_from_blog' ], 10 );
+		remove_action( 'clean_user_cache', [ $this, 'on_clean_user_cache' ], 10 );
+		remove_action( 'user_register', [ $this, 'sync_current_users_1000' ], 10 );
+		remove_action( 'granted_super_admin', [ $this, 'on_super_admin_change' ], 10 );
+		remove_action( 'revoked_super_admin', [ $this, 'on_super_admin_change' ], 10 );
+		remove_action( 'update_option_WPLANG', [ $this, 'on_site_language_change' ], 10 );
+		remove_action( 'profile_update', [ $this, 'sync_maybe_background' ], 10 );
+	}
+
+	/**
 	 * WordPress fires this action before it removes the user's capabilities, so we can't sync the
 	 * user here, the access it has to the site would not be removed. Instead, we remember them
 	 * and have on_clean_user_cache() do the actual re-syncing.
@@ -89,6 +104,11 @@ class Sync extends Feature {
 	 * @param int $blog_id
 	 */
 	public function on_remove_user_from_blog( $wp_user_id, $blog_id ) {
+		if ( ! $this->is_sync_allowed_for_request() ) {
+			// nothing queued means on_clean_user_cache() has nothing to do either
+			return;
+		}
+
 		$blog_id = (int) $blog_id;
 		$blog_id = $blog_id ? $blog_id : get_current_blog_id();
 
@@ -120,6 +140,10 @@ class Sync extends Feature {
 	 * @param int $wp_user_id
 	 */
 	public function on_super_admin_change( $wp_user_id ) {
+		if ( ! $this->is_sync_allowed_for_request() ) {
+			return;
+		}
+
 		if ( ! function_exists( 'is_multisite' ) || ! is_multisite() ) {
 			return;
 		}
@@ -376,6 +400,15 @@ class Sync extends Feature {
 	 * @see Sync::sync_current_users()
 	 */
 	public function sync_current_users_1000() {
+		if ( ! $this->is_sync_allowed_for_request() ) {
+			return;
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			// these hooks are not admin only, so this may run somewhere wp-admin/includes is not loaded
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
 		if ( ! is_plugin_active( 'matomo/matomo.php' ) ) {
 			// @see https://github.com/matomo-org/matomo-for-wordpress/issues/577
 			return;
@@ -659,5 +692,9 @@ class Sync extends Feature {
 			$parts = explode( '_', $locale );
 		}
 		return ! empty( $parts[0] ) ? $parts[0] : null;
+	}
+
+	private function is_sync_allowed_for_request() {
+		return ! Request::is_frontend();
 	}
 }

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -74,6 +74,8 @@ class Sync extends Feature {
 		add_action( 'remove_user_from_blog', [ $this, 'on_remove_user_from_blog' ], $prio = 10, $args = 2 );
 		add_action( 'clean_user_cache', [ $this, 'on_clean_user_cache' ], $prio = 10, $args = 1 );
 		add_action( 'user_register', [ $this, 'sync_current_users_1000' ], $prio = 10, $args = 0 );
+		add_action( 'granted_super_admin', [ $this, 'on_super_admin_change' ], $prio = 10, $args = 1 );
+		add_action( 'revoked_super_admin', [ $this, 'on_super_admin_change' ], $prio = 10, $args = 1 );
 		add_action( 'update_option_WPLANG', [ $this, 'on_site_language_change' ], $prio = 10, $args = 0 );
 		add_action( 'profile_update', [ $this, 'sync_maybe_background' ], $prio = 10, $args = 0 );
 	}
@@ -112,6 +114,32 @@ class Sync extends Feature {
 		unset( $this->pending_removals[ $wp_user_id ][ $blog_id ] );
 
 		$this->sync_user_for_current_blog( $wp_user_id );
+	}
+
+	/**
+	 * @param int $wp_user_id
+	 */
+	public function on_super_admin_change( $wp_user_id ) {
+		if ( ! function_exists( 'is_multisite' ) || ! is_multisite() ) {
+			return;
+		}
+
+		foreach ( get_sites( [ 'number' => 0 ] ) as $site ) {
+			if ( 1 === (int) $site->deleted ) {
+				continue;
+			}
+
+			switch_to_blog( $site->blog_id );
+
+			try {
+				$this->sync_user_for_current_blog( $wp_user_id );
+			} catch ( Exception $e ) {
+				// one blog failing must not stop the rest from being corrected
+				$this->logger->log_exception( 'user_sync', $e );
+			}
+
+			restore_current_blog();
+		}
 	}
 
 	/**

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -603,8 +603,9 @@ class Sync extends Feature {
 			return null;
 		}
 
+		// note: matomo_login may not be the same as mapped_matomo_login
 		$matomo_login = $this->ensure_user_exists( $user );
-		$user_model->deleteUserAccess( $mapped_matomo_login, [ $idsite ] );
+		$user_model->deleteUserAccess( $matomo_login, [ $idsite ] );
 		$user_model->addUserAccess( $matomo_login, $role, [ $idsite ] );
 		$user_model->setSuperUserAccess( $matomo_login, false );
 

--- a/classes/WpMatomo/User/Sync.php
+++ b/classes/WpMatomo/User/Sync.php
@@ -83,6 +83,9 @@ class Sync extends Feature {
 		add_action( 'revoked_super_admin', [ $this, 'on_super_admin_change' ], $prio = 10, $args = 1 );
 		add_action( 'update_option_WPLANG', [ $this, 'on_site_language_change' ], $prio = 10, $args = 0 );
 		add_action( 'profile_update', [ $this, 'sync_maybe_background' ], $prio = 10, $args = 0 );
+
+		// must run after the site sync hook
+		add_action( 'make_undelete_blog', [ $this, 'on_undelete_blog' ], $prio = Site\Sync::MAKE_UNDELETE_BLOG_PRIORITY + 1, $args = 1 );
 	}
 
 	/**
@@ -102,6 +105,7 @@ class Sync extends Feature {
 		remove_action( 'revoked_super_admin', [ $this, 'on_super_admin_change' ], 10 );
 		remove_action( 'update_option_WPLANG', [ $this, 'on_site_language_change' ], 10 );
 		remove_action( 'profile_update', [ $this, 'sync_maybe_background' ], 10 );
+		remove_action( 'make_undelete_blog', [ $this, 'on_undelete_blog' ], 11 );
 	}
 
 	/**
@@ -165,6 +169,26 @@ class Sync extends Feature {
 			// deleting a WordPress user must not fail because the Matomo cleanup did
 			$this->logger->log_exception( 'user_sync', $e );
 		}
+	}
+
+	/**
+	 * @param int $blog_id
+	 */
+	public function on_undelete_blog( $blog_id ) {
+		if ( ! $this->is_sync_allowed_for_request() ) {
+			return;
+		}
+
+		switch_to_blog( $blog_id );
+
+		try {
+			$this->sync_current_users();
+		} catch ( Exception $e ) {
+			// restoring a blog must not fail because Matomo could not be synced for it
+			$this->logger->log_exception( 'user_sync', $e );
+		}
+
+		restore_current_blog();
 	}
 
 	/**
@@ -509,6 +533,7 @@ class Sync extends Feature {
 
 		// need to make sure we recreate new instance later with latest dependencies in case they changed
 		API::unsetInstance();
+		UsersManager\API::unsetInstance();
 
 		foreach ( $users as $user ) {
 			// todo if we used transactions we could commit it after a possibly new access has been added
@@ -540,30 +565,28 @@ class Sync extends Feature {
 						$user_lang_model = new \Piwik\Plugins\LanguagesManager\Model();
 						$user_lang_model->setLanguageForUser( $matomo_login, $lang );
 					}
-				}
-				// phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
-				if ( 1 != $idsite ) {
-					// only needed if the actual site is not the default site... makes sure when they click in Matomo
-					// UI on "Dashboard" that the correct site is being opened by default
-					// eg if the linked site is actually idSite=2.
-					Access::doAsSuperUser(
-						function () use ( $matomo_login, &$idsite ) {
-							try {
-								UsersManager\API::unsetInstance();
-								// we need to unset the instance to make sure it fetches the
-								// up to date dependencies eg current plugin manager etc
 
-								UsersManager\API::getInstance()->setUserPreference(
-									$matomo_login,
-									UsersManager\API::PREFERENCE_DEFAULT_REPORT,
-									$idsite
-								);
-								//phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-							} catch ( Exception $e ) {
-								// ignore any error for now
+					// phpcs:ignore Universal.Operators.StrictComparisons.LooseNotEqual
+					if ( 1 != $idsite ) {
+						// only needed if the actual site is not the default site... makes sure when they click in Matomo
+						// UI on "Dashboard" that the correct site is being opened by default
+						// eg if the linked site is actually idSite=2.
+						Access::doAsSuperUser(
+							function () use ( $matomo_login, &$idsite ) {
+								try {
+									UsersManager\API::getInstance()->setUserPreference(
+										$matomo_login,
+										UsersManager\API::PREFERENCE_DEFAULT_REPORT,
+										$idsite
+									);
+								} catch ( Exception $e ) {
+									// a preference is not worth failing the sync over, but it should not
+									// disappear silently either
+									$this->logger->log_exception( 'user_sync', $e );
+								}
 							}
-						}
-					);
+						);
+					}
 				}
 			} catch ( Exception $e ) {
 				// one user sync failure must not abort the whole sync

--- a/matomo.php
+++ b/matomo.php
@@ -7,7 +7,7 @@
  * Version: 5.12.1
  * Domain Path: /languages
  * WC requires at least: 2.4.0
- * WC tested up to: 11.0.0
+ * WC tested up to: 11.0.1
  *
  * Matomo - free/libre analytics platform
  *

--- a/matomo.php
+++ b/matomo.php
@@ -4,7 +4,7 @@
  * Description: Privacy friendly, GDPR compliant and self-hosted. Matomo is the #1 Google Analytics alternative that gives you control of your data. Free and secure.
  * Author: Matomo
  * Author URI: https://matomo.org
- * Version: 5.12.1
+ * Version: 5.12.2
  * Domain Path: /languages
  * WC requires at least: 2.4.0
  * WC tested up to: 11.0.1

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -86,16 +86,14 @@ class Auth extends \Piwik\Plugins\Login\Auth
     {
         $code = null;
 
-        if (Capabilities::is_capability_check_available()) {
-            if (user_can($wpUserId, Capabilities::KEY_SUPERUSER)) {
-                $code = AuthResult::SUCCESS_SUPERUSER_AUTH_CODE;
-            } elseif (user_can($wpUserId, Capabilities::KEY_VIEW)) {
-                $code = AuthResult::SUCCESS;
-            }
+        if (user_can($wpUserId, Capabilities::KEY_SUPERUSER)) {
+            $code = AuthResult::SUCCESS_SUPERUSER_AUTH_CODE;
+        } elseif (user_can($wpUserId, Capabilities::KEY_VIEW)) {
+            $code = AuthResult::SUCCESS;
+        }
 
-            if ($code === null) {
-                return null;
-            }
+        if ($code === null) {
+            return null;
         }
 
         $login = User::get_matomo_user_login($wpUserId);
@@ -106,13 +104,7 @@ class Auth extends \Piwik\Plugins\Login\Auth
             return null;
         }
 
-        if ($code === null) {
-            // safe mode only, see Capabilities::is_capability_check_available(). the hooks that
-            // synthesise most matomo capabilities are not registered, so user_can() would reject
-            // administrators and anyone covered by the role mapping. fall back to the persisted
-            // access.
-            $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
-        } elseif ((new Sync())->sync_user_if_access_exceeds_capabilities($wpUserId, $matomoUser)) {
+        if ((new Sync())->sync_user_if_access_exceeds_capabilities($wpUserId, $matomoUser)) {
             // matomo's authorization layer trusts the persisted per site role verbatim, so the call
             // above corrects it when it grants more than the user's live WordPress capabilities do.
             // syncing can remove a user from Matomo, so re-read the one we authenticate as.

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -16,6 +16,7 @@ use Piwik\Log\LoggerInterface;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\SettingsServer;
 use Piwik\Tracker\TrackerConfig;
+use WpMatomo\Capabilities;
 use WpMatomo\User;
 
 if (!defined( 'ABSPATH')) {
@@ -73,7 +74,30 @@ class Auth extends \Piwik\Plugins\Login\Auth
             return null;
         }
 
-        $login = User::get_matomo_user_login($loggedInUserId);
+        return $this->makeAuthResultForWpUser($loggedInUserId);
+    }
+
+    /**
+     * @param int $wpUserId
+     * @return AuthResult|null null when the user must not be authenticated
+     */
+    private function makeAuthResultForWpUser($wpUserId)
+    {
+        $code = null;
+
+        if ($this->isCapabilityCheckAvailable()) {
+            if (user_can($wpUserId, Capabilities::KEY_SUPERUSER)) {
+                $code = AuthResult::SUCCESS_SUPERUSER_AUTH_CODE;
+            } elseif (user_can($wpUserId, Capabilities::KEY_VIEW)) {
+                $code = AuthResult::SUCCESS;
+            }
+
+            if ($code === null) {
+                return null;
+            }
+        }
+
+        $login = User::get_matomo_user_login($wpUserId);
 
         $userModel = new Model();
         $matomoUser = $userModel->getUser($login);
@@ -81,8 +105,34 @@ class Auth extends \Piwik\Plugins\Login\Auth
             return null;
         }
 
-        $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
+        if ($code === null) {
+            // safe mode only, see isCapabilityCheckAvailable(). matomo capabilities cannot be
+            // resolved at all, so user_can() would reject everyone including administrators. fall
+            // back to the persisted access.
+            $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
+        }
+
         return new AuthResult($code, $login, $this->token_auth);
+    }
+
+    /**
+     * Whether matomo capabilities can be resolved at all in this request. Normally
+     * available, but in safe mode, it's not.
+     *
+     * @return bool
+     */
+    private function isCapabilityCheckAvailable()
+    {
+        if (!class_exists('\WpMatomo')) {
+            return false;
+        }
+
+        $capabilities = \WpMatomo::get_active_feature(Capabilities::class);
+        if (empty($capabilities)) {
+            return false;
+        }
+
+        return has_filter('user_has_cap', [$capabilities, 'add_capabilities_to_user']) !== false;
     }
 
     private function isAppPasswordInTokenAuthAllowed()
@@ -134,15 +184,6 @@ class Auth extends \Piwik\Plugins\Login\Auth
             remove_filter('application_password_is_api_request', $callback);
         }
 
-        $login = User::get_matomo_user_login($loggedInUserId);
-
-        $userModel = new Model();
-        $matomoUser = $userModel->getUser($login);
-        if (empty($matomoUser)) {
-            return null;
-        }
-
-        $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
-        return new AuthResult($code, $login, $this->token_auth);
+        return $this->makeAuthResultForWpUser($loggedInUserId);
     }
 }

--- a/plugins/WordPress/Auth.php
+++ b/plugins/WordPress/Auth.php
@@ -18,6 +18,7 @@ use Piwik\SettingsServer;
 use Piwik\Tracker\TrackerConfig;
 use WpMatomo\Capabilities;
 use WpMatomo\User;
+use WpMatomo\User\Sync;
 
 if (!defined( 'ABSPATH')) {
     exit; // if accessed directly
@@ -85,7 +86,7 @@ class Auth extends \Piwik\Plugins\Login\Auth
     {
         $code = null;
 
-        if ($this->isCapabilityCheckAvailable()) {
+        if (Capabilities::is_capability_check_available()) {
             if (user_can($wpUserId, Capabilities::KEY_SUPERUSER)) {
                 $code = AuthResult::SUCCESS_SUPERUSER_AUTH_CODE;
             } elseif (user_can($wpUserId, Capabilities::KEY_VIEW)) {
@@ -106,33 +107,22 @@ class Auth extends \Piwik\Plugins\Login\Auth
         }
 
         if ($code === null) {
-            // safe mode only, see isCapabilityCheckAvailable(). matomo capabilities cannot be
-            // resolved at all, so user_can() would reject everyone including administrators. fall
-            // back to the persisted access.
+            // safe mode only, see Capabilities::is_capability_check_available(). the hooks that
+            // synthesise most matomo capabilities are not registered, so user_can() would reject
+            // administrators and anyone covered by the role mapping. fall back to the persisted
+            // access.
             $code = ((int) $matomoUser['superuser_access']) ? AuthResult::SUCCESS_SUPERUSER_AUTH_CODE : AuthResult::SUCCESS;
+        } elseif ((new Sync())->sync_user_if_access_exceeds_capabilities($wpUserId, $matomoUser)) {
+            // matomo's authorization layer trusts the persisted per site role verbatim, so the call
+            // above corrects it when it grants more than the user's live WordPress capabilities do.
+            // syncing can remove a user from Matomo, so re-read the one we authenticate as.
+            $login = User::get_matomo_user_login($wpUserId);
+            if (empty($login)) {
+                return null;
+            }
         }
 
         return new AuthResult($code, $login, $this->token_auth);
-    }
-
-    /**
-     * Whether matomo capabilities can be resolved at all in this request. Normally
-     * available, but in safe mode, it's not.
-     *
-     * @return bool
-     */
-    private function isCapabilityCheckAvailable()
-    {
-        if (!class_exists('\WpMatomo')) {
-            return false;
-        }
-
-        $capabilities = \WpMatomo::get_active_feature(Capabilities::class);
-        if (empty($capabilities)) {
-            return false;
-        }
-
-        return has_filter('user_has_cap', [$capabilities, 'add_capabilities_to_user']) !== false;
     }
 
     private function isAppPasswordInTokenAuthAllowed()

--- a/plugins/WordPress/Menu.php
+++ b/plugins/WordPress/Menu.php
@@ -40,6 +40,8 @@ class Menu extends \Piwik\Plugin\Menu
 
             $view = new View("@WordPress/blogselection");
             $sites = array();
+            // get_sites() by default limits to first 100. kept here to potentially avoid blocking page
+            // render. (it is still possible to switch to one of those sites via the WordPress admin)
             foreach ( get_sites() as $matomo_site ) {
                 /** @var \WP_Site $matomo_site */
                 switch_to_blog( $matomo_site->blog_id );

--- a/plugins/WordPress/SessionAuth.php
+++ b/plugins/WordPress/SessionAuth.php
@@ -43,6 +43,15 @@ class SessionAuth extends \Piwik\Session\SessionAuth
 
             if (!empty($permission)) {
                 $matomo_user = $this->findMatomoUser($user->ID);
+
+                // matomo's authorisation layer trusts the persisted per site role verbatim, so
+                // correct it now if it grants more than the user's live capabilities do. when
+                // findMatomoUser() just synced the user, this finds nothing to do.
+                if ((new User\Sync())->sync_user_if_access_exceeds_capabilities($user->ID, $matomo_user)) {
+                    // syncing can reallocate a contested login, so re-read the user it resolved to
+                    $matomo_user = $this->findMatomoUser($user->ID);
+                }
+
                 $token = $this->makeTemporaryToken($user->ID);
 
                 if (

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: matomoteam
 Tags: analytics,privacy-friendly,gdpr,behavior,conversion,wordpress analytics,google analytics,woocommerce analytics,matomo,statistics,stats,ecommerce
 Requires at least: 4.8
-Tested up to: 7.0.3
+Tested up to: 7.0.4
 Stable tag: 5.12.1
 Requires PHP: 7.2.5
 License: GPLv3 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: matomoteam
 Tags: analytics,privacy-friendly,gdpr,behavior,conversion,wordpress analytics,google analytics,woocommerce analytics,matomo,statistics,stats,ecommerce
 Requires at least: 4.8
 Tested up to: 7.0.4
-Stable tag: 5.12.1
+Stable tag: 5.12.2
 Requires PHP: 7.2.5
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/e2e/baseline/desktop_chrome/matomo-admin.system.general-settings.7.4.png
+++ b/tests/e2e/baseline/desktop_chrome/matomo-admin.system.general-settings.7.4.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7b7fc19526d2613c02dfb0fa5093635876043a0acdbb8e9e6783fba8e01cc3c3
-size 1751942
+oid sha256:37a8369f5e838b548f47060603587cd480165c85c0d923a4aaccb24744eca889
+size 1772043

--- a/tests/e2e/baseline/desktop_chrome/matomo-admin.system.general-settings.8.1.png
+++ b/tests/e2e/baseline/desktop_chrome/matomo-admin.system.general-settings.8.1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb49ff57f2175c1abb6c345de9cf55021d5d32c2f7400c7599595816e5fc0530
-size 1853808
+oid sha256:0ba74437015f477163e15dc5e2e90b2190529594e0cbbe8abaeb8cc6b3f3f96c
+size 1873841

--- a/tests/phpunit/framework/fixture/test-matomo-fixture.php
+++ b/tests/phpunit/framework/fixture/test-matomo-fixture.php
@@ -198,11 +198,9 @@ class MatomoUnit_Matomo_Fixture {
 
 	private function uninstall_matomo() {
 		try {
-			// will not be defined for the first run test case
-			if (
-				class_exists( '\Piwik\SettingsPiwik' )
-				&& \Piwik\SettingsPiwik::isMatomoInstalled()
-			) {
+			Bootstrap::bootstrap_environment();
+
+			if ( \Piwik\SettingsPiwik::isMatomoInstalled() ) {
 				$uninstall = new Uninstaller();
 				$uninstall->uninstall( true );
 			}

--- a/tests/phpunit/framework/fixture/test-matomo-fixture.php
+++ b/tests/phpunit/framework/fixture/test-matomo-fixture.php
@@ -32,7 +32,21 @@ use WpMatomo\User;
  * phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
  */
 class MatomoUnit_Matomo_Fixture {
-	public function set_up( $test_case = null ) {
+
+	/**
+	 * Applies the per test annotations this fixture supports: noTestMode, noDebugLog and
+	 * provideContainerConfig.
+	 *
+	 * Kept separate from set_up() so MatomoAnalytics_SharedFixture_TestCase, which does not run the
+	 * installer per test, can still honor them before it bootstraps.
+	 *
+	 * @param mixed $test_case
+	 * @param bool  $enable_test_mode set to false when the caller knows PIWIK_TEST_MODE must not be
+	 *                                defined, but has no test case to read @noTestMode off
+	 */
+	public function apply_test_annotations( $test_case = null, $enable_test_mode = true ) {
+		$annotations = [];
+
 		if ( $test_case ) {
 			$test_class_name  = get_class( $test_case );
 			$test_method_name = $test_case->getName();
@@ -43,7 +57,8 @@ class MatomoUnit_Matomo_Fixture {
 		}
 
 		if (
-			empty( $annotations['method']['noTestMode'] )
+			$enable_test_mode
+			&& empty( $annotations['method']['noTestMode'] )
 			&& ! defined( 'PIWIK_TEST_MODE' )
 		) {
 			define( 'PIWIK_TEST_MODE', true );
@@ -62,9 +77,13 @@ class MatomoUnit_Matomo_Fixture {
 			}
 		}
 
-		if ( ! empty( $annotations['method']['noDebugLog'] ) ) {
+		if ( ! empty( $annotations['method']['noDebugLog'] ) && ! defined( 'MATOMO_DEBUG' ) ) {
 			define( 'MATOMO_DEBUG', false );
 		}
+	}
+
+	public function set_up( $test_case = null, $enable_test_mode = true ) {
+		$this->apply_test_annotations( $test_case, $enable_test_mode );
 
 		$this->uninstall_matomo();
 
@@ -90,6 +109,14 @@ class MatomoUnit_Matomo_Fixture {
 		// is always set when tests start
 		$roles->add_roles( true );
 
+		$this->register_hooks();
+
+		if ( ! empty( $GLOBALS['wpdb'] ) ) {
+			$GLOBALS['wpdb']->suppress_errors( false );
+		}
+	}
+
+	public function register_hooks() {
 		add_action(
 			'set_current_user',
 			function () {
@@ -123,10 +150,6 @@ class MatomoUnit_Matomo_Fixture {
 				\Piwik\Log::unsetInstance();
 			}
 		);
-
-		if ( ! empty( $GLOBALS['wpdb'] ) ) {
-			$GLOBALS['wpdb']->suppress_errors( false );
-		}
 	}
 
 	public function tear_down() {

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -204,8 +204,27 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 				continue;
 			}
 
+			$this->delete_matomo_upload_dir( $blog['blog_id'] );
+
 			wpmu_delete_blog( $blog['blog_id'] );
 		}
+	}
+
+	/**
+	 * @param int $blog_id
+	 */
+	private function delete_matomo_upload_dir( $blog_id ) {
+		switch_to_blog( $blog_id );
+
+		try {
+			// removes the blog's matomo upload and cache dirs, and nothing else
+			( new \WpMatomo\Paths() )->uninstall();
+			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		} catch ( \Exception $e ) {
+			// ignore; a blog we could not clean up must not stop the rest from being deleted
+		}
+
+		restore_current_blog();
 	}
 
 	/**

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -124,6 +124,21 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 		set_current_screen( 'edit.php' );
 	}
 
+	protected function activate_matomo_plugin() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		if ( is_multisite() ) {
+			update_site_option( 'active_sitewide_plugins', [ 'matomo/matomo.php' => time() ] );
+		} else {
+			// is_plugin_active_for_network() always returns false outside multisite
+			update_option( 'active_plugins', [ 'matomo/matomo.php' ] );
+		}
+
+		$this->assertTrue( is_plugin_active( 'matomo/matomo.php' ) );
+	}
+
 	protected function skip_if_old_wordpress() {
 		if ( version_compare( getenv( 'WORDPRESS_VERSION' ), '5.6', '<' ) ) {
 			$this->markTestSkipped( 'WordPress version does not support application passwords.' );

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -24,6 +24,10 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 
 	protected $overwrite_wpdb = true;
 
+	protected $tracker_user;
+
+	protected $application_password;
+
 	/**
 	 * The ROLLBACK executed by WP_UnitTestCase sometimes does not rollback to the correct
 	 * state, which causes succeeding tests to fail. (Specifically, it can revert to
@@ -99,6 +103,92 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 		}
 
 		return $id;
+	}
+
+	protected function assert_tracking_response( $tracking_response ) {
+		$this->assertEquals( $this->get_expected_tracking_response(), $tracking_response );
+	}
+
+	protected function assert_not_tracking_response( $tracking_response ) {
+		$this->assertNotEquals( $this->get_expected_tracking_response(), $tracking_response );
+	}
+
+	protected function make_local_tracker( $date_time, $set_auth = false ) {
+		\WpMatomo\Bootstrap::do_bootstrap();
+
+		include_once __DIR__ . '/test-local-tracker.php';
+		$site     = new \WpMatomo\Site();
+		$paths    = new \WpMatomo\Paths();
+		$endpoint = $paths->get_tracker_api_rest_api_endpoint();
+		$tracker  = new MatomoLocalTracker( $site->get_current_matomo_site_id(), $endpoint );
+
+		$tracker->setForceVisitDateTime( $date_time );
+		$tracker->setIp( '156.5.3.2' );
+		// Optional tracking
+		$tracker->setUserAgent( 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.2.6) Gecko/20100625 Firefox/3.6.6 (.NET CLR 3.5.30729)' );
+		$tracker->setBrowserLanguage( 'fr' );
+		$tracker->setLocalTime( '12:34:06' );
+		$tracker->setResolution( 1024, 768 );
+		$tracker->setBrowserHasCookies( true );
+		$tracker->setPlugins( true, true, false );
+
+		if ( $set_auth ) {
+			$this->create_user_for_tracker();
+			$tracker->setTokenAuth( 'testtesttest' ); // ignored
+			$tracker->setExtraServerVar( 'PHP_AUTH_USER', $this->tracker_user );
+			$tracker->setExtraServerVar( 'PHP_AUTH_PW', $this->application_password );
+		}
+
+		return $tracker;
+	}
+
+	protected function create_user_for_tracker() {
+		if ( isset( $this->tracker_user ) ) {
+			return;
+		}
+
+		$user_id = self::factory()->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		$user_login = wp_get_current_user()->user_login;
+
+		$this->assertNotEmpty( $user_login );
+
+		$sync = new \WpMatomo\User\Sync();
+		$sync->sync_all();
+
+		$user_model = new \Piwik\Plugins\UsersManager\Model();
+		$this->assertNotEmpty( $user_model->getUser( \WpMatomo\User::get_matomo_user_login( $user_id ) ) );
+
+		\Piwik\Tracker\TrackerConfig::setConfigValue( 'allow_wp_app_password_auth', 1 );
+
+		// add application password
+		// NOTE: we don't skip all the tests here to make sure the auth code
+		// works when application password functions do not exist
+		if ( version_compare( getenv( 'WORDPRESS_VERSION' ), '5.6', '>=' ) ) {
+			add_filter( 'wp_is_application_passwords_available', '__return_true' );
+
+			$request = new WP_REST_Request( 'POST', '/wp/v2/users/me/application-passwords' );
+			$request->set_param( 'name', 'test' );
+			$response = rest_get_server()->dispatch( $request );
+
+			$response_data        = $response->get_data();
+			$application_password = $response_data['password'];
+
+			$this->application_password = $application_password;
+		}
+
+		$this->tracker_user = $user_login;
+	}
+
+	private function get_expected_tracking_response() {
+		$trans_gif_64 = 'R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$expected_response = base64_decode( $trans_gif_64 );
+		return $expected_response;
 	}
 
 	private function delete_extraneous_blogs() {

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -258,8 +258,11 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 			restore_current_blog();
 		}
 
-		$blogs = $wpdb->get_results( 'SELECT blog_id, deleted FROM ' . $wpdb->blogs . ' ORDER BY blog_id', ARRAY_A );
+		$blogs    = $wpdb->get_results( 'SELECT blog_id, deleted FROM ' . $wpdb->blogs . ' ORDER BY blog_id', ARRAY_A );
+		$blog_ids = [];
 		foreach ( $blogs as $blog ) {
+			$blog_ids[] = (int) $blog['blog_id'];
+
 			if ( 1 === (int) $blog['deleted'] || 1 === (int) $blog['blog_id'] ) {
 				continue;
 			}
@@ -267,6 +270,30 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 			$this->delete_matomo_upload_dir( $blog['blog_id'] );
 
 			wpmu_delete_blog( $blog['blog_id'] );
+		}
+
+		$this->delete_orphaned_matomo_upload_dirs( $blog_ids );
+	}
+
+	/**
+	 * Removes leftover matomo upload dirs from blogs that were deleted or dropped by
+	 * a test or snapshot restoration, so they won't be re-used when a blog is created
+	 * with the same ID.
+	 *
+	 * @param int[] $existing_blog_ids
+	 */
+	private function delete_orphaned_matomo_upload_dirs( $existing_blog_ids ) {
+		$sites_dir = dirname( ( new \WpMatomo\Paths() )->get_upload_base_dir() ) . '/sites';
+		if ( ! is_dir( $sites_dir ) ) {
+			return;
+		}
+
+		foreach ( new FilesystemIterator( $sites_dir, FilesystemIterator::SKIP_DOTS ) as $dir ) {
+			if ( ! $dir->isDir() || in_array( (int) $dir->getFilename(), $existing_blog_ids, true ) ) {
+				continue;
+			}
+
+			\Piwik\Filesystem::unlinkRecursive( $dir->getPathname() . '/matomo', true );
 		}
 	}
 

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -303,22 +303,93 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 		}
 
 		// then fill tables with snapshot data
+		$has_rows = self::get_tables_with_at_least_one_row( array_keys( $existing ) );
 		foreach ( array_keys( $existing ) as $table ) {
-			$wpdb->query( "TRUNCATE `$table`" );
-
 			$rows = ! empty( self::$initial_table_data[ $table ]['rows'] ) ? self::$initial_table_data[ $table ]['rows'] : [];
-			if ( ! empty( $rows ) ) {
-				foreach ( $rows as $data_row ) {
-					$wpdb->insert( $table, $data_row );
-				}
-			} else {
+
+			if ( empty( $rows ) ) {
 				$is_multisite_table = preg_match( '/^' . preg_quote( $table_prefix, '/' ) . '\d+_/', $table );
 				if ( $is_multisite_table ) {
 					// WordPress will only initialize a site if the site table for it does not exist
 					// so we have to drop these if present, not just truncate.
 					$wpdb->query( "DROP TABLE `$table`" );
+				} elseif ( ! empty( $has_rows[ $table ] ) ) {
+					$wpdb->query( "TRUNCATE `$table`" );
 				}
+
+				continue;
 			}
+
+			if ( ! empty( $has_rows[ $table ] ) ) {
+				$wpdb->query( "TRUNCATE `$table`" );
+			}
+
+			self::insert_snapshot_rows( $table, $rows );
+		}
+	}
+
+	/**
+	 * @param string[] $tables
+	 * @return array table name => bool
+	 */
+	private static function get_tables_with_at_least_one_row( $tables ) {
+		global $wpdb;
+
+		if ( empty( $tables ) ) {
+			return [];
+		}
+
+		$selects = [];
+		foreach ( $tables as $table ) {
+			$selects[] = "SELECT '" . $wpdb->_real_escape( $table ) . "' AS snapshot_table, EXISTS( SELECT 1 FROM `$table` ) AS has_rows";
+		}
+
+		$has_rows = [];
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- table names come from SHOW TABLES
+		foreach ( (array) $wpdb->get_results( implode( ' UNION ALL ', $selects ), ARRAY_A ) as $row ) {
+			$has_rows[ $row['snapshot_table'] ] = ! empty( $row['has_rows'] );
+		}
+
+		return $has_rows;
+	}
+
+	/**
+	 * @param string $table
+	 * @param array  $rows
+	 */
+	private static function insert_snapshot_rows( $table, $rows ) {
+		global $wpdb;
+
+		$columns    = array_keys( reset( $rows ) );
+		$column_sql = '`' . implode( '`, `', $columns ) . '`';
+		$insert_sql = "INSERT INTO `$table` ($column_sql) VALUES ";
+
+		$values = [];
+		$length = 0;
+
+		foreach ( $rows as $data_row ) {
+			$cells = [];
+			foreach ( $columns as $column ) {
+				$value   = isset( $data_row[ $column ] ) ? $data_row[ $column ] : null;
+				$cells[] = null === $value ? 'NULL' : "'" . $wpdb->_real_escape( $value ) . "'";
+			}
+
+			$value_sql = '(' . implode( ', ', $cells ) . ')';
+			$values[]  = $value_sql;
+			$length   += strlen( $value_sql );
+
+			// option values can be large, so flush before getting anywhere near max_allowed_packet
+			if ( $length > 500000 ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- values escaped above
+				$wpdb->query( $insert_sql . implode( ', ', $values ) );
+				$values = [];
+				$length = 0;
+			}
+		}
+
+		if ( ! empty( $values ) ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- values escaped above
+			$wpdb->query( $insert_sql . implode( ', ', $values ) );
 		}
 	}
 

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -283,17 +283,20 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 	 * @param int[] $existing_blog_ids
 	 */
 	private function delete_orphaned_matomo_upload_dirs( $existing_blog_ids ) {
-		$sites_dir = dirname( ( new \WpMatomo\Paths() )->get_upload_base_dir() ) . '/sites';
+		$paths     = new \WpMatomo\Paths();
+		$sites_dir = dirname( $paths->get_upload_base_dir() ) . '/sites';
 		if ( ! is_dir( $sites_dir ) ) {
 			return;
 		}
+
+		$filesystem = $paths->get_file_system();
 
 		foreach ( new FilesystemIterator( $sites_dir, FilesystemIterator::SKIP_DOTS ) as $dir ) {
 			if ( ! $dir->isDir() || in_array( (int) $dir->getFilename(), $existing_blog_ids, true ) ) {
 				continue;
 			}
 
-			\Piwik\Filesystem::unlinkRecursive( $dir->getPathname() . '/matomo', true );
+			$filesystem->rmdir( $dir->getPathname() . '/matomo', true );
 		}
 	}
 

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -20,6 +20,45 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 
 	protected static $initial_table_data = [];
 
+	/**
+	 * A Matomo install as it looks on the main blog. Used to bootstrap blogs created during tests
+	 * without running the (slow) installer.
+	 *
+	 * Set to null at first, false when there is nothing to clone.
+	 *
+	 * @var array|false|null
+	 */
+	private static $matomo_blog_template = null;
+
+	/**
+	 * Set to false to turn off the blog creation optimization.
+	 *
+	 * Should be used by tests that call Installer::install(), or require a blog without
+	 * Matomo installed for whatever reason.
+	 *
+	 * @var bool
+	 */
+	protected $clone_matomo_to_new_blogs = true;
+
+	/**
+	 * Tables a per-blog install leaves empty, because create_website()/create_user() fill them
+	 * afterwards. Cloning the main blog's rows into them would hand the new blog the main blog's
+	 * site and users.
+	 *
+	 * @var string[]
+	 */
+	private static $blog_specific_matomo_tables = [
+		'access',
+		'session',
+		'site',
+		'site_setting',
+		'site_url',
+		'user',
+		'user_dashboard',
+		'user_language',
+		'user_token_auth',
+	];
+
 	private $original_wpdb = null;
 
 	protected $overwrite_wpdb = true;
@@ -55,9 +94,15 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 
 		$this->wordpress_fixture = new MatomoUnit_WordPress_Fixture();
 		$this->wordpress_fixture->set_up();
+
+		if ( is_multisite() && $this->clone_matomo_to_new_blogs ) {
+			add_action( 'wp_initialize_site', [ $this, 'clone_matomo_install_to_new_blog' ], 100, 1 );
+		}
 	}
 
 	public function tearDown(): void {
+		remove_action( 'wp_initialize_site', [ $this, 'clone_matomo_install_to_new_blog' ], 100 );
+
 		if ( is_multisite() ) {
 			$this->delete_extraneous_blogs();
 		}
@@ -208,6 +253,115 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 
 			wpmu_delete_blog( $blog['blog_id'] );
 		}
+	}
+
+	/**
+	 * Installing Matomo takes a long time, and a multisite test that creates a blog pays it
+	 * again for every blog. The result is deterministic though, so we can clone the main blog
+	 * to generate a new one, which is much faster.
+	 *
+	 * @param WP_Site $new_site
+	 */
+	public function clone_matomo_install_to_new_blog( $new_site ) {
+		global $wpdb;
+
+		$template = self::get_matomo_blog_template();
+		if ( empty( $template ) ) {
+			return; // Matomo is not installed on the main blog, so there is nothing to clone
+		}
+
+		$blog_id       = (int) $new_site->blog_id;
+		$target_prefix = $wpdb->get_blog_prefix( $blog_id ) . MATOMO_DATABASE_PREFIX;
+
+		foreach ( $template['tables'] as $suffix => $table ) {
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$wpdb->query( str_replace( $template['prefix'], $target_prefix, $table['create'] ) );
+
+			if ( ! empty( $table['rows'] ) ) {
+				self::insert_snapshot_rows( $target_prefix . $suffix, $table['rows'] );
+			}
+		}
+
+		switch_to_blog( $blog_id );
+
+		$config_path = ( new \WpMatomo\Paths() )->get_config_ini_path();
+		wp_mkdir_p( dirname( $config_path ) );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		file_put_contents( $config_path, str_replace( $template['prefix'], $target_prefix, $template['config'] ) );
+
+		// what Installer::install() records so looks_like_it_is_installed() stops returning false
+		$blog_settings = get_option( \WpMatomo\Settings::OPTION );
+		$blog_settings = is_array( $blog_settings ) ? $blog_settings : [];
+		$blog_settings[ \WpMatomo\Settings::INSTANCE_COMPONENTS_INSTALLED ] = $template['components'];
+		update_option( \WpMatomo\Settings::OPTION, $blog_settings );
+
+		update_option( \WpMatomo\Installer::OPTION_NAME_INSTALL_VERSION, $template['version'] );
+		update_option( \WpMatomo\Installer::OPTION_NAME_INSTALL_DATE, time() );
+
+		// the matomo_* roles live in the blog's own wp_N_user_roles. Roles::add_roles() normally
+		// adds them on init, which has long since fired by the time a test creates a blog, so
+		// without this the new blog has no role carrying view_matomo and nothing can be granted
+		( new \WpMatomo\Roles( new \WpMatomo\Settings() ) )->add_roles( true );
+
+		restore_current_blog();
+	}
+
+	/**
+	 * @return array|false
+	 */
+	private static function get_matomo_blog_template() {
+		global $wpdb;
+
+		if ( null !== self::$matomo_blog_template ) {
+			return self::$matomo_blog_template;
+		}
+
+		self::$matomo_blog_template = false;
+
+		$prefix = $wpdb->base_prefix . MATOMO_DATABASE_PREFIX;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$tables = $wpdb->get_col( 'SHOW TABLES LIKE "' . $wpdb->esc_like( $prefix ) . '%"' );
+		if ( empty( $tables ) ) {
+			return self::$matomo_blog_template;
+		}
+
+		$config_path = ( new \WpMatomo\Paths() )->get_config_ini_path();
+		if ( ! file_exists( $config_path ) ) {
+			return self::$matomo_blog_template;
+		}
+
+		$settings   = new \WpMatomo\Settings();
+		$components = $settings->get_option( \WpMatomo\Settings::INSTANCE_COMPONENTS_INSTALLED );
+		if ( empty( $components ) ) {
+			return self::$matomo_blog_template;
+		}
+
+		$template = [];
+		foreach ( $tables as $table ) {
+			$suffix = substr( $table, strlen( $prefix ) );
+			$create = $wpdb->get_row( "SHOW CREATE TABLE `$table`", ARRAY_N );
+
+			$template[ $suffix ] = [
+				// without dropping AUTO_INCREMENT the new blog's first site would be idsite 2, where
+				// a real per blog install gives it idsite 1
+				'create' => isset( $create[1] ) ? preg_replace( '/ AUTO_INCREMENT=\d+/', '', $create[1] ) : null,
+				'rows'   => in_array( $suffix, self::$blog_specific_matomo_tables, true )
+					? []
+					: $wpdb->get_results( "SELECT * FROM `$table`", ARRAY_A ),
+			];
+		}
+
+		self::$matomo_blog_template = [
+			'prefix'     => $prefix,
+			'tables'     => $template,
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_get_contents
+			'config'     => file_get_contents( $config_path ),
+			'components' => $components,
+			'version'    => get_option( \WpMatomo\Installer::OPTION_NAME_INSTALL_VERSION ),
+		];
+
+		return self::$matomo_blog_template;
 	}
 
 	/**

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -75,6 +75,12 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 		set_current_screen( 'edit.php' );
 	}
 
+	protected function skip_if_old_wordpress() {
+		if ( version_compare( getenv( 'WORDPRESS_VERSION' ), '5.6', '<' ) ) {
+			$this->markTestSkipped( 'WordPress version does not support application passwords.' );
+		}
+	}
+
 	protected function create_set_super_admin() {
 		$logger = new \WpMatomo\Logger();
 		$logger->log( 'creating super admin' );

--- a/tests/phpunit/framework/test-case.php
+++ b/tests/phpunit/framework/test-case.php
@@ -72,7 +72,7 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 
 		parent::tearDown();
 
-		$this->restore_db_snapshot();
+		self::restore_db_snapshot();
 	}
 
 	protected function assume_admin_page() {
@@ -253,28 +253,60 @@ class MatomoUnit_TestCase extends WP_UnitTestCase {
 	}
 
 	private function snapshot_db_data() {
-		global $wpdb;
-
 		if ( ! empty( self::$initial_table_data ) ) {
 			return;
 		}
 
-		$tables = $wpdb->get_results( 'SHOW TABLES', ARRAY_A );
-		foreach ( $tables as $row ) {
-			$table                              = reset( $row );
-			self::$initial_table_data[ $table ] = $wpdb->get_results( "SELECT * FROM `$table`", ARRAY_A );
-		}
+		self::$initial_table_data = self::capture_db_snapshot();
 	}
 
-	private function restore_db_snapshot() {
-		global $wpdb, $table_prefix;
+	/**
+	 * @return array table name => [ 'create' => string|null, 'rows' => array ]
+	 */
+	protected static function capture_db_snapshot() {
+		global $wpdb;
+
+		$data = [];
 
 		$tables = $wpdb->get_results( 'SHOW TABLES', ARRAY_A );
 		foreach ( $tables as $row ) {
 			$table = reset( $row );
+
+			$create = $wpdb->get_row( "SHOW CREATE TABLE `$table`", ARRAY_N );
+
+			$data[ $table ] = [
+				'create' => isset( $create[1] ) ? $create[1] : null,
+				'rows'   => $wpdb->get_results( "SELECT * FROM `$table`", ARRAY_A ),
+			];
+		}
+
+		return $data;
+	}
+
+	protected static function restore_db_snapshot() {
+		global $wpdb, $table_prefix;
+
+		$existing = [];
+		foreach ( $wpdb->get_results( 'SHOW TABLES', ARRAY_A ) as $row ) {
+			$existing[ reset( $row ) ] = true;
+		}
+
+		// create tables that are missing from the db
+		foreach ( self::$initial_table_data as $table => $snapshot ) {
+			if ( isset( $existing[ $table ] ) || empty( $snapshot['create'] ) ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- SHOW CREATE TABLE output, nothing to prepare
+			$wpdb->query( $snapshot['create'] );
+			$existing[ $table ] = true;
+		}
+
+		// then fill tables with snapshot data
+		foreach ( array_keys( $existing ) as $table ) {
 			$wpdb->query( "TRUNCATE `$table`" );
 
-			$rows = ! empty( self::$initial_table_data[ $table ] ) ? self::$initial_table_data[ $table ] : [];
+			$rows = ! empty( self::$initial_table_data[ $table ]['rows'] ) ? self::$initial_table_data[ $table ]['rows'] : [];
 			if ( ! empty( $rows ) ) {
 				foreach ( $rows as $data_row ) {
 					$wpdb->insert( $table, $data_row );

--- a/tests/phpunit/framework/test-matomo-shared-fixture-test-case.php
+++ b/tests/phpunit/framework/test-matomo-shared-fixture-test-case.php
@@ -6,12 +6,18 @@
 
 require_once __DIR__ . '/fixture/test-matomo-fixture.php';
 
+use Piwik\Application\Kernel\GlobalSettingsProvider;
+use Piwik\Container\StaticContainer;
 use WpMatomo\Bootstrap;
+use WpMatomo\Paths;
 
 /**
- * Test case that sets up Matomo/WP once in setUpBeforeClass and creates
- * a DB snapshot to restore to this blank state in setUp(). Allows avoiding
- * a full install/uninstall per test.
+ * Test case that sets up Matomo/WP once and creates a DB snapshot to restore to this blank state
+ * in setUp(). Allows avoiding a full install/uninstall per test.
+ *
+ * Only the first class using this fixture in a process runs the Matomo installer. It is torn down
+ * at the end of every class as usual, so nothing leaks into classes that do not use the fixture;
+ * later classes rebuild it from the snapshot instead, which is far faster than installing.
  */
 class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
 
@@ -22,24 +28,49 @@ class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
 
 	private static $saved_snapshot;
 
+	/**
+	 * Snapshot of WordPress with Matomo installed, kept across classes.
+	 *
+	 * @var array
+	 */
+	private static $shared_matomo_snapshot = [];
+
+	/**
+	 * The Matomo upload dir as it looks once installed, as relative path => contents. The database
+	 * snapshot cannot cover this, and uninstalling deletes the whole directory, so we need to
+	 * keep track and restore it in setUp.
+	 *
+	 * @var array
+	 */
+	private static $shared_matomo_files = [];
+
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
-		self::$matomo_fixture = new MatomoUnit_Matomo_Fixture();
-		self::$matomo_fixture->set_up();
+		// the parent's per-test restore has to target the database with Matomo installed, so swap
+		// the snapshot out and put the original back in tearDownAfterClass() for the classes that
+		// do not use this fixture.
+		self::$saved_snapshot = self::$initial_table_data;
 
-		// force the parent's per-test restore to target THIS class's installed database:
-		// emptying the snapshot makes the first test's start_transaction() re-capture it now,
-		// with Matomo installed. previous value saved for other classes.
-		self::$saved_snapshot     = self::$initial_table_data;
-		self::$initial_table_data = [];
+		if ( empty( self::$shared_matomo_snapshot ) ) { // snapshot empty, so build it
+			self::$matomo_fixture = new MatomoUnit_Matomo_Fixture();
+			self::$matomo_fixture->set_up();
+
+			self::$shared_matomo_snapshot = self::capture_db_snapshot();
+			self::$shared_matomo_files    = self::capture_matomo_upload_dir();
+		} else { // snapshot full, so re-use it
+			self::$initial_table_data = self::$shared_matomo_snapshot;
+
+			self::restore_shared_fixture();
+		}
+
+		self::$initial_table_data = self::$shared_matomo_snapshot;
 	}
 
 	public static function tearDownAfterClass(): void {
-		self::$matomo_fixture->tear_down();
+		( new MatomoUnit_Matomo_Fixture() )->tear_down();
 		self::$matomo_fixture = null;
 
-		// restore original snapshot
 		self::$initial_table_data = self::$saved_snapshot;
 		self::$saved_snapshot     = null;
 
@@ -79,5 +110,72 @@ class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
 		restore_error_handler();
 
 		parent::tearDown();
+	}
+
+	private static function restore_shared_fixture() {
+		self::restore_matomo_upload_dir();
+
+		clearstatcache();
+		Bootstrap::set_not_bootstrapped();
+
+		self::restore_db_snapshot();
+
+		// the rows are back, but the WordPress cache still has the old data, so clear it
+		wp_cache_flush();
+
+		global $wp_roles;
+		if ( $wp_roles instanceof WP_Roles ) {
+			$wp_roles->for_site();
+		}
+
+		if ( class_exists( StaticContainer::class ) && StaticContainer::getContainer() ) {
+			StaticContainer::get( GlobalSettingsProvider::class )->reload();
+		}
+	}
+
+	/**
+	 * @return array relative path => contents
+	 */
+	private static function capture_matomo_upload_dir() {
+		$base = ( new Paths() )->get_upload_base_dir();
+		if ( ! is_dir( $base ) ) {
+			return [];
+		}
+
+		$files = [];
+
+		$iterator = new RecursiveIteratorIterator(
+			// RecursiveDirectoryIterator rather than glob(), which would skip the .htaccess files
+			new RecursiveDirectoryIterator( $base, FilesystemIterator::SKIP_DOTS )
+		);
+
+		foreach ( $iterator as $file ) {
+			if ( ! $file->isFile() ) {
+				continue;
+			}
+
+			$relative = substr( $file->getPathname(), strlen( $base ) + 1 );
+			if ( strpos( $relative, 'tmp/' ) === 0 ) {
+				continue;
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_get_contents
+			$files[ $relative ] = file_get_contents( $file->getPathname() );
+		}
+
+		return $files;
+	}
+
+	private static function restore_matomo_upload_dir() {
+		$base = ( new Paths() )->get_upload_base_dir();
+
+		foreach ( self::$shared_matomo_files as $relative => $contents ) {
+			$path = $base . '/' . $relative;
+
+			wp_mkdir_p( dirname( $path ) );
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			file_put_contents( $path, $contents );
+		}
 	}
 }

--- a/tests/phpunit/framework/test-matomo-shared-fixture-test-case.php
+++ b/tests/phpunit/framework/test-matomo-shared-fixture-test-case.php
@@ -2,14 +2,18 @@
 /**
  * @package matomo
  * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery.NoCaching
  */
 
 require_once __DIR__ . '/fixture/test-matomo-fixture.php';
+require_once __DIR__ . '/traits/test-matomo-analytics-test.php';
 
 use Piwik\Application\Kernel\GlobalSettingsProvider;
 use Piwik\Container\StaticContainer;
 use WpMatomo\Bootstrap;
 use WpMatomo\Paths;
+use WpMatomo\Report\Metadata;
 
 /**
  * Test case that sets up Matomo/WP once and creates a DB snapshot to restore to this blank state
@@ -20,6 +24,8 @@ use WpMatomo\Paths;
  * later classes rebuild it from the snapshot instead, which is far faster than installing.
  */
 class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
+
+	use MatomoAnalyticsTest;
 
 	/**
 	 * @var MatomoUnit_Matomo_Fixture
@@ -54,7 +60,7 @@ class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
 
 		if ( empty( self::$shared_matomo_snapshot ) ) { // snapshot empty, so build it
 			self::$matomo_fixture = new MatomoUnit_Matomo_Fixture();
-			self::$matomo_fixture->set_up();
+			self::$matomo_fixture->set_up( null, ! static::class_has_no_test_mode_test() );
 
 			self::$shared_matomo_snapshot = self::capture_db_snapshot();
 			self::$shared_matomo_files    = self::capture_matomo_upload_dir();
@@ -96,9 +102,30 @@ class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
 			}
 		);
 
+		// a @runInSeparateProcess test tears its class down in the child process, so the parent
+		// never runs the tearDown() that would have put the tables back
+		self::restore_db_snapshot_if_tables_are_missing();
+
+		// the parent restores the database in tearDown(), but a test that uninstalls Matomo also
+		// deletes config.ini.php and the rest of the upload dir, so those have to come back too
+		self::restore_matomo_upload_dir();
+
+		$fixture = new MatomoUnit_Matomo_Fixture();
+
+		// the installer does not run per test here, but the annotations it reads still have to be
+		// honoured before anything bootstraps
+		$fixture->apply_test_annotations( $this );
+
 		// reset all in memory caches
 		Bootstrap::destroy_bootstrapped_environment();
+		Metadata::clear_cache();
 		Bootstrap::do_bootstrap();
+
+		$fixture->register_hooks();
+
+		if ( ! empty( $GLOBALS['wpdb'] ) ) {
+			$GLOBALS['wpdb']->suppress_errors( false );
+		}
 
 		global $wp_roles;
 		if ( $wp_roles instanceof WP_Roles ) {
@@ -110,6 +137,48 @@ class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
 		restore_error_handler();
 
 		parent::tearDown();
+	}
+
+	private static function class_has_no_test_mode_test() {
+		foreach ( get_class_methods( static::class ) as $method ) {
+			if ( strpos( $method, 'test' ) !== 0 ) {
+				continue;
+			}
+
+			$annotations = PHPUnit\Util\Test::parseTestMethodAnnotations( static::class, $method );
+			if ( ! empty( $annotations['method']['noTestMode'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Restoring the snapshot on every setUp() would roughly double what the per test restore costs,
+	 * so only do it when something really is gone - which in practice means Matomo's tables were
+	 * dropped by an uninstall this process did not get to clean up after.
+	 */
+	private static function restore_db_snapshot_if_tables_are_missing() {
+		global $wpdb;
+
+		$existing = [];
+		foreach ( $wpdb->get_results( 'SHOW TABLES', ARRAY_A ) as $row ) {
+			$existing[ reset( $row ) ] = true;
+		}
+
+		foreach ( array_keys( self::$initial_table_data ) as $table ) {
+			if ( isset( $existing[ $table ] ) ) {
+				continue;
+			}
+
+			self::restore_db_snapshot();
+
+			// the rows are back, but the WordPress cache still has the old data, so clear it
+			wp_cache_flush();
+
+			return;
+		}
 	}
 
 	private static function restore_shared_fixture() {
@@ -169,6 +238,8 @@ class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
 	private static function restore_matomo_upload_dir() {
 		$base = ( new Paths() )->get_upload_base_dir();
 
+		self::delete_files_not_in_snapshot( $base );
+
 		foreach ( self::$shared_matomo_files as $relative => $contents ) {
 			$path = $base . '/' . $relative;
 
@@ -176,6 +247,47 @@ class MatomoAnalytics_SharedFixture_TestCase extends MatomoUnit_TestCase {
 
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 			file_put_contents( $path, $contents );
+		}
+
+		clearstatcache();
+	}
+
+	/**
+	 * A reinstall would leave the upload dir with only the files the installer creates, so anything
+	 * a test wrote there has to go, or it is visible to the next test.
+	 *
+	 * @param string $base
+	 */
+	private static function delete_files_not_in_snapshot( $base ) {
+		if ( ! is_dir( $base ) ) {
+			return;
+		}
+
+		$iterator = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator( $base, FilesystemIterator::SKIP_DOTS ),
+			RecursiveIteratorIterator::CHILD_FIRST
+		);
+
+		foreach ( $iterator as $file ) {
+			$relative = substr( $file->getPathname(), strlen( $base ) + 1 );
+
+			// the tmp dir is excluded from the snapshot, so it is not ours to clean up
+			if ( 'tmp' === $relative || strpos( $relative, 'tmp/' ) === 0 ) {
+				continue;
+			}
+
+			if ( $file->isDir() ) {
+				if ( ! ( new FilesystemIterator( $file->getPathname() ) )->valid() ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir
+					rmdir( $file->getPathname() );
+				}
+				continue;
+			}
+
+			if ( ! isset( self::$shared_matomo_files[ $relative ] ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+				unlink( $file->getPathname() );
+			}
 		}
 	}
 }

--- a/tests/phpunit/framework/test-matomo-test-case.php
+++ b/tests/phpunit/framework/test-matomo-test-case.php
@@ -28,6 +28,7 @@ use WpMatomo\Uninstaller;
 use WpMatomo\User;
 
 require_once __DIR__ . '/fixture/test-matomo-fixture.php';
+require_once __DIR__ . '/traits/test-matomo-analytics-test.php';
 
 /**
  * Piwik constants
@@ -37,50 +38,12 @@ require_once __DIR__ . '/fixture/test-matomo-fixture.php';
  */
 class MatomoAnalytics_TestCase extends MatomoUnit_TestCase {
 
+	use MatomoAnalyticsTest;
+
 	/**
 	 * @var MatomoUnit_Matomo_Fixture
 	 */
 	protected $matomo_fixture;
-
-	/**
-	 * Disable creation of temporary tables. This may be needed when you're writing a test that is
-	 * tracking/archiving data. Problem is with temp tables many queries fail like this
-	 *
-	 * Can't really use temporary tables as we otherwise get errors like
-	 * : WP DB Error: Can't reopen table: 'log_action' - in plugin Actions at PluginsArchiver.php:186
-	 * because temp tables cannot be joined
-	 *
-	 * @var bool
-	 */
-	protected $disable_temp_tables = false;
-
-	/**
-	 * @param string $query
-	 *
-	 * @return mixed
-	 * phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
-	 */
-	public function _create_temporary_tables( $query ) {
-		if ( ! $this->disable_temp_tables ) {
-			$query = parent::_create_temporary_tables( $query );
-		}
-
-		return $query;
-	}
-
-	/**
-	 * @param string $query
-	 *
-	 * @return mixed
-	 * phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
-	 */
-	public function _drop_temporary_tables( $query ) {
-		if ( ! $this->disable_temp_tables ) {
-			$query = parent::_drop_temporary_tables( $query );
-		}
-
-		return $query;
-	}
 
 	public function setUp(): void {
 		parent::setUp();
@@ -133,21 +96,5 @@ class MatomoAnalytics_TestCase extends MatomoUnit_TestCase {
 
 	protected function assume_admin_page() {
 		set_current_screen( 'edit.php' );
-	}
-
-	protected function enable_browser_archiving() {
-		$_GET['trigger']                                = 'archivephp';
-		$general                                        = Config::getInstance()->General;
-		$general['enable_browser_archiving_triggering'] = 1;
-		$general['time_before_today_archive_considered_outdated'] = 1;
-		Config::getInstance()->General                            = $general;
-
-		$debug                            = Config::getInstance()->Debug;
-		$debug['always_archive_data_day'] = 1;
-		Config::getInstance()->Debug      = $debug;
-	}
-
-	protected function create_set_super_admin() {
-		return $this->matomo_fixture->create_set_super_admin( self::factory() );
 	}
 }

--- a/tests/phpunit/framework/test-matomo-test-case.php
+++ b/tests/phpunit/framework/test-matomo-test-case.php
@@ -54,10 +54,6 @@ class MatomoAnalytics_TestCase extends MatomoUnit_TestCase {
 	 */
 	protected $disable_temp_tables = false;
 
-	protected $tracker_user;
-
-	protected $application_password;
-
 	/**
 	 * @param string $query
 	 *
@@ -139,21 +135,6 @@ class MatomoAnalytics_TestCase extends MatomoUnit_TestCase {
 		set_current_screen( 'edit.php' );
 	}
 
-	protected function assert_tracking_response( $tracking_response ) {
-		$this->assertEquals( $this->get_expected_tracking_response(), $tracking_response );
-	}
-
-	protected function assert_not_tracking_response( $tracking_response ) {
-		$this->assertNotEquals( $this->get_expected_tracking_response(), $tracking_response );
-	}
-
-	private function get_expected_tracking_response() {
-		$trans_gif_64 = 'R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
-		$expected_response = base64_decode( $trans_gif_64 );
-		return $expected_response;
-	}
-
 	protected function enable_browser_archiving() {
 		$_GET['trigger']                                = 'archivephp';
 		$general                                        = Config::getInstance()->General;
@@ -166,78 +147,7 @@ class MatomoAnalytics_TestCase extends MatomoUnit_TestCase {
 		Config::getInstance()->Debug      = $debug;
 	}
 
-	protected function make_local_tracker( $date_time, $set_auth = false ) {
-		Bootstrap::do_bootstrap();
-
-		include_once 'test-local-tracker.php';
-		$site     = new WpMatomo\Site();
-		$paths    = new Paths();
-		$endpoint = $paths->get_tracker_api_rest_api_endpoint();
-		$tracker  = new MatomoLocalTracker( $site->get_current_matomo_site_id(), $endpoint );
-
-		$tracker->setForceVisitDateTime( $date_time );
-		$tracker->setIp( '156.5.3.2' );
-		// Optional tracking
-		$tracker->setUserAgent( 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.2.6) Gecko/20100625 Firefox/3.6.6 (.NET CLR 3.5.30729)' );
-		$tracker->setBrowserLanguage( 'fr' );
-		$tracker->setLocalTime( '12:34:06' );
-		$tracker->setResolution( 1024, 768 );
-		$tracker->setBrowserHasCookies( true );
-		$tracker->setPlugins( true, true, false );
-
-		if ( $set_auth ) {
-			$this->create_user_for_tracker();
-			$tracker->setTokenAuth( 'testtesttest' ); // ignored
-			$tracker->setExtraServerVar( 'PHP_AUTH_USER', $this->tracker_user );
-			$tracker->setExtraServerVar( 'PHP_AUTH_PW', $this->application_password );
-		}
-
-		return $tracker;
-	}
-
 	protected function create_set_super_admin() {
 		return $this->matomo_fixture->create_set_super_admin( self::factory() );
-	}
-
-	protected function create_user_for_tracker() {
-		if ( isset( $this->tracker_user ) ) {
-			return;
-		}
-
-		$user_id = self::factory()->user->create(
-			array(
-				'role' => 'administrator',
-			)
-		);
-		wp_set_current_user( $user_id );
-		$user_login = wp_get_current_user()->user_login;
-
-		$this->assertNotEmpty( $user_login );
-
-		$sync = new \WpMatomo\User\Sync();
-		$sync->sync_all();
-
-		$user_model = new \Piwik\Plugins\UsersManager\Model();
-		$this->assertNotEmpty( $user_model->getUser( \WpMatomo\User::get_matomo_user_login( $user_id ) ) );
-
-		\Piwik\Tracker\TrackerConfig::setConfigValue( 'allow_wp_app_password_auth', 1 );
-
-		// add application password
-		// NOTE: we don't skip all the tests here to make sure the auth code
-		// works when application password functions do not exist
-		if ( version_compare( getenv( 'WORDPRESS_VERSION' ), '5.6', '>=' ) ) {
-			add_filter( 'wp_is_application_passwords_available', '__return_true' );
-
-			$request = new WP_REST_Request( 'POST', '/wp/v2/users/me/application-passwords' );
-			$request->set_param( 'name', 'test' );
-			$response = rest_get_server()->dispatch( $request );
-
-			$response_data        = $response->get_data();
-			$application_password = $response_data['password'];
-
-			$this->application_password = $application_password;
-		}
-
-		$this->tracker_user = $user_login;
 	}
 }

--- a/tests/phpunit/framework/test-matomo-test-case.php
+++ b/tests/phpunit/framework/test-matomo-test-case.php
@@ -240,10 +240,4 @@ class MatomoAnalytics_TestCase extends MatomoUnit_TestCase {
 
 		$this->tracker_user = $user_login;
 	}
-
-	protected function skip_if_old_wordpress() {
-		if ( version_compare( getenv( 'WORDPRESS_VERSION' ), '5.6', '<' ) ) {
-			$this->markTestSkipped( 'WordPress version does not support application passwords.' );
-		}
-	}
 }

--- a/tests/phpunit/framework/traits/test-matomo-analytics-test.php
+++ b/tests/phpunit/framework/traits/test-matomo-analytics-test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Helpers shared by the two test cases that run against an installed Matomo,
+ * MatomoAnalytics_TestCase and MatomoAnalytics_SharedFixture_TestCase.
+ *
+ * @package matomo
+ */
+
+use Piwik\Config;
+
+trait MatomoAnalyticsTest {
+
+	/**
+	 * Disable creation of temporary tables. This may be needed when you're writing a test that is
+	 * tracking/archiving data. Problem is with temp tables many queries fail like this
+	 *
+	 * Can't really use temporary tables as we otherwise get errors like
+	 * : WP DB Error: Can't reopen table: 'log_action' - in plugin Actions at PluginsArchiver.php:186
+	 * because temp tables cannot be joined
+	 *
+	 * @var bool
+	 */
+	protected $disable_temp_tables = false;
+
+	/**
+	 * @param string $query
+	 *
+	 * @return mixed
+	 * phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+	 */
+	public function _create_temporary_tables( $query ) {
+		if ( ! $this->disable_temp_tables ) {
+			$query = parent::_create_temporary_tables( $query );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * @param string $query
+	 *
+	 * @return mixed
+	 * phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+	 */
+	public function _drop_temporary_tables( $query ) {
+		if ( ! $this->disable_temp_tables ) {
+			$query = parent::_drop_temporary_tables( $query );
+		}
+
+		return $query;
+	}
+
+	protected function enable_browser_archiving() {
+		$_GET['trigger']                                = 'archivephp';
+		$general                                        = Config::getInstance()->General;
+		$general['enable_browser_archiving_triggering'] = 1;
+		$general['time_before_today_archive_considered_outdated'] = 1;
+		Config::getInstance()->General                            = $general;
+
+		$debug                            = Config::getInstance()->Debug;
+		$debug['always_archive_data_day'] = 1;
+		Config::getInstance()->Debug      = $debug;
+	}
+
+	protected function create_set_super_admin() {
+		return ( new MatomoUnit_Matomo_Fixture() )->create_set_super_admin( self::factory() );
+	}
+}

--- a/tests/phpunit/plugins/WordPress/test-auth.php
+++ b/tests/phpunit/plugins/WordPress/test-auth.php
@@ -232,37 +232,6 @@ class WordPressAuthTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( AuthResult::SUCCESS, $result->getCode() );
 	}
 
-	public function test_authenticate_should_accept_an_application_password_when_the_capabilities_feature_is_not_registered() {
-		$this->skip_if_old_wordpress();
-
-		$wp_user_id = $this->create_mapped_user( 'nocapsuser', 'nocapsuser@example.com', 'nocapsuser' );
-		( new WP_User( $wp_user_id ) )->add_role( 'administrator' );
-
-		( new Model() )->addUserAccess( 'nocapsuser', View::ID, [ $this->get_current_idsite() ] );
-
-		$password = $this->create_application_password( $wp_user_id );
-
-		wp_set_current_user( 0 );
-		$_SERVER['PHP_AUTH_USER'] = 'nocapsuser';
-		$_SERVER['PHP_AUTH_PW']   = $password;
-
-		$capabilities = WpMatomo::get_active_feature( Capabilities::class );
-		$this->assertNotEmpty( $capabilities, 'Capabilities is expected to be registered by default' );
-
-		$capabilities->remove_hooks();
-		try {
-			// without the user_has_cap filter an administrator has no matomo capability at all
-			$this->assertFalse( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_VIEW ) );
-
-			$result = ( new Auth() )->authenticate();
-		} finally {
-			$capabilities->register_hooks();
-		}
-
-		$this->assertTrue( $result->wasAuthenticationSuccessful() );
-		$this->assertSame( 'nocapsuser', $result->getIdentity() );
-	}
-
 	public function test_authenticate_should_revoke_access_that_outranks_the_wp_capability() {
 		$this->skip_if_old_wordpress();
 
@@ -297,25 +266,26 @@ class WordPressAuthTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( View::ID, $this->get_access_for_idsite( 'downgraded', $idsite ) );
 	}
 
-	public function test_authenticate_should_not_revoke_access_when_the_capabilities_feature_is_not_registered() {
+	public function test_authenticate_should_reject_when_matomo_capabilities_cannot_be_resolved() {
 		$this->skip_if_old_wordpress();
 
-		$wp_user_id = $this->create_mapped_user( 'safemodeuser', 'safemodeuser@example.com', 'safemodeuser' );
+		$wp_user_id = $this->create_mapped_user( 'nocapsuser', 'nocapsuser@example.com', 'nocapsuser' );
 		( new WP_User( $wp_user_id ) )->add_role( 'administrator' );
 
 		$idsite = $this->get_current_idsite();
 
-		( new Model() )->addUserAccess( 'safemodeuser', Admin::ID, [ $idsite ] );
+		( new Model() )->addUserAccess( 'nocapsuser', Admin::ID, [ $idsite ] );
 
 		$password = $this->create_application_password( $wp_user_id );
 
 		wp_set_current_user( 0 );
-		$_SERVER['PHP_AUTH_USER'] = 'safemodeuser';
+		$_SERVER['PHP_AUTH_USER'] = 'nocapsuser';
 		$_SERVER['PHP_AUTH_PW']   = $password;
 
 		$capabilities = WpMatomo::get_active_feature( Capabilities::class );
 		$this->assertNotEmpty( $capabilities, 'Capabilities is expected to be registered by default' );
 
+		// simulate something like a plugin removing the hook
 		$capabilities->remove_hooks();
 		try {
 			$result = ( new Auth() )->authenticate();
@@ -323,9 +293,10 @@ class WordPressAuthTest extends MatomoAnalytics_SharedFixture_TestCase {
 			$capabilities->register_hooks();
 		}
 
-		// safe mode cannot resolve capabilities, so it must not conclude everyone lost their access
-		$this->assertTrue( $result->wasAuthenticationSuccessful() );
-		$this->assertSame( Admin::ID, $this->get_access_for_idsite( 'safemodeuser', $idsite ) );
+		$this->assertFalse( $result->wasAuthenticationSuccessful() );
+
+		// authentication is rejected, but stored access stays
+		$this->assertSame( Admin::ID, $this->get_access_for_idsite( 'nocapsuser', $idsite ) );
 	}
 
 	private function authenticate_with_token( $token ) {

--- a/tests/phpunit/plugins/WordPress/test-auth.php
+++ b/tests/phpunit/plugins/WordPress/test-auth.php
@@ -8,6 +8,7 @@
  */
 
 use Piwik\Access;
+use Piwik\Access\Role\Admin;
 use Piwik\Access\Role\View;
 use Piwik\API\Request as ApiRequest;
 use Piwik\AuthResult;
@@ -262,6 +263,71 @@ class WordPressAuthTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( 'nocapsuser', $result->getIdentity() );
 	}
 
+	public function test_authenticate_should_revoke_access_that_outranks_the_wp_capability() {
+		$this->skip_if_old_wordpress();
+
+		$wp_user_id = $this->create_mapped_user( 'downgraded', 'downgraded@example.com', 'downgraded' );
+		( new WP_User( $wp_user_id ) )->add_role( Roles::ROLE_VIEW );
+
+		$idsite = $this->get_current_idsite();
+
+		// the admin access a sync left behind before the WordPress side was downgraded to view
+		( new Model() )->addUserAccess( 'downgraded', Admin::ID, [ $idsite ] );
+
+		$password = $this->create_application_password( $wp_user_id );
+
+		wp_set_current_user( 0 );
+		$_SERVER['PHP_AUTH_USER'] = 'downgraded';
+		$_SERVER['PHP_AUTH_PW']   = $password;
+
+		$auth   = new Auth();
+		$result = $auth->authenticate();
+
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+
+		// matomo's authorisation layer reads the access table, so it must no longer see admin
+		Access::getInstance()->reloadAccess( $auth );
+
+		$admin_sites = array_map( 'intval', Access::getInstance()->getSitesIdWithAdminAccess() );
+		$view_sites  = array_map( 'intval', Access::getInstance()->getSitesIdWithAtLeastViewAccess() );
+
+		$this->assertNotContains( (int) $idsite, $admin_sites );
+		$this->assertContains( (int) $idsite, $view_sites );
+
+		$this->assertSame( View::ID, $this->get_access_for_idsite( 'downgraded', $idsite ) );
+	}
+
+	public function test_authenticate_should_not_revoke_access_when_the_capabilities_feature_is_not_registered() {
+		$this->skip_if_old_wordpress();
+
+		$wp_user_id = $this->create_mapped_user( 'safemodeuser', 'safemodeuser@example.com', 'safemodeuser' );
+		( new WP_User( $wp_user_id ) )->add_role( 'administrator' );
+
+		$idsite = $this->get_current_idsite();
+
+		( new Model() )->addUserAccess( 'safemodeuser', Admin::ID, [ $idsite ] );
+
+		$password = $this->create_application_password( $wp_user_id );
+
+		wp_set_current_user( 0 );
+		$_SERVER['PHP_AUTH_USER'] = 'safemodeuser';
+		$_SERVER['PHP_AUTH_PW']   = $password;
+
+		$capabilities = WpMatomo::get_active_feature( Capabilities::class );
+		$this->assertNotEmpty( $capabilities, 'Capabilities is expected to be registered by default' );
+
+		$capabilities->remove_hooks();
+		try {
+			$result = ( new Auth() )->authenticate();
+		} finally {
+			$capabilities->register_hooks();
+		}
+
+		// safe mode cannot resolve capabilities, so it must not conclude everyone lost their access
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( Admin::ID, $this->get_access_for_idsite( 'safemodeuser', $idsite ) );
+	}
+
 	private function authenticate_with_token( $token ) {
 		$auth = new Auth();
 		$auth->setLogin( null );
@@ -320,5 +386,20 @@ class WordPressAuthTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	private function get_current_idsite() {
 		return ( new Site() )->get_current_matomo_site_id();
+	}
+
+	/**
+	 * @param string $matomo_login
+	 * @param int    $idsite
+	 * @return string|null
+	 */
+	private function get_access_for_idsite( $matomo_login, $idsite ) {
+		foreach ( ( new Model() )->getSitesAccessFromUser( $matomo_login ) as $access ) {
+			if ( (int) $access['site'] === (int) $idsite ) {
+				return $access['access'];
+			}
+		}
+
+		return null;
 	}
 }

--- a/tests/phpunit/plugins/WordPress/test-auth.php
+++ b/tests/phpunit/plugins/WordPress/test-auth.php
@@ -8,19 +8,24 @@
  */
 
 use Piwik\Access;
+use Piwik\Access\Role\View;
 use Piwik\API\Request as ApiRequest;
+use Piwik\AuthResult;
 use Piwik\Container\StaticContainer;
 use Piwik\NoAccessException;
 use Piwik\Plugins\UsersManager\Model;
 use Piwik\Plugins\WordPress\Auth;
 use Piwik\Request\AuthenticationToken;
+use WpMatomo\Capabilities;
+use WpMatomo\Roles;
+use WpMatomo\Site;
 use WpMatomo\User;
 
 /**
  * @package matomo
  * phpcs:disable WordPress.Security.NonceVerification.Missing
  */
-class WordPressAuthTest extends MatomoAnalytics_TestCase {
+class WordPressAuthTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	private $original_get;
 	private $original_post;
@@ -152,6 +157,111 @@ class WordPressAuthTest extends MatomoAnalytics_TestCase {
 		$this->assertFalse( Access::getInstance()->hasSuperUserAccess() );
 	}
 
+	public function test_authenticate_should_reject_an_application_password_when_the_user_has_no_matomo_view_capability() {
+		$this->skip_if_old_wordpress();
+
+		$wp_user_id = $this->create_mapped_user( 'staleuser', 'staleuser@example.com', 'staleuser' );
+
+		// the View access a sync left behind after the WordPress side was revoked
+		( new Model() )->addUserAccess( 'staleuser', View::ID, [ $this->get_current_idsite() ] );
+
+		$this->assertFalse( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_VIEW ) );
+
+		// the credential is created only after the user lost their Matomo capability
+		$password = $this->create_application_password( $wp_user_id );
+
+		// no WordPress session: the application password is the only thing being presented
+		wp_set_current_user( 0 );
+		$_SERVER['PHP_AUTH_USER'] = 'staleuser';
+		$_SERVER['PHP_AUTH_PW']   = $password;
+
+		$result = ( new Auth() )->authenticate();
+
+		$this->assertFalse( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'anonymous', $result->getIdentity() );
+	}
+
+	public function test_authenticate_should_accept_an_application_password_when_the_user_has_matomo_view_capability() {
+		$this->skip_if_old_wordpress();
+
+		$wp_user_id = $this->create_mapped_user( 'liveuser', 'liveuser@example.com', 'liveuser' );
+		( new WP_User( $wp_user_id ) )->add_role( Roles::ROLE_VIEW );
+
+		( new Model() )->addUserAccess( 'liveuser', View::ID, [ $this->get_current_idsite() ] );
+
+		$this->assertTrue( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_VIEW ) );
+
+		$password = $this->create_application_password( $wp_user_id );
+
+		wp_set_current_user( 0 );
+		$_SERVER['PHP_AUTH_USER'] = 'liveuser';
+		$_SERVER['PHP_AUTH_PW']   = $password;
+
+		$result = ( new Auth() )->authenticate();
+
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'liveuser', $result->getIdentity() );
+	}
+
+	public function test_authenticate_should_not_grant_superuser_access_when_only_the_persisted_matomo_row_says_so() {
+		$this->skip_if_old_wordpress();
+
+		$wp_user_id = $this->create_mapped_user( 'staleadmin', 'staleadmin@example.com', 'staleadmin' );
+		( new WP_User( $wp_user_id ) )->add_role( Roles::ROLE_VIEW );
+
+		$model = new Model();
+		$model->addUserAccess( 'staleadmin', View::ID, [ $this->get_current_idsite() ] );
+
+		// the superuser flag a sync left behind after the WordPress side was downgraded
+		$model->setSuperUserAccess( 'staleadmin', true );
+
+		$this->assertFalse( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_SUPERUSER ) );
+
+		$password = $this->create_application_password( $wp_user_id );
+
+		wp_set_current_user( 0 );
+		$_SERVER['PHP_AUTH_USER'] = 'staleadmin';
+		$_SERVER['PHP_AUTH_PW']   = $password;
+
+		$result = ( new Auth() )->authenticate();
+
+		// the user still has View, so they authenticate, but only at the level WordPress grants
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+		$this->assertFalse( $result->hasSuperUserAccess() );
+		$this->assertSame( AuthResult::SUCCESS, $result->getCode() );
+	}
+
+	public function test_authenticate_should_accept_an_application_password_when_the_capabilities_feature_is_not_registered() {
+		$this->skip_if_old_wordpress();
+
+		$wp_user_id = $this->create_mapped_user( 'nocapsuser', 'nocapsuser@example.com', 'nocapsuser' );
+		( new WP_User( $wp_user_id ) )->add_role( 'administrator' );
+
+		( new Model() )->addUserAccess( 'nocapsuser', View::ID, [ $this->get_current_idsite() ] );
+
+		$password = $this->create_application_password( $wp_user_id );
+
+		wp_set_current_user( 0 );
+		$_SERVER['PHP_AUTH_USER'] = 'nocapsuser';
+		$_SERVER['PHP_AUTH_PW']   = $password;
+
+		$capabilities = WpMatomo::get_active_feature( Capabilities::class );
+		$this->assertNotEmpty( $capabilities, 'Capabilities is expected to be registered by default' );
+
+		$capabilities->remove_hooks();
+		try {
+			// without the user_has_cap filter an administrator has no matomo capability at all
+			$this->assertFalse( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_VIEW ) );
+
+			$result = ( new Auth() )->authenticate();
+		} finally {
+			$capabilities->register_hooks();
+		}
+
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'nocapsuser', $result->getIdentity() );
+	}
+
 	private function authenticate_with_token( $token ) {
 		$auth = new Auth();
 		$auth->setLogin( null );
@@ -193,5 +303,22 @@ class WordPressAuthTest extends MatomoAnalytics_TestCase {
 		$token = $model->generateRandomTokenAuth();
 		$model->addTokenAuth( $matomo_login, $token, 'test token', '2020-01-01 00:00:00' );
 		return $token;
+	}
+
+	private function create_application_password( $wp_user_id ) {
+		add_filter( 'wp_is_application_passwords_available', '__return_true' );
+
+		$created = WP_Application_Passwords::create_new_application_password(
+			$wp_user_id,
+			[ 'name' => 'regression test' ]
+		);
+
+		$this->assertNotWPError( $created );
+
+		return $created[0];
+	}
+
+	private function get_current_idsite() {
+		return ( new Site() )->get_current_matomo_site_id();
 	}
 }

--- a/tests/phpunit/plugins/WordPress/test-session-auth.php
+++ b/tests/phpunit/plugins/WordPress/test-session-auth.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ * @package matomo
+ */
+
+use Piwik\Access\Role\Admin;
+use Piwik\Access\Role\View;
+use Piwik\Plugins\UsersManager\Model;
+use Piwik\Plugins\WordPress\SessionAuth;
+use WpMatomo\Capabilities;
+use WpMatomo\Roles;
+use WpMatomo\Site;
+use WpMatomo\User;
+use WpMatomo\User\Sync;
+
+/**
+ * @package matomo
+ */
+class WordPressSessionAuthTest extends MatomoAnalytics_SharedFixture_TestCase {
+
+	public function test_authenticate_should_revoke_access_that_outranks_the_wp_capability() {
+		$wp_user_id = $this->create_view_user();
+		$login      = $this->sync_and_get_login( $wp_user_id );
+		$idsite     = $this->get_current_idsite();
+
+		// the admin access a sync left behind before the WordPress side was downgraded to view
+		$this->set_access_for_idsite( $login, Admin::ID, $idsite );
+
+		wp_set_current_user( $wp_user_id );
+
+		$result = ( new SessionAuth() )->authenticate();
+
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( $login, $result->getIdentity() );
+		$this->assertSame( View::ID, $this->get_access_for_idsite( $login, $idsite ) );
+	}
+
+	public function test_authenticate_should_leave_access_that_matches_the_wp_capability() {
+		$wp_user_id = $this->create_view_user();
+		$login      = $this->sync_and_get_login( $wp_user_id );
+		$idsite     = $this->get_current_idsite();
+
+		$this->assertSame( View::ID, $this->get_access_for_idsite( $login, $idsite ) );
+
+		wp_set_current_user( $wp_user_id );
+
+		$result = ( new SessionAuth() )->authenticate();
+
+		$this->assertTrue( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( View::ID, $this->get_access_for_idsite( $login, $idsite ) );
+	}
+
+	public function test_authenticate_should_be_anonymous_when_no_user_is_logged_in() {
+		wp_set_current_user( 0 );
+
+		$result = ( new SessionAuth() )->authenticate();
+
+		$this->assertFalse( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'anonymous', $result->getIdentity() );
+	}
+
+	public function test_authenticate_should_reject_a_user_without_the_matomo_view_capability() {
+		$wp_user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$this->assertFalse( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_VIEW ) );
+
+		wp_set_current_user( $wp_user_id );
+
+		$result = ( new SessionAuth() )->authenticate();
+
+		$this->assertFalse( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'anonymous', $result->getIdentity() );
+	}
+
+	/**
+	 * @return int
+	 */
+	private function create_view_user() {
+		$wp_user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		( new WP_User( $wp_user_id ) )->add_role( Roles::ROLE_VIEW );
+
+		$this->assertTrue( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_VIEW ) );
+		$this->assertFalse( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_ADMIN ) );
+
+		return $wp_user_id;
+	}
+
+	/**
+	 * @param int $wp_user_id
+	 * @return string
+	 */
+	private function sync_and_get_login( $wp_user_id ) {
+		( new Sync() )->sync_current_users();
+
+		$login = User::get_matomo_user_login( $wp_user_id );
+		$this->assertNotEmpty( $login );
+
+		return $login;
+	}
+
+	private function get_current_idsite() {
+		return ( new Site() )->get_current_matomo_site_id();
+	}
+
+	/**
+	 * @param string $matomo_login
+	 * @param int    $idsite
+	 * @return string|null
+	 */
+	private function get_access_for_idsite( $matomo_login, $idsite ) {
+		foreach ( ( new Model() )->getSitesAccessFromUser( $matomo_login ) as $access ) {
+			if ( (int) $access['site'] === (int) $idsite ) {
+				return $access['access'];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param string $matomo_login
+	 * @param string $role
+	 * @param int    $idsite
+	 */
+	private function set_access_for_idsite( $matomo_login, $role, $idsite ) {
+		$model = new Model();
+
+		$model->deleteUserAccess( $matomo_login, [ $idsite ] );
+		$model->addUserAccess( $matomo_login, $role, [ $idsite ] );
+
+		$this->assertSame( $role, $this->get_access_for_idsite( $matomo_login, $idsite ) );
+	}
+}

--- a/tests/phpunit/plugins/WordPress/test-session-auth.php
+++ b/tests/phpunit/plugins/WordPress/test-session-auth.php
@@ -76,6 +76,34 @@ class WordPressSessionAuthTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( 'anonymous', $result->getIdentity() );
 	}
 
+	public function test_authenticate_should_reject_when_matomo_capabilities_cannot_be_resolved() {
+		// an administrator's Matomo capabilities are added by the user_has_cap filter rather
+		// than stored on the role, so removing the filter takes all of them away
+		$wp_user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$login      = $this->sync_and_get_login( $wp_user_id );
+		$idsite     = $this->get_current_idsite();
+
+		$this->set_access_for_idsite( $login, Admin::ID, $idsite );
+
+		wp_set_current_user( $wp_user_id );
+
+		$capabilities = WpMatomo::get_active_feature( Capabilities::class );
+		$this->assertNotEmpty( $capabilities, 'Capabilities is expected to be registered by default' );
+
+		$capabilities->remove_hooks();
+		try {
+			$result = ( new SessionAuth() )->authenticate();
+		} finally {
+			$capabilities->register_hooks();
+		}
+
+		$this->assertFalse( $result->wasAuthenticationSuccessful() );
+		$this->assertSame( 'anonymous', $result->getIdentity() );
+
+		// rejecting is not the same as revoking, the stored access is left alone
+		$this->assertSame( Admin::ID, $this->get_access_for_idsite( $login, $idsite ) );
+	}
+
 	/**
 	 * @return int
 	 */

--- a/tests/phpunit/plugins/WordPress/test-wordpress-umd-css.php
+++ b/tests/phpunit/plugins/WordPress/test-wordpress-umd-css.php
@@ -16,7 +16,7 @@ use Piwik\Theme;
  * phpcs:disable WordPress.WP.AlternativeFunctions
  * phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
  */
-class WordPressUmdCssTest extends MatomoAnalytics_TestCase {
+class WordPressUmdCssTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	const CUSTOM_CSS_PLUGIN    = 'WpUmdCssTestPlugin';
 	const CUSTOM_NO_CSS_PLUGIN = 'WpUmdNoCssTestPlugin';

--- a/tests/phpunit/plugins/WordPress/test-wppasswordverifier.php
+++ b/tests/phpunit/plugins/WordPress/test-wppasswordverifier.php
@@ -14,7 +14,7 @@ use WpMatomo\User;
 /**
  * @package matomo
  */
-class WpPasswordVerifierTest extends MatomoAnalytics_TestCase {
+class WpPasswordVerifierTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var WpPasswordVerifier

--- a/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-advertisingconversionexport.php
+++ b/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-advertisingconversionexport.php
@@ -9,7 +9,7 @@
 
 use WpMatomo\Admin\PluginSuggestions\Suggestions\AdvertisingConversionExport;
 
-class AdvertisingConversionExportTest extends MatomoAnalytics_TestCase {
+class AdvertisingConversionExportTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-funnels.php
+++ b/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-funnels.php
@@ -10,7 +10,7 @@
 use WpMatomo\Admin\PluginSuggestions\Suggestions\Funnels;
 
 
-class FunnelsTest extends MatomoAnalytics_TestCase {
+class FunnelsTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-heatmapsessionrecording.php
+++ b/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-heatmapsessionrecording.php
@@ -9,7 +9,7 @@
 
 use WpMatomo\Admin\PluginSuggestions\Suggestions\HeatmapSessionRecording;
 
-class HeatmapSessionRecordingTest extends MatomoAnalytics_TestCase {
+class HeatmapSessionRecordingTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-searchenginekeywordsperformance.php
+++ b/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-searchenginekeywordsperformance.php
@@ -10,7 +10,7 @@
 use Piwik\Common;
 use WpMatomo\Admin\PluginSuggestions\Suggestions\SearchEngineKeywordsPerformance;
 
-class SearchEngineKeywordsPerformanceTest extends MatomoAnalytics_TestCase {
+class SearchEngineKeywordsPerformanceTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-usersflow.php
+++ b/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-usersflow.php
@@ -9,7 +9,7 @@
 
 use WpMatomo\Admin\PluginSuggestions\Suggestions\UsersFlow;
 
-class UsersFlowTest extends MatomoAnalytics_TestCase {
+class UsersFlowTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-wp-premium-bundle.php
+++ b/tests/phpunit/wpmatomo/admin/pluginsuggestions/suggestions/test-wp-premium-bundle.php
@@ -9,7 +9,7 @@
 
 use WpMatomo\Admin\PluginSuggestions\Suggestions\WpPremiumBundle;
 
-class WpPremiumBundleTest extends MatomoAnalytics_TestCase {
+class WpPremiumBundleTest extends MatomoAnalytics_SharedFixture_TestCase {
 	public function test_should_trigger_should_return_true_if_more_than_three_plugins_installed() {
 		$suggestion = $this->make_suggestion(
 			[

--- a/tests/phpunit/wpmatomo/admin/pluginsuggestions/test-plugin-suggestions.php
+++ b/tests/phpunit/wpmatomo/admin/pluginsuggestions/test-plugin-suggestions.php
@@ -12,7 +12,7 @@ use WpMatomo\Admin\PluginSuggestions\Suggestions\AdvertisingConversionExport;
 use WpMatomo\Admin\PluginSuggestions\Suggestions\Funnels;
 use WpMatomo\Admin\PluginSuggestions\Suggestions\HeatmapSessionRecording;
 
-class PluginSuggestionsTest extends MatomoAnalytics_TestCase {
+class PluginSuggestionsTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/phpunit/wpmatomo/admin/pluginsuggestions/test-suggestion.php
+++ b/tests/phpunit/wpmatomo/admin/pluginsuggestions/test-suggestion.php
@@ -36,7 +36,7 @@ class TestSuggestion extends Suggestion {
 	}
 }
 
-class SuggestionTest extends MatomoAnalytics_TestCase {
+class SuggestionTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 
 	public function test_is_suggestion_applicable_returns_true_if_the_suggestion_plugin_is_not_installed() {

--- a/tests/phpunit/wpmatomo/admin/test-accesssettings.php
+++ b/tests/phpunit/wpmatomo/admin/test-accesssettings.php
@@ -9,7 +9,7 @@ use WpMatomo\Capabilities;
 use WpMatomo\Roles;
 use WpMatomo\Settings;
 
-class AdminAccessSettingsTest extends MatomoAnalytics_TestCase {
+class AdminAccessSettingsTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var AccessSettings

--- a/tests/phpunit/wpmatomo/admin/test-adminsettings.php
+++ b/tests/phpunit/wpmatomo/admin/test-adminsettings.php
@@ -6,7 +6,7 @@
 use WpMatomo\Admin\AdminSettings;
 use WpMatomo\Settings;
 
-class AdminSettingsTest extends MatomoAnalytics_TestCase {
+class AdminSettingsTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var AdminSettings

--- a/tests/phpunit/wpmatomo/admin/test-dashboard.php
+++ b/tests/phpunit/wpmatomo/admin/test-dashboard.php
@@ -7,7 +7,7 @@ use WpMatomo\Admin\Dashboard;
 use WpMatomo\Report\Dates;
 use WpMatomo\Report\Renderer;
 
-class AdminDashboardTest extends MatomoAnalytics_TestCase {
+class AdminDashboardTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	const EXAMPLE_ID = 'VisitsSummary_get';
 

--- a/tests/phpunit/wpmatomo/admin/test-exclusionsettings.php
+++ b/tests/phpunit/wpmatomo/admin/test-exclusionsettings.php
@@ -9,7 +9,7 @@ use WpMatomo\Capabilities;
 use WpMatomo\Admin\InvalidIpException;
 use WpMatomo\Settings;
 
-class AdminExclusionSettingsTest extends MatomoAnalytics_TestCase {
+class AdminExclusionSettingsTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var ExclusionSettings

--- a/tests/phpunit/wpmatomo/admin/test-summary.php
+++ b/tests/phpunit/wpmatomo/admin/test-summary.php
@@ -9,7 +9,7 @@ use WpMatomo\Settings;
 use WpMatomo\Report\Dates;
 use WpMatomo\Report\Renderer;
 
-class AdminSummaryTest extends MatomoAnalytics_TestCase {
+class AdminSummaryTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Summary

--- a/tests/phpunit/wpmatomo/admin/test-systemreport.php
+++ b/tests/phpunit/wpmatomo/admin/test-systemreport.php
@@ -18,7 +18,7 @@ $piwik_minimumPHPVersion = '7.2.5';
  * phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
  * phpcs:disable WordPress.DB.DirectDatabaseQuery.SchemaChange
  */
-class AdminSystemReportTest extends MatomoAnalytics_TestCase {
+class AdminSystemReportTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var SystemReport

--- a/tests/phpunit/wpmatomo/admin/test-trackingsettings-bootstrapped.php
+++ b/tests/phpunit/wpmatomo/admin/test-trackingsettings-bootstrapped.php
@@ -6,7 +6,7 @@
 use WpMatomo\Admin\TrackingSettings;
 use WpMatomo\Settings;
 
-class AdminTrackingSettingsBootstrappedTest extends MatomoAnalytics_TestCase {
+class AdminTrackingSettingsBootstrappedTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var TrackingSettings

--- a/tests/phpunit/wpmatomo/admin/test-trackingsettings.php
+++ b/tests/phpunit/wpmatomo/admin/test-trackingsettings.php
@@ -17,7 +17,7 @@ use WpMatomo\Settings;
  *
  * phpcs:disable WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents
  */
-class AdminTrackingSettingsTest extends MatomoAnalytics_TestCase {
+class AdminTrackingSettingsTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var TrackingSettings

--- a/tests/phpunit/wpmatomo/db/test-info.php
+++ b/tests/phpunit/wpmatomo/db/test-info.php
@@ -5,7 +5,7 @@
 
 use WpMatomo\Db\Settings;
 
-class DbInfoTest extends MatomoAnalytics_TestCase {
+class DbInfoTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Settings

--- a/tests/phpunit/wpmatomo/db/test-wordpress.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpress.php
@@ -105,8 +105,9 @@ class DbWordPressTest extends MatomoAnalytics_SharedFixture_TestCase {
 	}
 
 	public function test_query_can_execute_select_queries() {
-		$table  = Common::prefixTable( 'user' );
-		$result = $this->db->query( ' select * from ' . $table );
+		$table = Common::prefixTable( 'user' );
+		// scoped to a single row: installing also creates Matomo's own anonymous user
+		$result = $this->db->query( ' select * from ' . $table . ' where login = ?', [ 'admin' ] );
 		$first  = $result->fetch();
 		$this->assertEquals( 'admin', $first['login'] );
 
@@ -116,7 +117,7 @@ class DbWordPressTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_query_can_execute_select_queries_with_comments() {
 		$table  = Common::prefixTable( 'user' );
-		$result = $this->db->query( ' /* trigger = CronArchive */ select * from ' . $table );
+		$result = $this->db->query( ' /* trigger = CronArchive */ select * from ' . $table . ' where login = ?', [ 'admin' ] );
 
 		$first = $result->fetch();
 		$this->assertEquals( 'admin', $first['login'] );

--- a/tests/phpunit/wpmatomo/db/test-wordpresstracker.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpresstracker.php
@@ -65,8 +65,9 @@ class DbWordPressTrackerTest extends MatomoAnalytics_SharedFixture_TestCase {
 	}
 
 	public function test_query_can_execute_select_queries() {
-		$table  = Common::prefixTable( 'user' );
-		$result = $this->db->query( ' select * from ' . $table );
+		$table = Common::prefixTable( 'user' );
+		// scoped to a single row: installing also creates Matomo's own anonymous user
+		$result = $this->db->query( ' select * from ' . $table . ' where login = ?', [ 'admin' ] );
 		$first  = $result->fetch();
 		$this->assertEquals( 'admin', $first['login'] );
 
@@ -76,7 +77,7 @@ class DbWordPressTrackerTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_query_can_execute_select_queries_with_comments() {
 		$table  = Common::prefixTable( 'user' );
-		$result = $this->db->query( ' /* trigger = CronArchive */ select * from ' . $table );
+		$result = $this->db->query( ' /* trigger = CronArchive */ select * from ' . $table . ' where login = ?', [ 'admin' ] );
 
 		$first = $result->fetch();
 		$this->assertEquals( 'admin', $first['login'] );

--- a/tests/phpunit/wpmatomo/db/test-wordpresstracker.php
+++ b/tests/phpunit/wpmatomo/db/test-wordpresstracker.php
@@ -6,7 +6,7 @@
 use Piwik\Common;
 use Piwik\Tracker\Db\WordPress;
 
-class DbWordPressTrackerTest extends MatomoAnalytics_TestCase {
+class DbWordPressTrackerTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var WordPress

--- a/tests/phpunit/wpmatomo/ecommerce/test-base.php
+++ b/tests/phpunit/wpmatomo/ecommerce/test-base.php
@@ -18,7 +18,7 @@ require_once __DIR__ . '/../../framework/mocks/mock-ajax-tracker.php';
  * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
  * phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
  */
-class BaseTest extends MatomoAnalytics_TestCase {
+class BaseTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Settings

--- a/tests/phpunit/wpmatomo/ecommerce/test-woocommerce.php
+++ b/tests/phpunit/wpmatomo/ecommerce/test-woocommerce.php
@@ -46,6 +46,8 @@ class WoocommerceTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	private $tracker;
 
+	private $sync_config;
+
 	public function setUp(): void {
 		parent::setUp();
 

--- a/tests/phpunit/wpmatomo/ecommerce/test-woocommerce.php
+++ b/tests/phpunit/wpmatomo/ecommerce/test-woocommerce.php
@@ -31,7 +31,7 @@ class TestWoocommerce extends \WpMatomo\Ecommerce\Woocommerce {
 /**
  * @package matomo
  */
-class WoocommerceTest extends MatomoAnalytics_TestCase {
+class WoocommerceTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	use MatomoWooCommerceAwareTest;
 

--- a/tests/phpunit/wpmatomo/report/test-data.php
+++ b/tests/phpunit/wpmatomo/report/test-data.php
@@ -5,7 +5,7 @@
 
 use WpMatomo\Report\Data;
 
-class ReportDataTest extends MatomoAnalytics_TestCase {
+class ReportDataTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Data

--- a/tests/phpunit/wpmatomo/report/test-dates.php
+++ b/tests/phpunit/wpmatomo/report/test-dates.php
@@ -6,7 +6,7 @@
 use WpMatomo\Report\Dates;
 use WpMatomo\User;
 
-class ReportDatesTest extends MatomoAnalytics_TestCase {
+class ReportDatesTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Dates

--- a/tests/phpunit/wpmatomo/report/test-metadata.php
+++ b/tests/phpunit/wpmatomo/report/test-metadata.php
@@ -6,7 +6,7 @@
 use WpMatomo\Bootstrap;
 use WpMatomo\Report\Metadata;
 
-class ReportMetadataTest extends MatomoAnalytics_TestCase {
+class ReportMetadataTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Metadata

--- a/tests/phpunit/wpmatomo/report/test-renderer.php
+++ b/tests/phpunit/wpmatomo/report/test-renderer.php
@@ -5,7 +5,7 @@
 
 use WpMatomo\Report\Dates;
 
-class ReportRendererTest extends MatomoAnalytics_TestCase {
+class ReportRendererTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	protected $disable_temp_tables = true;
 

--- a/tests/phpunit/wpmatomo/site/sync/test-syncconfig.php
+++ b/tests/phpunit/wpmatomo/site/sync/test-syncconfig.php
@@ -6,7 +6,7 @@
 use WpMatomo\Settings;
 use WpMatomo\Site\Sync;
 
-class SiteSyncConfigTest extends MatomoAnalytics_TestCase {
+class SiteSyncConfigTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Sync\SyncConfig

--- a/tests/phpunit/wpmatomo/site/test-sync.php
+++ b/tests/phpunit/wpmatomo/site/test-sync.php
@@ -463,11 +463,14 @@ class SiteSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 		update_blog_status( $blog_id, 'deleted', '1' );
 
-		// renamed before the hooks are registered, so update_option_blogname cannot sync it for us
-		// and the only thing left that could is the restore below
+		// renamed while Matomo is still inactive, so the plugin's own update_option_blogname hook
+		// cannot sync it for us and the only thing left that could is the restore below
 		switch_to_blog( $blog_id );
 		update_option( 'blogname', 'Renamed While Deleted' );
 		restore_current_blog();
+
+		// restore handlers require matomo to be active on the blog
+		$this->activate_matomo_plugin();
 
 		// sync_all() skips blogs flagged deleted, so the Matomo site stays stale
 		$this->sync->sync_all();

--- a/tests/phpunit/wpmatomo/site/test-sync.php
+++ b/tests/phpunit/wpmatomo/site/test-sync.php
@@ -20,7 +20,7 @@ class MockMatomoSiteSync extends Sync {
 	}
 }
 
-class SiteSyncTest extends MatomoAnalytics_TestCase {
+class SiteSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Sync
@@ -107,6 +107,36 @@ class SiteSyncTest extends MatomoAnalytics_TestCase {
 				),
 			),
 			$this->mock->synced_sites
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_sync_all_should_not_limit_the_number_of_blogs_it_syncs() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$limits = [];
+
+		$capture = function ( $query ) use ( &$limits ) {
+			$limits[] = (int) $query->query_vars['number'];
+		};
+
+		add_action( 'pre_get_sites', $capture );
+		try {
+			$this->mock->sync_all();
+		} finally {
+			remove_action( 'pre_get_sites', $capture );
+		}
+
+		$this->assertNotEmpty( $limits, 'expected sync_all() to query the list of blogs' );
+		$this->assertSame(
+			[ 0 ],
+			array_values( array_unique( $limits ) ),
+			'WP_Site_Query defaults to 100 blogs, so a limit leaves the rest without a Matomo site'
 		);
 	}
 

--- a/tests/phpunit/wpmatomo/site/test-sync.php
+++ b/tests/phpunit/wpmatomo/site/test-sync.php
@@ -4,6 +4,7 @@
  */
 
 use Piwik\Plugins\SitesManager\Model;
+use WpMatomo\Bootstrap;
 use WpMatomo\Settings;
 use WpMatomo\Site;
 use WpMatomo\Site\Sync;
@@ -444,6 +445,43 @@ class SiteSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		wp_delete_site( $blog_id );
 	}
 
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_sync_a_blog_that_has_been_restored_and_is_no_longer_flagged_deleted() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		// restoring a blog only ever happens in the network admin, and the sync is skipped on front
+		// end requests
+		$this->assume_admin_page();
+
+		$blog_id = $this->create_blog_with_matomo();
+		$idsite  = Site::get_matomo_site_id( $blog_id );
+
+		update_blog_status( $blog_id, 'deleted', '1' );
+
+		// renamed before the hooks are registered, so update_option_blogname cannot sync it for us
+		// and the only thing left that could is the restore below
+		switch_to_blog( $blog_id );
+		update_option( 'blogname', 'Renamed While Deleted' );
+		restore_current_blog();
+
+		// sync_all() skips blogs flagged deleted, so the Matomo site stays stale
+		$this->sync->sync_all();
+		$this->assertNotSame( 'Renamed While Deleted', $this->get_matomo_site_name_for_blog( $blog_id, $idsite ) );
+
+		$this->sync->register_hooks();
+
+		update_blog_status( $blog_id, 'deleted', '0' );
+
+		$this->assertSame( 'Renamed While Deleted', $this->get_matomo_site_name_for_blog( $blog_id, $idsite ) );
+
+		wp_delete_site( $blog_id );
+	}
+
 	private function create_blog_with_matomo() {
 		$blog_id = self::factory()->blog->create();
 
@@ -452,6 +490,25 @@ class SiteSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertNotEmpty( Site::get_matomo_site_id( $blog_id ) );
 
 		return $blog_id;
+	}
+
+	/**
+	 * every blog has its own matomo_site table, so the row has to be read while switched to it
+	 *
+	 * @param int $blog_id
+	 * @param int $idsite
+	 * @return string
+	 */
+	private function get_matomo_site_name_for_blog( $blog_id, $idsite ) {
+		switch_to_blog( $blog_id );
+		Bootstrap::do_bootstrap();
+
+		$site = ( new Model() )->getSiteFromId( $idsite );
+
+		restore_current_blog();
+		Bootstrap::do_bootstrap();
+
+		return $site['name'];
 	}
 
 	/**

--- a/tests/phpunit/wpmatomo/site/test-sync.php
+++ b/tests/phpunit/wpmatomo/site/test-sync.php
@@ -360,6 +360,113 @@ class SiteSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 	}
 
 	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_drop_the_matomo_tables_of_a_deleted_blog() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$blog_id = $this->create_blog_with_matomo();
+		$this->assertNotEmpty( $this->get_matomo_tables_for_blog( $blog_id ) );
+
+		wp_delete_site( $blog_id );
+
+		$this->assertSame( [], $this->get_matomo_tables_for_blog( $blog_id ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_remove_the_site_mapping_of_a_deleted_blog() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$blog_id = $this->create_blog_with_matomo();
+
+		$this->assertNotEmpty( Site::get_matomo_site_id( $blog_id ) );
+
+		wp_delete_site( $blog_id );
+
+		$this->assertEmpty( Site::get_matomo_site_id( $blog_id ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_keep_the_matomo_data_of_other_blogs_when_one_blog_is_deleted() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$deleted_blog_id = $this->create_blog_with_matomo();
+		$kept_blog_id    = $this->create_blog_with_matomo();
+
+		$kept_tables = $this->get_matomo_tables_for_blog( $kept_blog_id );
+		$kept_idsite = Site::get_matomo_site_id( $kept_blog_id );
+		$this->assertNotEmpty( $kept_tables );
+		$this->assertNotEmpty( $kept_idsite );
+
+		wp_delete_site( $deleted_blog_id );
+
+		// the mapping is deleted per blog, not with a LIKE across the whole network
+		$this->assertSame( $kept_tables, $this->get_matomo_tables_for_blog( $kept_blog_id ) );
+		$this->assertSame( $kept_idsite, Site::get_matomo_site_id( $kept_blog_id ) );
+
+		wp_delete_site( $kept_blog_id );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_keep_the_matomo_data_of_a_blog_that_is_only_flagged_deleted() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$blog_id = $this->create_blog_with_matomo();
+
+		$tables = $this->get_matomo_tables_for_blog( $blog_id );
+		$idsite = Site::get_matomo_site_id( $blog_id );
+		$this->assertNotEmpty( $tables );
+
+		// flagging a blog deleted is reversible, so nothing may be destroyed
+		wpmu_delete_blog( $blog_id, false );
+
+		$this->assertSame( $tables, $this->get_matomo_tables_for_blog( $blog_id ) );
+		$this->assertSame( $idsite, Site::get_matomo_site_id( $blog_id ) );
+
+		wp_delete_site( $blog_id );
+	}
+
+	private function create_blog_with_matomo() {
+		$blog_id = self::factory()->blog->create();
+
+		$this->sync->sync_all();
+
+		$this->assertNotEmpty( Site::get_matomo_site_id( $blog_id ) );
+
+		return $blog_id;
+	}
+
+	/**
+	 * @param int $blog_id
+	 * @return string[]
+	 */
+	private function get_matomo_tables_for_blog( $blog_id ) {
+		switch_to_blog( $blog_id );
+		$tables = ( new DbSettings() )->get_installed_matomo_tables();
+		restore_current_blog();
+
+		return $tables;
+	}
+
+	/**
 	 * get the mapping options in the wp_options table
 	 *
 	 * @return stdClass[]|null

--- a/tests/phpunit/wpmatomo/test-access.php
+++ b/tests/phpunit/wpmatomo/test-access.php
@@ -3,12 +3,16 @@
  * @package matomo
  */
 
+use Piwik\Plugins\UsersManager\Model;
 use WpMatomo\Access;
 use WpMatomo\Capabilities;
 use WpMatomo\Roles;
 use WpMatomo\Settings;
+use WpMatomo\Site;
+use WpMatomo\User;
+use WpMatomo\User\Sync;
 
-class AccessTest extends MatomoAnalytics_TestCase {
+class AccessTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Access
@@ -91,5 +95,44 @@ class AccessTest extends MatomoAnalytics_TestCase {
 			),
 			$access
 		);
+	}
+
+	public function test_save_should_grant_access_that_the_capabilities_it_just_stored_allow() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		$this->access->save( array( 'editor' => Capabilities::KEY_VIEW ) );
+
+		$login = User::get_matomo_user_login( $user_id );
+		$this->assertNotEmpty( $login );
+		$this->assertEquals( array( $this->get_current_site_id() ), $this->get_view_sites_for( $login ) );
+	}
+
+	public function test_save_should_revoke_access_that_the_capabilities_it_just_stored_no_longer_allow() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		// the behaviour under test is save()'s own sync, so get to the starting state independently
+		$this->access->save( array( 'editor' => Capabilities::KEY_VIEW ) );
+		( new Sync() )->sync_current_users();
+
+		$login = User::get_matomo_user_login( $user_id );
+		$this->assertEquals( array( $this->get_current_site_id() ), $this->get_view_sites_for( $login ) );
+
+		$this->access->save( array( 'editor' => Capabilities::KEY_NONE ) );
+
+		$this->assertSame( array(), $this->get_view_sites_for( $login ) );
+	}
+
+	private function get_current_site_id() {
+		return ( new Site() )->get_current_matomo_site_id();
+	}
+
+	/**
+	 * @param string $login
+	 * @return array
+	 */
+	private function get_view_sites_for( $login ) {
+		$view_access = ( new Model() )->getUsersSitesFromAccess( 'view' );
+
+		return isset( $view_access[ $login ] ) ? $view_access[ $login ] : array();
 	}
 }

--- a/tests/phpunit/wpmatomo/test-ajax-tracker.php
+++ b/tests/phpunit/wpmatomo/test-ajax-tracker.php
@@ -18,7 +18,7 @@ require_once __DIR__ . '/../framework/mocks/mock-ajax-tracker.php';
  * phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
  * phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
  */
-class AjaxTrackerTest extends MatomoAnalytics_TestCase {
+class AjaxTrackerTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	use MatomoWooCommerceAwareTest;
 

--- a/tests/phpunit/wpmatomo/test-annotations.php
+++ b/tests/phpunit/wpmatomo/test-annotations.php
@@ -10,7 +10,7 @@ use WpMatomo\Bootstrap;
 use WpMatomo\Settings;
 use WpMatomo\Site;
 
-class AnnotationsTest extends MatomoAnalytics_TestCase {
+class AnnotationsTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Annotations

--- a/tests/phpunit/wpmatomo/test-api.php
+++ b/tests/phpunit/wpmatomo/test-api.php
@@ -5,7 +5,7 @@
 
 use WpMatomo\API;
 
-class ApiTest extends MatomoAnalytics_TestCase {
+class ApiTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Api

--- a/tests/phpunit/wpmatomo/test-capabilities.php
+++ b/tests/phpunit/wpmatomo/test-capabilities.php
@@ -3,6 +3,9 @@
  * @package matomo
  */
 
+use Piwik\Access\Role\Admin;
+use Piwik\Access\Role\View;
+use Piwik\Access\Role\Write;
 use WpMatomo\Access;
 use WpMatomo\Capabilities;
 use WpMatomo\Settings;
@@ -20,7 +23,7 @@ class TestMatomoCapabilities extends Capabilities {
 	}
 }
 
-class CapabilitiesTest extends MatomoAnalytics_TestCase {
+class CapabilitiesTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var TestMatomoCapabilities
@@ -79,7 +82,7 @@ class CapabilitiesTest extends MatomoAnalytics_TestCase {
 	public function test_add_capabilities_to_user_and_add_capabilities_to_roles( $assume_network_enabled ) {
 		$this->settings->set_assume_is_network_enabled_in_tests( $assume_network_enabled );
 
-		$this->matomo_fixture->create_set_super_admin( self::factory() );
+		$this->create_set_super_admin();
 
 		$id1 = self::factory()->user->create( array( 'role' => 'editor' ) );
 		$id2 = self::factory()->user->create( array( 'role' => 'author' ) );
@@ -126,6 +129,62 @@ class CapabilitiesTest extends MatomoAnalytics_TestCase {
 			[ true ],
 			[ false ],
 		];
+	}
+
+	public function test_get_role_ranking_should_rank_matomo_access_from_no_access_to_superuser() {
+		// also guards the role IDs in Capabilities against drifting from Matomo's Role classes, as
+		// they have to be spelled out literally there
+		$this->assertSame( 0, Capabilities::get_role_ranking( null ) );
+		$this->assertSame( 0, Capabilities::get_role_ranking( 'noaccess' ) );
+		$this->assertSame( 1, Capabilities::get_role_ranking( View::ID ) );
+		$this->assertSame( 2, Capabilities::get_role_ranking( Write::ID ) );
+		$this->assertSame( 3, Capabilities::get_role_ranking( Admin::ID ) );
+		$this->assertSame( 4, Capabilities::get_role_ranking( Capabilities::ROLE_SUPERUSER ) );
+	}
+
+	/**
+	 * @dataProvider get_test_data_for_network_enabled_test
+	 */
+	public function test_get_highest_role_for_user_should_return_the_matomo_access_the_wp_capability_maps_to( $assume_network_enabled ) {
+		$this->settings->set_assume_is_network_enabled_in_tests( $assume_network_enabled );
+
+		$super_admin_id = $this->create_set_super_admin();
+
+		$admin_id     = self::factory()->user->create( [ 'role' => 'editor' ] );
+		$write_id     = self::factory()->user->create( [ 'role' => 'author' ] );
+		$view_id      = self::factory()->user->create( [ 'role' => 'contributor' ] );
+		$no_access_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$access = new Access( $this->settings );
+		$access->save(
+			[
+				'editor'      => Capabilities::KEY_ADMIN,
+				'author'      => Capabilities::KEY_WRITE,
+				'contributor' => Capabilities::KEY_VIEW,
+			]
+		);
+
+		$this->assertSame( Capabilities::ROLE_SUPERUSER, Capabilities::get_highest_role_for_user( $super_admin_id ) );
+		$this->assertSame( Admin::ID, Capabilities::get_highest_role_for_user( $admin_id ) );
+		$this->assertSame( Write::ID, Capabilities::get_highest_role_for_user( $write_id ) );
+		$this->assertSame( View::ID, Capabilities::get_highest_role_for_user( $view_id ) );
+		$this->assertNull( Capabilities::get_highest_role_for_user( $no_access_id ) );
+	}
+
+	public function test_is_capability_check_available_should_be_true_while_the_feature_is_registered() {
+		$this->assertTrue( Capabilities::is_capability_check_available() );
+	}
+
+	public function test_is_capability_check_available_should_be_false_once_the_feature_stops_filtering_capabilities() {
+		$registered = WpMatomo::get_active_feature( Capabilities::class );
+		$this->assertNotEmpty( $registered, 'Capabilities is expected to be registered by default' );
+
+		$registered->remove_hooks();
+		try {
+			$this->assertFalse( Capabilities::is_capability_check_available() );
+		} finally {
+			$registered->register_hooks();
+		}
 	}
 
 	private function make_all_caps( $caps_to_set ) {

--- a/tests/phpunit/wpmatomo/test-capabilities.php
+++ b/tests/phpunit/wpmatomo/test-capabilities.php
@@ -171,22 +171,6 @@ class CapabilitiesTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertNull( Capabilities::get_highest_role_for_user( $no_access_id ) );
 	}
 
-	public function test_is_capability_check_available_should_be_true_while_the_feature_is_registered() {
-		$this->assertTrue( Capabilities::is_capability_check_available() );
-	}
-
-	public function test_is_capability_check_available_should_be_false_once_the_feature_stops_filtering_capabilities() {
-		$registered = WpMatomo::get_active_feature( Capabilities::class );
-		$this->assertNotEmpty( $registered, 'Capabilities is expected to be registered by default' );
-
-		$registered->remove_hooks();
-		try {
-			$this->assertFalse( Capabilities::is_capability_check_available() );
-		} finally {
-			$registered->register_hooks();
-		}
-	}
-
 	private function make_all_caps( $caps_to_set ) {
 		$caps = array();
 		foreach ( $this->make_capabilities()->get_all_capabilities_sorted_by_highest_permission() as $cap ) {

--- a/tests/phpunit/wpmatomo/test-install.php
+++ b/tests/phpunit/wpmatomo/test-install.php
@@ -12,7 +12,7 @@ use WpMatomo\ScheduledTasks;
 use WpMatomo\Settings;
 use WpMatomo\Uninstaller;
 
-class InstallTest extends MatomoAnalytics_SharedFixture_TestCase {
+class InstallTest extends MatomoAnalytics_TestCase {
 
 	/**
 	 * these tests need to run Installer::install() itself, so a new blog has to start out without

--- a/tests/phpunit/wpmatomo/test-install.php
+++ b/tests/phpunit/wpmatomo/test-install.php
@@ -117,6 +117,13 @@ class InstallTest extends MatomoAnalytics_TestCase {
 		$users_model = new UsersModel();
 		$all_users   = $users_model->getUsers( array() );
 
+		// matomo creates its own anonymous user at install time. it is not a WP user and the sync
+		// leaves it alone, so only the admin row is compared in full below
+		$this->assertSame( array( 'admin', 'anonymous' ), array_column( $all_users, 'login' ) );
+		$this->assertEquals( '0', $all_users[1]['superuser_access'] );
+
+		$all_users = array( $all_users[0] );
+
 		foreach ( array( 'password', 'date_registered', 'ts_password_modified' ) as $field ) {
 			$this->assertNotEmpty( $all_users[0][ $field ] );
 			unset( $all_users[0][ $field ] );

--- a/tests/phpunit/wpmatomo/test-install.php
+++ b/tests/phpunit/wpmatomo/test-install.php
@@ -12,7 +12,7 @@ use WpMatomo\ScheduledTasks;
 use WpMatomo\Settings;
 use WpMatomo\Uninstaller;
 
-class InstallTest extends MatomoAnalytics_TestCase {
+class InstallTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * these tests need to run Installer::install() itself, so a new blog has to start out without
@@ -155,7 +155,7 @@ class InstallTest extends MatomoAnalytics_TestCase {
 		$this->assertFalse( $this->installer->looks_like_it_is_installed() );
 		$this->assertFalse( Installer::is_intalled() );
 
-		$this->matomo_fixture->reset_config_for_install();
+		( new MatomoUnit_Matomo_Fixture() )->reset_config_for_install();
 
 		Bootstrap::set_not_bootstrapped();
 		$this->assertTrue( $this->installer->install() );

--- a/tests/phpunit/wpmatomo/test-install.php
+++ b/tests/phpunit/wpmatomo/test-install.php
@@ -15,6 +15,14 @@ use WpMatomo\Uninstaller;
 class InstallTest extends MatomoAnalytics_TestCase {
 
 	/**
+	 * these tests need to run Installer::install() itself, so a new blog has to start out without
+	 * Matomo rather than getting the framework's cloned install
+	 *
+	 * @var bool
+	 */
+	protected $clone_matomo_to_new_blogs = false;
+
+	/**
 	 * @var Settings
 	 */
 	private $settings;

--- a/tests/phpunit/wpmatomo/test-mail.php
+++ b/tests/phpunit/wpmatomo/test-mail.php
@@ -7,7 +7,7 @@
 
 use Piwik\Mail;
 
-class MailTest extends MatomoAnalytics_TestCase {
+class MailTest extends MatomoAnalytics_SharedFixture_TestCase {
 	public function test_mail() {
 		if ( ! is_file( $this->plugin_file() ) ) {
 			$this->fail( 'cannot run mail test without wp-mail-smtp, plugin must be installed and configured via consts locally' );

--- a/tests/phpunit/wpmatomo/test-optout.php
+++ b/tests/phpunit/wpmatomo/test-optout.php
@@ -6,7 +6,7 @@ use WpMatomo\Admin\PrivacySettings;
  * @package matomo
  * phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
  */
-class OptOutTest extends MatomoAnalytics_TestCase {
+class OptOutTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_matomo_opt_out_classic_no_options() {
 		$result = do_shortcode( '[matomo_opt_out]' );

--- a/tests/phpunit/wpmatomo/test-release.php
+++ b/tests/phpunit/wpmatomo/test-release.php
@@ -6,7 +6,7 @@
  * @package matomo
  *
  */
-class ReleaseTest extends MatomoAnalytics_TestCase {
+class ReleaseTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	const MAX_RELEASE_SIZE = 26214400; // 25mb
 

--- a/tests/phpunit/wpmatomo/test-roles.php
+++ b/tests/phpunit/wpmatomo/test-roles.php
@@ -9,6 +9,8 @@ use WpMatomo\Settings;
 
 class RolesTest extends MatomoUnit_TestCase {
 
+	const THIRD_PARTY_ROLE = 'test_shop_manager';
+
 	/**
 	 * @var Roles
 	 */
@@ -20,6 +22,14 @@ class RolesTest extends MatomoUnit_TestCase {
 		$this->roles = $this->make_roles();
 		$this->roles->uninstall();
 		$this->roles->add_roles();
+	}
+
+	public function tearDown(): void {
+		// WP_Roles keeps roles in memory, and the database restore does not touch that, so a role
+		// left behind here would show up in every test case that runs after this one
+		remove_role( self::THIRD_PARTY_ROLE );
+
+		parent::tearDown();
 	}
 
 	private function make_roles() {
@@ -86,18 +96,28 @@ class RolesTest extends MatomoUnit_TestCase {
 	}
 
 	public function test_get_available_roles_for_configuration() {
+		add_role( self::THIRD_PARTY_ROLE, 'Shop manager' );
+
 		$roles = $this->roles->get_available_roles_for_configuration();
-		$this->assertSame(
-			array(
-				'editor'       => 'Editor',
-				'author'       => 'Author',
-				'contributor'  => 'Contributor',
-				'subscriber'   => 'Subscriber',
-				'customer'     => 'Customer',
-				'shop_manager' => 'Shop manager',
-			),
-			$roles
+
+		$expected = array(
+			'editor'               => 'Editor',
+			'author'               => 'Author',
+			'contributor'          => 'Contributor',
+			'subscriber'           => 'Subscriber',
+			self::THIRD_PARTY_ROLE => 'Shop manager',
 		);
+		foreach ( $expected as $role_name => $display_name ) {
+			$this->assertArrayHasKey( $role_name, $roles );
+			$this->assertSame( $display_name, $roles[ $role_name ] );
+		}
+
+		// administrator is the super user when not network enabled, so it is not configurable
+		$this->assertArrayNotHasKey( 'administrator', $roles );
+
+		foreach ( array_keys( $this->roles->get_matomo_roles() ) as $matomo_role ) {
+			$this->assertArrayNotHasKey( $matomo_role, $roles );
+		}
 	}
 
 	public function test_role_capability() {

--- a/tests/phpunit/wpmatomo/test-scheduled-tasks.php
+++ b/tests/phpunit/wpmatomo/test-scheduled-tasks.php
@@ -19,7 +19,7 @@ use WpMatomo\Uninstaller;
  * Don't need remote access
  * phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
  */
-class ScheduledTasksTest extends MatomoAnalytics_TestCase {
+class ScheduledTasksTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var ScheduledTasks

--- a/tests/phpunit/wpmatomo/test-settings.php
+++ b/tests/phpunit/wpmatomo/test-settings.php
@@ -6,7 +6,7 @@
 use WpMatomo\Admin\TrackingSettings;
 use WpMatomo\Settings;
 
-class SettingsTest extends MatomoAnalytics_TestCase {
+class SettingsTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Settings

--- a/tests/phpunit/wpmatomo/test-tracking.php
+++ b/tests/phpunit/wpmatomo/test-tracking.php
@@ -6,7 +6,7 @@
 /**
  * @phpcs:disable WordPress.PHP.IniSet.Risky
  */
-class TrackingTest extends MatomoAnalytics_TestCase {
+class TrackingTest extends MatomoAnalytics_SharedFixture_TestCase {
 	public function setUp(): void {
 		parent::setUp();
 

--- a/tests/phpunit/wpmatomo/test-uninstall.php
+++ b/tests/phpunit/wpmatomo/test-uninstall.php
@@ -11,7 +11,7 @@ use WpMatomo\Site;
 use WpMatomo\Uninstaller;
 use WpMatomo\User;
 
-class UninstallTest extends MatomoAnalytics_TestCase {
+class UninstallTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	/**
 	 * @var Installer

--- a/tests/phpunit/wpmatomo/test-uninstall.php
+++ b/tests/phpunit/wpmatomo/test-uninstall.php
@@ -11,7 +11,7 @@ use WpMatomo\Site;
 use WpMatomo\Uninstaller;
 use WpMatomo\User;
 
-class UninstallTest extends MatomoAnalytics_SharedFixture_TestCase {
+class UninstallTest extends MatomoAnalytics_TestCase {
 
 	/**
 	 * @var Installer

--- a/tests/phpunit/wpmatomo/test-updater.php
+++ b/tests/phpunit/wpmatomo/test-updater.php
@@ -7,7 +7,7 @@ use WpMatomo\Settings;
 use WpMatomo\Updater;
 use WpMatomo\User;
 
-class UpdaterTest extends MatomoAnalytics_TestCase {
+class UpdaterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 
 	/**
@@ -130,7 +130,12 @@ class UpdaterTest extends MatomoAnalytics_TestCase {
 	}
 
 	public function test_update_from_version_applys_updates_from_specified_version_to_current() {
-		\Piwik\Plugin\Manager::getInstance()->activatePlugin( 'TagManager' );
+		// activating TagManager looks the site up through the SitesManager API, which needs access
+		\Piwik\Access::doAsSuperUser(
+			function () {
+				\Piwik\Plugin\Manager::getInstance()->activatePlugin( 'TagManager' );
+			}
+		);
 
 		$settings  = new Settings();
 		$installer = new \WpMatomo\Installer( $settings );

--- a/tests/phpunit/wpmatomo/test-wp-matomo.php
+++ b/tests/phpunit/wpmatomo/test-wp-matomo.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @package matomo
+ */
+
+use WpMatomo\Capabilities;
+use WpMatomo\ScheduledTasks;
+use WpMatomo\Settings;
+use WpMatomo\Site\Sync as SiteSync;
+use WpMatomo\TrackingCode;
+use WpMatomo\User\Sync as UserSync;
+
+class WpMatomoTest extends MatomoUnit_TestCase {
+
+	public function test_get_safe_mode_features_should_include_capabilities_so_matomo_permissions_still_resolve() {
+		$this->assertContains( Capabilities::class, $this->get_safe_mode_feature_classes() );
+	}
+
+	public function test_get_safe_mode_features_should_include_capabilities_outside_wp_admin() {
+		set_current_screen( 'front' );
+		$this->assertFalse( is_admin() );
+
+		$this->assertContains( Capabilities::class, $this->get_safe_mode_feature_classes() );
+	}
+
+	public function test_get_safe_mode_features_should_not_include_features_that_boot_matomo() {
+		$this->assume_admin_page();
+
+		$classes = $this->get_safe_mode_feature_classes();
+
+		// safe mode exists so that a broken Matomo cannot take WordPress down with it, so nothing
+		// that reaches into the Matomo application may come back
+		$this->assertNotContains( SiteSync::class, $classes );
+		$this->assertNotContains( UserSync::class, $classes );
+		$this->assertNotContains( ScheduledTasks::class, $classes );
+		$this->assertNotContains( TrackingCode::class, $classes );
+	}
+
+	public function test_get_safe_mode_features_should_only_offer_the_admin_features_in_wp_admin() {
+		$this->assume_admin_page();
+		$admin_classes = $this->get_safe_mode_feature_classes();
+
+		set_current_screen( 'front' );
+		$this->assertFalse( is_admin() );
+		$front_classes = $this->get_safe_mode_feature_classes();
+
+		$this->assertContains( \WpMatomo\Admin\SafeModeMenu::class, $admin_classes );
+		$this->assertNotContains( \WpMatomo\Admin\SafeModeMenu::class, $front_classes );
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function get_safe_mode_feature_classes() {
+		$classes = [];
+
+		foreach ( WpMatomo::get_safe_mode_features( new Settings() ) as $feature ) {
+			$classes[] = get_class( $feature );
+		}
+
+		return $classes;
+	}
+}

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -1101,6 +1101,59 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( $login, User::get_matomo_user_login( $user_id ) );
 	}
 
+	public function test_register_hooks_should_not_delete_a_matomo_user_that_another_wordpress_user_is_also_mapped_to() {
+		$this->activate_matomo_plugin();
+
+		$keeper_id    = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$keeper_login = $this->grant_matomo_view_and_sync( $keeper_id );
+
+		$deleted_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$this->grant_matomo_view_and_sync( $deleted_id );
+
+		// corrupted state: both WP users point at the same Matomo login. deleting one of them must
+		// not take the identity the other is still using with it
+		User::map_matomo_user_login( $deleted_id, $keeper_login );
+
+		( new Sync() )->register_hooks();
+
+		self::delete_user( $deleted_id );
+
+		$this->assertNotEmpty( $this->get_matomo_user( $keeper_login ) );
+		$this->assertSame( $keeper_login, User::get_matomo_user_login( $keeper_id ) );
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $keeper_login ) );
+
+		// the contested mapping must not outlive the WP user it belonged to, or the keeper goes on
+		// looking contested and gets reallocated on their next sync
+		$this->assertFalse( User::get_matomo_user_login( $deleted_id ) );
+	}
+
+	public function test_register_hooks_should_stop_a_deleted_users_token_tracking() {
+		$this->activate_matomo_plugin();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		( new WP_User( $user_id ) )->add_role( Roles::ROLE_ADMIN );
+
+		( new Sync() )->sync_current_users();
+
+		$login = User::get_matomo_user_login( $user_id );
+		$this->assertSame( Admin::ID, $this->get_access_for_current_site( $login ) );
+
+		$token = ( new Model() )->generateRandomTokenAuth();
+		( new Model() )->addTokenAuth( $login, $token, 'test token', Date::now()->getDatetime() );
+
+		$idsite = $this->get_current_site_id();
+		$this->assertTrue( TrackerRequest::authenticateSuperUserOrAdminOrWrite( $token, $idsite ) );
+
+		( new Sync() )->register_hooks();
+
+		self::delete_user( $user_id );
+		$this->assertEmpty( $this->get_matomo_user( $login ) );
+
+		// the token rows went with the user, but the tracker compares against a hashed copy it never
+		// rechecks, so without invalidating it the token of a deleted user keeps tracking
+		$this->assertFalse( TrackerRequest::authenticateSuperUserOrAdminOrWrite( $token, $idsite ) );
+	}
+
 	public function test_register_hooks_should_leave_matomo_alone_when_a_user_it_never_synced_is_deleted() {
 		$this->activate_matomo_plugin();
 

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -132,6 +132,29 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		wp_delete_site( $blogid2 );
 	}
 
+	/**
+	 * @group ms-required
+	 */
+	public function test_sync_all_should_not_limit_the_number_of_blogs_it_reconciles() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$limits = $this->capture_blog_query_limits(
+			function () {
+				$this->mock->sync_all();
+			}
+		);
+
+		$this->assertNotEmpty( $limits, 'expected sync_all() to query the list of blogs' );
+		$this->assertSame(
+			[ 0 ],
+			array_values( array_unique( $limits ) ),
+			'WP_Site_Query defaults to 100 blogs, so a limit leaves the rest unreconciled'
+		);
+	}
+
 	public function test_sync_current_site_does_not_fail() {
 		$this->assertNull( $this->sync->sync_current_users() );
 	}
@@ -892,6 +915,27 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertEmpty( User::get_matomo_user_login( $user_id ) );
 
 		$this->assertFalse( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
+	}
+
+	/**
+	 * @param callable $callback
+	 * @return int[] the `number` query var of every blog query the callback made
+	 */
+	private function capture_blog_query_limits( $callback ) {
+		$limits = [];
+
+		$capture = function ( $query ) use ( &$limits ) {
+			$limits[] = (int) $query->query_vars['number'];
+		};
+
+		add_action( 'pre_get_sites', $capture );
+		try {
+			$callback();
+		} finally {
+			remove_action( 'pre_get_sites', $capture );
+		}
+
+		return $limits;
 	}
 
 	private function get_matomo_user( $login ) {

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -5,7 +5,9 @@
 
 use Piwik\Access\Role\Admin;
 use Piwik\Access\Role\View;
+use Piwik\Date;
 use Piwik\Plugins\UsersManager\Model;
+use Piwik\Tracker\Request as TrackerRequest;
 use WpMatomo\Access;
 use WpMatomo\Bootstrap;
 use WpMatomo\Capabilities;
@@ -1152,6 +1154,33 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		// superuser_access already grants every site, so the row the earlier role added is unneeded
 		$this->assertEquals( '1', $this->get_matomo_user( $login )['superuser_access'] );
 		$this->assertNull( $this->get_access_for_current_site( $login ) );
+	}
+
+	public function test_sync_current_users_should_stop_a_token_tracking_once_the_access_behind_it_is_gone() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		( new WP_User( $user_id ) )->add_role( Roles::ROLE_ADMIN );
+
+		( new Sync() )->sync_current_users();
+
+		$login = User::get_matomo_user_login( $user_id );
+		$this->assertSame( Admin::ID, $this->get_access_for_current_site( $login ) );
+
+		// the plugin never issues these itself, but UsersManager.createAppSpecificTokenAuth can, and
+		// only admin/write access puts one in the tracker's list of tokens allowed to force an IP,
+		// a timestamp or a visitor id
+		$token = ( new Model() )->generateRandomTokenAuth();
+		( new Model() )->addTokenAuth( $login, $token, 'test token', Date::now()->getDatetime() );
+
+		$idsite = $this->get_current_site_id();
+		$this->assertTrue( TrackerRequest::authenticateSuperUserOrAdminOrWrite( $token, $idsite ) );
+
+		( new WP_User( $user_id ) )->remove_role( Roles::ROLE_ADMIN );
+		( new WP_User( $user_id ) )->add_role( Roles::ROLE_VIEW );
+
+		( new Sync() )->sync_current_users();
+
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
+		$this->assertFalse( TrackerRequest::authenticateSuperUserOrAdminOrWrite( $token, $idsite ) );
 	}
 
 	public function test_sync_current_users_should_keep_a_user_whose_sync_threw_and_still_sync_the_rest() {

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -816,6 +816,50 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 	/**
 	 * @group ms-required
 	 */
+	public function test_register_hooks_should_resync_a_blog_that_has_been_restored_and_is_no_longer_flagged_deleted() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$this->activate_matomo_plugin();
+
+		$beta = $this->create_blog_with_matomo();
+
+		$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_login' => 'restoredadmin',
+			]
+		);
+		grant_super_admin( $user_id );
+
+		$logins = $this->sync_and_get_logins_per_blog( $user_id, [ $beta ] );
+		$login  = $logins[ $beta ];
+		$this->assertSame( '1', $this->get_matomo_user_on_blog( $beta, $login )['superuser_access'] );
+
+		( new Sync() )->register_hooks();
+
+		update_blog_status( $beta, 'deleted', '1' );
+
+		revoke_super_admin( $user_id );
+
+		// on_super_admin_change() skips blogs flagged deleted, so this one keeps access it should no
+		// longer have
+		$this->assertSame( '1', $this->get_matomo_user_on_blog( $beta, $login )['superuser_access'] );
+
+		update_blog_status( $beta, 'deleted', '0' );
+
+		// after restoration, the user is resynced, and because it has no Matomo capabilities
+		// as a subscriber, it is removed
+		$this->assertEmpty( $this->get_matomo_user_on_blog( $beta, $login ) );
+
+		wp_delete_site( $beta );
+	}
+
+	/**
+	 * @group ms-required
+	 */
 	public function test_on_super_admin_change_should_correct_blogs_other_than_the_current_one() {
 		if ( ! is_multisite() ) {
 			$this->markTestSkipped( 'Not multisite.' );

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -199,13 +199,16 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 		$model  = new Model();
 		$logins = $model->getUsersLogin();
-		$this->assertSame( array( 'admin', 'admin1', 'admin2' ), $logins );
+
+		$this->assertSame( array( 'admin', 'admin1', 'admin2', 'anonymous' ), $logins );
 
 		// all admins should also be super users
-		foreach ( $logins as $login ) {
+		foreach ( array( 'admin', 'admin1', 'admin2' ) as $login ) {
 			$matomo_user = $this->get_matomo_user( $login );
 			$this->assertEquals( '1', $matomo_user['superuser_access'] );
 		}
+
+		$this->assertEquals( '0', $this->get_matomo_user( 'anonymous' )['superuser_access'] );
 	}
 
 	public function test_sync_current_users_creates_users_where_needed() {
@@ -231,6 +234,7 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 				'admin',
 				'admin1',
 				'admin2',
+				'anonymous',
 				'author1',
 				'author2',
 				'editor1',
@@ -296,6 +300,7 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 				'admin',
 				'admin1',
 				'admin4',
+				'anonymous',
 				'contributor1',
 				'editor1',
 				'editor2',
@@ -335,6 +340,7 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 				'admin',
 				'admin1',
 				'admin4',
+				'anonymous',
 				'contributor1',
 				'editor1',
 				'editor2',
@@ -1031,11 +1037,9 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
 		$login   = $this->grant_matomo_view_and_sync( $user_id );
 
-		// matomo can hold sites beyond the one WordPress maps to this blog. access to one of those
-		// is what keeps the Matomo user alive once remove_user_from_blog() has revoked this site,
-		// and so is the only state in which deleting it would be observable
-		$other_idsite = $this->get_current_site_id() + 1000;
-		( new Model() )->addUserAccess( $login, View::ID, [ $other_idsite ] );
+		// a super admin is entitled to Matomo on every blog whether or not they are a member of it,
+		// so removing them from this one leaves a Matomo user that has to survive
+		grant_super_admin( $user_id );
 
 		( new Sync() )->register_hooks();
 
@@ -1048,9 +1052,8 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		wp_delete_user( $user_id );
 		$this->assertNotEmpty( get_userdata( $user_id ) );
 
-		// this blog's site was revoked by remove_user_from_blog(), the other one is untouched
-		$this->assertEquals( [ $other_idsite ], $this->get_view_sites_for( $login ) );
 		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
+		$this->assertEquals( '1', $this->get_matomo_user( $login )['superuser_access'] );
 		$this->assertSame( $login, User::get_matomo_user_login( $user_id ) );
 	}
 
@@ -1224,7 +1227,7 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( View::ID, $this->get_access_for_current_site( $other_login ) );
 	}
 
-	public function test_sync_user_if_access_exceeds_capabilities_should_clear_superuser_access_when_the_identity_survives() {
+	public function test_sync_user_if_access_exceeds_capabilities_should_remove_a_revoked_user_that_a_stale_site_row_would_otherwise_keep() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 
 		( new Sync() )->sync_current_users();
@@ -1233,15 +1236,34 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertNotEmpty( $login );
 		$this->assertEquals( '1', $this->get_matomo_user( $login )['superuser_access'] );
 
-		// add view access row in addition to the superuser flag above
-		( new Model() )->addUserAccess( $login, View::ID, [ $this->get_current_site_id() + 1000 ] );
+		// stale site access which shouldn't normally happen
+		$stale_idsite = $this->get_current_site_id() + 1000;
+		( new Model() )->addUserAccess( $login, View::ID, [ $stale_idsite ] );
 
 		( new WP_User( $user_id ) )->remove_role( 'administrator' ); // user will have no access after this
 
 		$this->assertTrue( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
 
+		$this->assertEmpty( $this->get_matomo_user( $login ) );
+		$this->assertSame( [], ( new Model() )->getSitesAccessFromUser( $login ) );
+	}
+
+	public function test_sync_current_users_should_remove_access_to_sites_the_blog_is_not_mapped_to() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		// only one Matomo site belongs to a blog, so a row for any other is orphaned. Site\Sync
+		// can produce them by creating a fresh site whenever the blog to site mapping is lost
+		$stale_idsite = $this->get_current_site_id() + 1000;
+		( new Model() )->addUserAccess( $login, Admin::ID, [ $stale_idsite ] );
+
+		( new Sync() )->sync_current_users();
+
+		// the user is retained, so nothing else would ever have reconciled the stale row
 		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
-		$this->assertEquals( '0', $this->get_matomo_user( $login )['superuser_access'] );
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
+		$this->assertEquals( [ $this->get_current_site_id() ], $this->get_view_sites_for( $login ) );
+		$this->assertSame( [], ( new Model() )->getUsersSitesFromAccess( Admin::ID ) );
 	}
 
 	public function test_sync_user_if_access_exceeds_capabilities_should_revoke_when_no_capability_resolves_for_the_user() {

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -50,6 +50,15 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
+		$this->assume_admin_page();
+
+		// if left active, the plugin's own Sync would start syncing on every role change. these
+		// tests drive their own instance, so leave only the test one hooked
+		$registered = WpMatomo::get_active_feature( Sync::class );
+		if ( $registered ) {
+			$registered->remove_hooks();
+		}
+
 		$this->sync            = new MockMatomoUserSync();
 		$this->sync->mock_sync = false;
 		$this->mock            = new MockMatomoUserSync();

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -1474,21 +1474,6 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( $role, $this->get_access_for_current_site( $login ) );
 	}
 
-	private function activate_matomo_plugin() {
-		if ( ! function_exists( 'is_plugin_active' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		if ( is_multisite() ) {
-			update_site_option( 'active_sitewide_plugins', [ 'matomo/matomo.php' => time() ] );
-		} else {
-			// is_plugin_active_for_network() always returns false outside multisite
-			update_option( 'active_plugins', [ 'matomo/matomo.php' ] );
-		}
-
-		$this->assertTrue( is_plugin_active( 'matomo/matomo.php' ) );
-	}
-
 	/**
 	 * @param int $wp_user_id
 	 * @return string the Matomo login the user was synced to

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -972,6 +972,33 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( $login, User::get_matomo_user_login( $user_id ) );
 	}
 
+	public function test_on_clean_user_cache_should_not_delete_another_users_access_when_the_login_mapping_is_reallocated() {
+		$this->activate_matomo_plugin();
+
+		$other_id    = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$other_login = $this->grant_matomo_view_and_sync( $other_id );
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		( new WP_User( $user_id ) )->add_role( Roles::ROLE_VIEW );
+
+		// corrupted state: both WP users point at the same Matomo login, so syncing this one has to
+		// give it a login of its own rather than let the two share an identity
+		User::map_matomo_user_login( $user_id, $other_login );
+
+		$sync = new Sync();
+		$sync->on_remove_user_from_blog( $user_id, get_current_blog_id() );
+		$sync->on_clean_user_cache( $user_id );
+
+		$new_login = User::get_matomo_user_login( $user_id );
+		$this->assertNotEmpty( $new_login );
+		$this->assertNotSame( $other_login, $new_login );
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $new_login ) );
+
+		// the contested login belongs to the other user, who was not part of this sync at all
+		$this->assertSame( $other_login, User::get_matomo_user_login( $other_id ) );
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $other_login ) );
+	}
+
 	public function test_register_hooks_should_delete_the_matomo_user_when_a_wordpress_user_is_deleted() {
 		$this->activate_matomo_plugin();
 

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -5,6 +5,7 @@
 
 use Piwik\Plugins\UsersManager\Model;
 use WpMatomo\Access;
+use WpMatomo\Bootstrap;
 use WpMatomo\Capabilities;
 use WpMatomo\Roles;
 use WpMatomo\Settings;
@@ -590,9 +591,302 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$caps->remove_hooks();
 	}
 
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_revoke_matomo_access_when_a_user_is_removed_from_a_blog() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$this->activate_matomo_plugin();
+
+		$beta = $this->create_blog_with_matomo();
+
+		$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_login' => 'betaviewer',
+			]
+		);
+		add_user_to_blog( $beta, $user_id, Roles::ROLE_VIEW );
+
+		// check that the user really does have Matomo View on the other blog before we remove them
+		$this->switch_to_bootstrapped_blog( $beta );
+		( new Sync() )->sync_current_users();
+		$beta_idsite = $this->get_current_site_id();
+		$login       = User::get_matomo_user_login( $user_id );
+		$this->assertNotEmpty( $login );
+		$this->assertEquals( [ $beta_idsite ], $this->get_view_sites_for( $login ) );
+		$this->restore_bootstrapped_blog();
+
+		( new Sync() )->register_hooks();
+
+		remove_user_from_blog( $user_id, $beta );
+
+		$this->switch_to_bootstrapped_blog( $beta );
+
+		// sanity check: WordPress itself no longer considers the user able to view Matomo here, so
+		// anything left below is Matomo's own stale state and not a broken fixture
+		$this->assertFalse( user_can( new WP_User( $user_id ), Capabilities::KEY_VIEW ) );
+
+		$this->assertEquals( [], $this->get_view_sites_for( $login ) );
+		$this->assertEmpty( $this->get_matomo_user( $login ) );
+		$this->assertFalse( User::get_matomo_user_login( $user_id ) );
+
+		$this->restore_bootstrapped_blog();
+
+		wp_delete_site( $beta );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_keep_matomo_access_on_other_blogs_when_a_user_is_removed_from_one_blog() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$this->activate_matomo_plugin();
+
+		$beta = $this->create_blog_with_matomo();
+
+		$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_login' => 'dualsiteviewer',
+			]
+		);
+		add_user_to_blog( $beta, $user_id, Roles::ROLE_VIEW );
+
+		// the user keeps Matomo View on the main blog, which is the access that must be preserved
+		( new WP_User( $user_id ) )->add_role( Roles::ROLE_VIEW );
+		( new Sync() )->sync_current_users();
+		$main_idsite = $this->get_current_site_id();
+		$main_login  = User::get_matomo_user_login( $user_id );
+		$this->assertNotEmpty( $main_login );
+		$this->assertEquals( [ $main_idsite ], $this->get_view_sites_for( $main_login ) );
+
+		$this->switch_to_bootstrapped_blog( $beta );
+		( new Sync() )->sync_current_users();
+		$this->restore_bootstrapped_blog();
+
+		( new Sync() )->register_hooks();
+
+		remove_user_from_blog( $user_id, $beta );
+
+		Bootstrap::do_bootstrap();
+
+		$this->assertTrue( user_can( new WP_User( $user_id ), Capabilities::KEY_VIEW ) );
+		$this->assertSame( $main_login, User::get_matomo_user_login( $user_id ) );
+		$this->assertNotEmpty( $this->get_matomo_user( $main_login ) );
+		$this->assertEquals( [ $main_idsite ], $this->get_view_sites_for( $main_login ) );
+
+		wp_delete_site( $beta );
+	}
+
+	public function test_on_remove_user_from_blog_should_not_change_matomo_access_on_its_own() {
+		$this->activate_matomo_plugin();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		( new Sync() )->on_remove_user_from_blog( $user_id, get_current_blog_id() );
+
+		$this->assertEquals( [ $this->get_current_site_id() ], $this->get_view_sites_for( $login ) );
+		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
+		$this->assertSame( $login, User::get_matomo_user_login( $user_id ) );
+	}
+
+	public function test_on_remove_user_from_blog_should_fall_back_to_the_current_blog_when_no_blog_id_is_given() {
+		$this->activate_matomo_plugin();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		$sync = new Sync();
+		$sync->on_remove_user_from_blog( $user_id, 0 );
+
+		$this->remove_matomo_view_from_user( $user_id );
+
+		$sync->on_clean_user_cache( $user_id );
+
+		$this->assertEquals( [], $this->get_view_sites_for( $login ) );
+		$this->assertEmpty( $this->get_matomo_user( $login ) );
+	}
+
+	public function test_on_clean_user_cache_should_do_nothing_when_the_user_was_not_removed() {
+		$this->activate_matomo_plugin();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		// the capability is gone but no removal was recorded, so this is one of the many unrelated
+		// clean_user_cache() calls that must be ignored
+		$this->remove_matomo_view_from_user( $user_id );
+
+		( new Sync() )->on_clean_user_cache( $user_id );
+
+		$this->assertEquals( [ $this->get_current_site_id() ], $this->get_view_sites_for( $login ) );
+		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
+	}
+
+	public function test_on_clean_user_cache_should_do_nothing_when_the_removal_was_recorded_for_a_different_blog() {
+		$this->activate_matomo_plugin();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		$this->remove_matomo_view_from_user( $user_id );
+
+		$sync = new Sync();
+		$sync->on_remove_user_from_blog( $user_id, get_current_blog_id() + 1234 );
+
+		$sync->on_clean_user_cache( $user_id );
+
+		$this->assertEquals( [ $this->get_current_site_id() ], $this->get_view_sites_for( $login ) );
+		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_on_clean_user_cache_should_flush_only_the_blog_it_is_called_on() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$this->activate_matomo_plugin();
+
+		$beta = $this->create_blog_with_matomo();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		add_user_to_blog( $beta, $user_id, Roles::ROLE_VIEW );
+
+		$main_login = $this->grant_matomo_view_and_sync( $user_id );
+
+		$this->switch_to_bootstrapped_blog( $beta );
+		( new Sync() )->sync_current_users();
+		$beta_idsite = $this->get_current_site_id();
+		$beta_login  = User::get_matomo_user_login( $user_id );
+		$this->assertEquals( [ $beta_idsite ], $this->get_view_sites_for( $beta_login ) );
+		$this->remove_matomo_view_from_user( $user_id );
+		$this->restore_bootstrapped_blog();
+
+		$this->remove_matomo_view_from_user( $user_id );
+
+		$sync = new Sync();
+		$sync->on_remove_user_from_blog( $user_id, $beta );
+		$sync->on_remove_user_from_blog( $user_id, get_current_blog_id() );
+
+		// flushing on the main blog must leave the queued entry for the other blog alone
+		$sync->on_clean_user_cache( $user_id );
+
+		$this->assertEquals( [], $this->get_view_sites_for( $main_login ) );
+
+		$this->switch_to_bootstrapped_blog( $beta );
+		$this->assertEquals( [ $beta_idsite ], $this->get_view_sites_for( $beta_login ) );
+
+		$sync->on_clean_user_cache( $user_id );
+
+		$this->assertEquals( [], $this->get_view_sites_for( $beta_login ) );
+		$this->restore_bootstrapped_blog();
+
+		wp_delete_site( $beta );
+	}
+
+	public function test_on_clean_user_cache_should_keep_access_for_a_user_who_still_has_the_capability() {
+		$this->activate_matomo_plugin();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		$sync = new Sync();
+		$sync->on_remove_user_from_blog( $user_id, get_current_blog_id() );
+
+		// deliberately not taking the capability away
+		$sync->on_clean_user_cache( $user_id );
+
+		$this->assertEquals( [ $this->get_current_site_id() ], $this->get_view_sites_for( $login ) );
+		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
+		$this->assertSame( $login, User::get_matomo_user_login( $user_id ) );
+	}
+
 	private function get_matomo_user( $login ) {
 		$model = new Model();
 
 		return $model->getUser( $login );
+	}
+
+	private function activate_matomo_plugin() {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		if ( is_multisite() ) {
+			update_site_option( 'active_sitewide_plugins', [ 'matomo/matomo.php' => time() ] );
+		} else {
+			// is_plugin_active_for_network() always returns false outside multisite
+			update_option( 'active_plugins', [ 'matomo/matomo.php' ] );
+		}
+
+		$this->assertTrue( is_plugin_active( 'matomo/matomo.php' ) );
+	}
+
+	/**
+	 * @param int $wp_user_id
+	 * @return string the Matomo login the user was synced to
+	 */
+	private function grant_matomo_view_and_sync( $wp_user_id ) {
+		( new WP_User( $wp_user_id ) )->add_role( Roles::ROLE_VIEW );
+
+		( new Sync() )->sync_current_users();
+
+		$login = User::get_matomo_user_login( $wp_user_id );
+		$this->assertNotEmpty( $login );
+		$this->assertEquals( [ $this->get_current_site_id() ], $this->get_view_sites_for( $login ) );
+
+		return $login;
+	}
+
+	/**
+	 * @param int $wp_user_id
+	 */
+	private function remove_matomo_view_from_user( $wp_user_id ) {
+		( new WP_User( $wp_user_id ) )->remove_role( Roles::ROLE_VIEW );
+
+		$this->assertFalse( user_can( new WP_User( $wp_user_id ), Capabilities::KEY_VIEW ) );
+	}
+
+	private function create_blog_with_matomo() {
+		$blog_id = self::factory()->blog->create();
+
+		( new \WpMatomo\Site\Sync( new Settings() ) )->sync_all();
+
+		$this->assertNotEmpty( Site::get_matomo_site_id( $blog_id ) );
+
+		return $blog_id;
+	}
+
+	private function switch_to_bootstrapped_blog( $blog_id ) {
+		switch_to_blog( $blog_id );
+		Bootstrap::do_bootstrap();
+	}
+
+	private function restore_bootstrapped_blog() {
+		restore_current_blog();
+		Bootstrap::do_bootstrap();
+	}
+
+	/**
+	 * @param string $login
+	 * @return array
+	 */
+	private function get_view_sites_for( $login ) {
+		$view_access = ( new Model() )->getUsersSitesFromAccess( 'view' );
+		return isset( $view_access[ $login ] ) ? $view_access[ $login ] : [];
 	}
 }

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -3,6 +3,8 @@
  * @package matomo
  */
 
+use Piwik\Access\Role\Admin;
+use Piwik\Access\Role\View;
 use Piwik\Plugins\UsersManager\Model;
 use WpMatomo\Access;
 use WpMatomo\Bootstrap;
@@ -815,10 +817,117 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( $login, User::get_matomo_user_login( $user_id ) );
 	}
 
+	public function test_sync_user_if_access_exceeds_capabilities_should_downgrade_an_access_row_that_outranks_the_wp_capability() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		// the admin access a sync left behind before the user was downgraded to view in WordPress
+		$this->set_access_for_current_site( $login, Admin::ID );
+
+		$this->assertTrue( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
+
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
+	}
+
+	public function test_sync_user_if_access_exceeds_capabilities_should_leave_an_access_row_that_matches_the_wp_capability() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		$this->assertFalse( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
+
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
+	}
+
+	public function test_sync_user_if_access_exceeds_capabilities_should_not_upgrade_an_access_row_below_the_wp_capability() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		// promoted in WordPress but not synced yet. granting access is a sync's job, not ours
+		( new WP_User( $user_id ) )->add_role( Roles::ROLE_ADMIN );
+		$this->assertTrue( user_can( new WP_User( $user_id ), Capabilities::KEY_ADMIN ) );
+
+		$this->assertFalse( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
+
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
+	}
+
+	public function test_sync_user_if_access_exceeds_capabilities_should_clear_a_stale_superuser_flag() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		// the flag a sync left behind after the WordPress side was downgraded
+		( new Model() )->setSuperUserAccess( $login, true );
+		$this->assertNotEmpty( $this->get_matomo_user( $login )['superuser_access'] );
+
+		$this->assertTrue( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
+
+		$this->assertEmpty( $this->get_matomo_user( $login )['superuser_access'] );
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
+	}
+
+	public function test_sync_user_if_access_exceeds_capabilities_should_do_nothing_when_matomo_capabilities_cannot_be_resolved() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		$this->set_access_for_current_site( $login, Admin::ID );
+
+		$capabilities = WpMatomo::get_active_feature( Capabilities::class );
+		$this->assertNotEmpty( $capabilities, 'Capabilities is expected to be registered by default' );
+
+		// safe mode: without the user_has_cap filter nobody resolves any matomo capability, so
+		// every user would look like they no longer qualify for the access they have
+		$capabilities->remove_hooks();
+		try {
+			$this->assertFalse( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
+		} finally {
+			$capabilities->register_hooks();
+		}
+
+		$this->assertSame( Admin::ID, $this->get_access_for_current_site( $login ) );
+	}
+
+	public function test_sync_user_if_access_exceeds_capabilities_should_do_nothing_when_the_user_is_not_mapped_to_a_matomo_user() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+
+		$this->assertEmpty( User::get_matomo_user_login( $user_id ) );
+
+		$this->assertFalse( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
+	}
+
 	private function get_matomo_user( $login ) {
 		$model = new Model();
 
 		return $model->getUser( $login );
+	}
+
+	/**
+	 * @param string $login
+	 * @return string|null the Matomo access the login has to the current site
+	 */
+	private function get_access_for_current_site( $login ) {
+		$idsite = $this->get_current_site_id();
+
+		foreach ( ( new Model() )->getSitesAccessFromUser( $login ) as $access ) {
+			if ( (int) $access['site'] === (int) $idsite ) {
+				return $access['access'];
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param string $login
+	 * @param string $role
+	 */
+	private function set_access_for_current_site( $login, $role ) {
+		$model  = new Model();
+		$idsite = $this->get_current_site_id();
+
+		$model->deleteUserAccess( $login, [ $idsite ] );
+		$model->addUserAccess( $login, $role, [ $idsite ] );
+
+		$this->assertSame( $role, $this->get_access_for_current_site( $login ) );
 	}
 
 	private function activate_matomo_plugin() {

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -712,6 +712,129 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		wp_delete_site( $beta );
 	}
 
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_revoke_matomo_superuser_access_on_every_blog_when_super_admin_is_revoked() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$this->activate_matomo_plugin();
+
+		$beta = $this->create_blog_with_matomo();
+
+		$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_login' => 'netadmin',
+			]
+		);
+		grant_super_admin( $user_id );
+
+		$logins = $this->sync_and_get_logins_per_blog( $user_id, [ $beta ] );
+
+		foreach ( $logins as $blog_id => $login ) {
+			$this->assertSame( '1', $this->get_matomo_user_on_blog( $blog_id, $login )['superuser_access'] );
+		}
+
+		( new Sync() )->register_hooks();
+
+		revoke_super_admin( $user_id );
+
+		// sanity check: WordPress itself no longer considers them a Matomo superuser, so anything
+		// left below is Matomo's own stale state and not a broken fixture
+		$this->assertFalse( user_can( new WP_User( $user_id ), Capabilities::KEY_SUPERUSER ) );
+
+		foreach ( $logins as $blog_id => $login ) {
+			// a subscriber has no Matomo capability at all, so they are removed
+			$this->assertEmpty( $this->get_matomo_user_on_blog( $blog_id, $login ) );
+		}
+
+		wp_delete_site( $beta );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_grant_matomo_superuser_access_on_every_blog_when_super_admin_is_granted() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$this->activate_matomo_plugin();
+
+		$beta = $this->create_blog_with_matomo();
+
+		$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_login' => 'futureadmin',
+			]
+		);
+
+		$logins = $this->sync_and_get_logins_per_blog( $user_id, [ $beta ] );
+
+		foreach ( $logins as $login ) {
+			$this->assertFalse( $login, 'a subscriber should not be in Matomo yet' );
+		}
+
+		( new Sync() )->register_hooks();
+
+		grant_super_admin( $user_id );
+
+		foreach ( array_keys( $logins ) as $blog_id ) {
+			$this->switch_to_bootstrapped_blog( $blog_id );
+			$login = User::get_matomo_user_login( $user_id );
+			$this->assertNotEmpty( $login );
+			$this->assertSame( '1', $this->get_matomo_user( $login )['superuser_access'] );
+			$this->restore_bootstrapped_blog();
+		}
+
+		wp_delete_site( $beta );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_on_super_admin_change_should_correct_blogs_other_than_the_current_one() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$this->activate_matomo_plugin();
+
+		$beta = $this->create_blog_with_matomo();
+
+		$user_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_login' => 'formeradmin',
+			]
+		);
+		grant_super_admin( $user_id );
+
+		$logins = $this->sync_and_get_logins_per_blog( $user_id, [ $beta ] );
+
+		// take the status away without the hooks registered, leaving the flag stale everywhere
+		revoke_super_admin( $user_id );
+
+		foreach ( $logins as $blog_id => $login ) {
+			$this->assertSame( '1', $this->get_matomo_user_on_blog( $blog_id, $login )['superuser_access'] );
+		}
+
+		( new Sync() )->on_super_admin_change( $user_id );
+
+		foreach ( $logins as $blog_id => $login ) {
+			$this->assertEmpty( $this->get_matomo_user_on_blog( $blog_id, $login ) );
+		}
+
+		wp_delete_site( $beta );
+	}
+
 	public function test_on_remove_user_from_blog_should_not_change_matomo_access_on_its_own() {
 		$this->activate_matomo_plugin();
 
@@ -942,6 +1065,38 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$model = new Model();
 
 		return $model->getUser( $login );
+	}
+
+	/**
+	 * @param int   $wp_user_id
+	 * @param int[] $other_blog_ids
+	 * @return array<int, string|false>
+	 */
+	private function sync_and_get_logins_per_blog( $wp_user_id, $other_blog_ids ) {
+		$logins = [];
+
+		foreach ( array_merge( [ get_current_blog_id() ], $other_blog_ids ) as $blog_id ) {
+			$this->switch_to_bootstrapped_blog( $blog_id );
+			( new Sync() )->sync_current_users();
+			$logins[ $blog_id ] = User::get_matomo_user_login( $wp_user_id );
+			$this->restore_bootstrapped_blog();
+		}
+
+		return $logins;
+	}
+
+	/**
+	 * @param int    $blog_id
+	 * @param string $login
+	 *
+	 * @return array
+	 */
+	private function get_matomo_user_on_blog( $blog_id, $login ) {
+		$this->switch_to_bootstrapped_blog( $blog_id );
+		$matomo_user = $this->get_matomo_user( $login );
+		$this->restore_bootstrapped_blog();
+
+		return $matomo_user;
 	}
 
 	/**

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -1092,25 +1092,18 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
 	}
 
-	public function test_sync_user_if_access_exceeds_capabilities_should_do_nothing_when_matomo_capabilities_cannot_be_resolved() {
+	public function test_sync_user_if_access_exceeds_capabilities_should_revoke_when_no_capability_resolves_for_the_user() {
 		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
 		$login   = $this->grant_matomo_view_and_sync( $user_id );
 
-		$this->set_access_for_current_site( $login, Admin::ID );
+		// the user is left entitled to no Matomo access at all, so the access a sync left behind
+		// is the only thing keeping them in Matomo
+		$this->remove_matomo_view_from_user( $user_id );
 
-		$capabilities = WpMatomo::get_active_feature( Capabilities::class );
-		$this->assertNotEmpty( $capabilities, 'Capabilities is expected to be registered by default' );
+		$this->assertTrue( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
 
-		// safe mode: without the user_has_cap filter nobody resolves any matomo capability, so
-		// every user would look like they no longer qualify for the access they have
-		$capabilities->remove_hooks();
-		try {
-			$this->assertFalse( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
-		} finally {
-			$capabilities->register_hooks();
-		}
-
-		$this->assertSame( Admin::ID, $this->get_access_for_current_site( $login ) );
+		// the user has access to no site anymore, so they are removed from Matomo entirely
+		$this->assertEmpty( $this->get_matomo_user( $login ) );
 	}
 
 	public function test_sync_user_if_access_exceeds_capabilities_should_do_nothing_when_the_user_is_not_mapped_to_a_matomo_user() {

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -1092,6 +1092,61 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
 	}
 
+	public function test_on_clean_user_cache_should_not_touch_other_users_when_the_removed_user_was_never_mapped() {
+		$this->activate_matomo_plugin();
+
+		$other_id    = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$other_login = $this->grant_matomo_view_and_sync( $other_id );
+
+		// Matomo never knew about this one, so get_matomo_user_login() gives back false and every
+		// cleanup query below runs with a false login
+		$unmapped_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$this->assertFalse( User::get_matomo_user_login( $unmapped_id ) );
+
+		$sync = new Sync();
+		$sync->on_remove_user_from_blog( $unmapped_id, get_current_blog_id() );
+		$sync->on_clean_user_cache( $unmapped_id );
+
+		$this->assertNotEmpty( $this->get_matomo_user( $other_login ) );
+		$this->assertEquals( [ $this->get_current_site_id() ], $this->get_view_sites_for( $other_login ) );
+		$this->assertEquals( '1', $this->get_matomo_user( 'admin' )['superuser_access'] );
+	}
+
+	public function test_sync_current_users_should_not_leave_a_per_site_access_row_on_a_superuser() {
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $login ) );
+
+		( new WP_User( $user_id ) )->add_role( 'administrator' );
+
+		( new Sync() )->sync_current_users();
+
+		// superuser_access already grants every site, so the row the earlier role added is unneeded
+		$this->assertEquals( '1', $this->get_matomo_user( $login )['superuser_access'] );
+		$this->assertNull( $this->get_access_for_current_site( $login ) );
+	}
+
+	public function test_sync_user_if_access_exceeds_capabilities_should_clear_superuser_access_when_the_identity_survives() {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+
+		( new Sync() )->sync_current_users();
+
+		$login = User::get_matomo_user_login( $user_id );
+		$this->assertNotEmpty( $login );
+		$this->assertEquals( '1', $this->get_matomo_user( $login )['superuser_access'] );
+
+		// add view access row in addition to the superuser flag above
+		( new Model() )->addUserAccess( $login, View::ID, [ $this->get_current_site_id() + 1000 ] );
+
+		( new WP_User( $user_id ) )->remove_role( 'administrator' ); // user will have no access after this
+
+		$this->assertTrue( ( new Sync() )->sync_user_if_access_exceeds_capabilities( $user_id ) );
+
+		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
+		$this->assertEquals( '0', $this->get_matomo_user( $login )['superuser_access'] );
+	}
+
 	public function test_sync_user_if_access_exceeds_capabilities_should_revoke_when_no_capability_resolves_for_the_user() {
 		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
 		$login   = $this->grant_matomo_view_and_sync( $user_id );

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -972,6 +972,78 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertSame( $login, User::get_matomo_user_login( $user_id ) );
 	}
 
+	public function test_register_hooks_should_delete_the_matomo_user_when_a_wordpress_user_is_deleted() {
+		$this->activate_matomo_plugin();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		( new Sync() )->register_hooks();
+
+		// picks wp_delete_user() on single site and wpmu_delete_user() on multisite
+		self::delete_user( $user_id );
+
+		$this->assertEquals( [], $this->get_view_sites_for( $login ) );
+		$this->assertEmpty( $this->get_matomo_user( $login ) );
+		$this->assertFalse( User::get_matomo_user_login( $user_id ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_register_hooks_should_keep_the_matomo_user_when_only_deleted_from_one_blog() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Not multisite.' );
+			return;
+		}
+
+		$this->activate_matomo_plugin();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login   = $this->grant_matomo_view_and_sync( $user_id );
+
+		// matomo can hold sites beyond the one WordPress maps to this blog. access to one of those
+		// is what keeps the Matomo user alive once remove_user_from_blog() has revoked this site,
+		// and so is the only state in which deleting it would be observable
+		$other_idsite = $this->get_current_site_id() + 1000;
+		( new Model() )->addUserAccess( $login, View::ID, [ $other_idsite ] );
+
+		( new Sync() )->register_hooks();
+
+		if ( ! function_exists( 'wp_delete_user' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+
+		// on multisite wp_delete_user() only removes the user from the current blog, so it fires
+		// deleted_user while the WordPress user itself still exists
+		wp_delete_user( $user_id );
+		$this->assertNotEmpty( get_userdata( $user_id ) );
+
+		// this blog's site was revoked by remove_user_from_blog(), the other one is untouched
+		$this->assertEquals( [ $other_idsite ], $this->get_view_sites_for( $login ) );
+		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
+		$this->assertSame( $login, User::get_matomo_user_login( $user_id ) );
+	}
+
+	public function test_register_hooks_should_leave_matomo_alone_when_a_user_it_never_synced_is_deleted() {
+		$this->activate_matomo_plugin();
+
+		$synced_user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$login          = $this->grant_matomo_view_and_sync( $synced_user_id );
+
+		// a subscriber has no Matomo capability, so nothing ever mapped them to a Matomo user
+		$unsynced_user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$this->assertFalse( User::get_matomo_user_login( $unsynced_user_id ) );
+
+		( new Sync() )->register_hooks();
+
+		self::delete_user( $unsynced_user_id );
+
+		$this->assertEquals( [ $this->get_current_site_id() ], $this->get_view_sites_for( $login ) );
+		$this->assertNotEmpty( $this->get_matomo_user( $login ) );
+		$this->assertSame( $login, User::get_matomo_user_login( $synced_user_id ) );
+	}
+
 	public function test_sync_user_if_access_exceeds_capabilities_should_downgrade_an_access_row_that_outranks_the_wp_capability() {
 		$user_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
 		$login   = $this->grant_matomo_view_and_sync( $user_id );

--- a/tests/phpunit/wpmatomo/user/test-sync.php
+++ b/tests/phpunit/wpmatomo/user/test-sync.php
@@ -1154,6 +1154,47 @@ class UserSyncTest extends MatomoAnalytics_SharedFixture_TestCase {
 		$this->assertNull( $this->get_access_for_current_site( $login ) );
 	}
 
+	public function test_sync_current_users_should_keep_a_user_whose_sync_threw_and_still_sync_the_rest() {
+		$failing_id = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_login' => 'aaa_sync_fails',
+			]
+		);
+		$other_id   = self::factory()->user->create(
+			[
+				'role'       => 'subscriber',
+				'user_login' => 'zzz_sync_works',
+			]
+		);
+
+		$failing_login = $this->grant_matomo_view_and_sync( $failing_id );
+		$other_login   = $this->grant_matomo_view_and_sync( $other_id );
+
+		$fail_for_one_user = function ( $user ) use ( $failing_id ) {
+			if ( (int) $user->ID === $failing_id ) {
+				throw new \Exception( 'simulated failure while syncing this user' );
+			}
+		};
+
+		add_action( 'matomo_before_sync_user', $fail_for_one_user );
+		try {
+			( new Sync() )->sync_current_users();
+		} finally {
+			remove_action( 'matomo_before_sync_user', $fail_for_one_user );
+		}
+
+		// the sync never got far enough to decide this user has no access, so the cleanup sweep must
+		// leave them alone rather than read the failure as "not entitled to anything"
+		$this->assertNotEmpty( $this->get_matomo_user( $failing_login ) );
+		$this->assertSame( $failing_login, User::get_matomo_user_login( $failing_id ) );
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $failing_login ) );
+
+		// the users after the failing one were still synced
+		$this->assertNotEmpty( $this->get_matomo_user( $other_login ) );
+		$this->assertSame( View::ID, $this->get_access_for_current_site( $other_login ) );
+	}
+
 	public function test_sync_user_if_access_exceeds_capabilities_should_clear_superuser_access_when_the_identity_survives() {
 		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-browserconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-browserconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\BrowsersConverter;
 
-class BrowserConverterTest extends MatomoAnalytics_TestCase {
+class BrowserConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$browsers = BrowsersConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-pagetitleconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-pagetitleconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\PagesTitleConverter;
 
-class PageTitleConverterTest extends MatomoAnalytics_TestCase {
+class PageTitleConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$pages = PagesTitleConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-platformconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-platformconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\PlatformConverter;
 
-class PlatformConverterTest extends MatomoAnalytics_TestCase {
+class PlatformConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$platforms = PlatformConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-referrerconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-referrerconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\ReferrersConverter;
 
-class ReferrersConverterTest extends MatomoAnalytics_TestCase {
+class ReferrersConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$referrers = ReferrersConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-searchengineconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-searchengineconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\SearchEngineConverter;
 
-class SearchEngineConverterTest extends MatomoAnalytics_TestCase {
+class SearchEngineConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$search_engines = SearchEngineConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-searchqueryconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-searchqueryconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\SearchQueryConverter;
 
-class SearchQueryConverterTest extends MatomoAnalytics_TestCase {
+class SearchQueryConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$search_queries = SearchQueryConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-usercityconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-usercityconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\UserCityConverter;
 
-class UserCityConverterTest extends MatomoAnalytics_TestCase {
+class UserCityConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$cities = UserCityConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-usercountryconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-usercountryconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\UserCountryConverter;
 
-class UserCountryConverterTest extends MatomoAnalytics_TestCase {
+class UserCountryConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$countries = UserCountryConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-userregionconverter.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/dataconverters/test-userregionconverter.php
@@ -2,7 +2,7 @@
 
 use WpMatomo\WpStatistics\DataConverters\UserRegionConverter;
 
-class UserRegionConverterTest extends MatomoAnalytics_TestCase {
+class UserRegionConverterTest extends MatomoAnalytics_SharedFixture_TestCase {
 
 	public function test_empty_list() {
 		$regions = UserRegionConverter::convert( [] );

--- a/tests/phpunit/wpmatomo/wpstatistics/test-import.php
+++ b/tests/phpunit/wpmatomo/wpstatistics/test-import.php
@@ -14,7 +14,7 @@ use WpMatomo\ScheduledTasks;
 use WpMatomo\Settings;
 use WpMatomo\WpStatistics\IncompatibleWpStatisticsVersion;
 
-class ImportTest extends MatomoAnalytics_TestCase {
+class ImportTest extends MatomoAnalytics_SharedFixture_TestCase {
 	/**
 	 * static due to multiple tests instanciations
 	 *


### PR DESCRIPTION
### Description

Changes to plugin:
* do not use remove_user_from_blog hook to re-sync users since this occurs before the user in WordPress has actually been removed from the blog. instead, in remove_user_from_blog keep track of users that need to be re-synced, then in clean_user_cache, which is called after the user is removed, sync any users that need to be synced.
* after authentication, if a user has more Matomo capabilities than their WP capabilities allow, correct the user access row and only grant what their WP capabilities allow.
* fix get_sites() calls that needed all sites in a WP install, but only returned the first 100 (the limit by default is 100).
* make sure access syncing occurs when a user is granted superuser access and if superuser access is revoked.
* make sure user syncing can occur in all non-frontend requests (including REST/XML RPC, etc.) as these can be used to modify user access in WP.
* make sure site syncing can occur in all non-frontend requests (including REST/XML RPC, etc.) as these can be used to modify user access in WP.
* if there are more than 1000 users, instead of skipping a sync in a request, schedule a sync to occur in the next cron run.
* remove a matomo user when a user is deleted in a non-multisite WP site.
* when saving user assigned role => matomo permission mappings, make sure to finalize row changes BEFORE initiating a user sync (or the changes won't be applied until the next cron run
* when a site is deleted in WP, delete the WP => matomo site mapping and drop matomo tables.
* make sure the Capabilities feature is available in safe mode, as authorization is always necessary.
* keep user access state in Matomo consistent when WP user is superuser (so superuser flag set, no extra user access rows for the user).
* when syncing a user's access, make sure to delete existing access for the **resolved** user's login, rather than trusting the stored mapping.
* handle exceptions gracefully during user sync and site sync.
* invalidate the tracker cache after a user sync, just in case there is a token auth for the user still in the tracker cache (not normally possible unless someone specifically went out of their way to create a token auth).
* fix a typo in the word 'anonymous' that previously caused anonymous users to be deleted during syncing.
* make sure blog restoration triggers a site and user sync (if matomo is activated for the site).

Changes to tests:
* further optimization tests through the MatomoAnalytics_SharedFixture_TestCase class. Instead of just skipping full installation for each test, skip it for each SharedFixture class (so it is done once per test run, instead of just once per test case).
* switch to the SharedFixture base class wherever it can currently be used (some still need MatomoAnalytics_TestCase because they test the install/uninstall process)
* when restoring db snapshots, do not truncate tables with 0 rows and insert data using batch inserts
* for multisite tests, when creating new blogs, bootstrap them from the db snapshot instead of performing a full Matomo install

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
